### PR TITLE
Add test infrastructure: slow/e2e markers and fixture optimization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ testpaths = ["tests/unit", "tests/integration", "tests/e2e"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "-ra -q"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "e2e: marks end-to-end tests requiring Playwright browsers",
+]
 
 [tool.coverage.run]
 source = ["src/promptgrimoire"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,14 @@
+"""E2E test configuration.
+
+Auto-applies the 'e2e' marker to all tests in this directory.
+Skip with: pytest -m "not e2e"
+"""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Add e2e marker to all tests in this directory."""
+    for item in items:
+        if "/e2e/" in str(item.fspath):
+            item.add_marker(pytest.mark.e2e)


### PR DESCRIPTION
## Summary

Pytest markers and fixture optimizations for faster test feedback loops.

**Changes:**
- `pyproject.toml`: Add `slow` and `e2e` pytest markers
- `tests/e2e/conftest.py`: Auto-mark all e2e tests (no manual decoration needed)
- `tests/unit/test_rtf_parser.py`: Module-scoped fixture (15.7s → 2.4s)
- `tests/unit/test_crdt_persistence.py`: Fast scheduling tests + slow marker on real-timing tests

**Usage:**
```bash
pytest                              # All tests
pytest -m 'not slow'                # Skip slow tests  
pytest -m 'not e2e'                 # Skip Playwright tests
pytest -m 'not e2e and not slow'    # Fast feedback (~4s)
```

## User Acceptance Tests

### UAT 1: Full test suite
```bash
uv run pytest
```
- [ ] All tests pass
- [ ] Note total time: ____s

### UAT 2: Skip slow tests
```bash
uv run pytest -m 'not slow'
```
- [ ] Tests pass
- [ ] Note time: ____s (should be ~13s faster than full run)

### UAT 3: Skip e2e tests
```bash
uv run pytest -m 'not e2e'
```
- [ ] Tests pass
- [ ] Note time: ____s
- [ ] Verify Playwright tests were skipped

### UAT 4: Fast feedback loop
```bash
uv run pytest -m 'not e2e and not slow'
```
- [ ] Tests pass
- [ ] Time should be ~4s

---

🤖 Generated with [Claude Code](https://claude.ai/code)