### PR TITLE
Add missing ENABLE_DEMO_PAGES to Claude Code env template

### DIFF
--- a/scripts/env.claude-code-async
+++ b/scripts/env.claude-code-async
@@ -34,6 +34,11 @@ ROLEPLAY_LOG_DIR=logs/sessions
 LOREBOOK_TOKEN_BUDGET=0
 
 # =============================================================================
+# Demo Pages
+# =============================================================================
+ENABLE_DEMO_PAGES=false
+
+# =============================================================================
 # Database (Unix socket, trust auth)
 # =============================================================================
 DATABASE_URL=postgresql+asyncpg://claude@/promptgrimoire?host=/var/run/postgresql


### PR DESCRIPTION
The env template was missing this variable, causing test_env_vars to
fail after fresh setup.