### PR TITLE
fix: skip broadcast callbacks for deleted NiceGUI clients

### DIFF
--- a/src/promptgrimoire/pages/annotation/__init__.py
+++ b/src/promptgrimoire/pages/annotation/__init__.py
@@ -115,7 +115,7 @@ class _RemotePresence:
         dead), the ``with`` block raises and the caller's
         ``contextlib.suppress(Exception)`` handles it.
         """
-        if self.callback and self.nicegui_client:
+        if self.callback and self.nicegui_client and not self.nicegui_client._deleted:
             with self.nicegui_client:
                 await self.callback()
 

--- a/src/promptgrimoire/pages/annotation/broadcast.py
+++ b/src/promptgrimoire/pages/annotation/broadcast.py
@@ -265,7 +265,10 @@ async def _handle_client_delete(
         )
         remaining = list(_workspace_presence.get(workspace_key, {}).items())
         for _cid, presence in remaining:
-            if presence.nicegui_client is not None:
+            if (
+                presence.nicegui_client is not None
+                and not presence.nicegui_client._deleted
+            ):
                 with contextlib.suppress(Exception):
                     await presence.nicegui_client.run_javascript(
                         removal_js,

--- a/tests/unit/test_broadcast_deleted_client.py
+++ b/tests/unit/test_broadcast_deleted_client.py
@@ -1,0 +1,67 @@
+"""Test that broadcast operations skip deleted NiceGUI clients.
+
+Regression test for a bug where _handle_client_delete iterates remaining
+clients and invokes their presence callbacks. If a remaining client has
+also been deleted by the time its callback runs, invoke_callback enters
+the deleted client's context and tries to create UI elements, triggering
+NiceGUI's "Client has been deleted but is still being used" warning.
+
+The fix: invoke_callback and run_javascript guards must check
+``nicegui_client._deleted`` before entering the client context.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from promptgrimoire.pages.annotation import _RemotePresence
+
+
+def _make_presence(*, deleted: bool = False) -> _RemotePresence:
+    """Build a _RemotePresence with a mock NiceGUI client.
+
+    Parameters
+    ----------
+    deleted
+        If True, the mock client's ``_deleted`` attribute is set to True,
+        simulating a client that has been removed but whose object still
+        exists in memory.
+    """
+    mock_client = MagicMock()
+    mock_client._deleted = deleted
+    # The context manager (``with client:``) should still work for non-deleted
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+
+    callback = AsyncMock()
+
+    return _RemotePresence(
+        name="Test User",
+        color="#ff0000",
+        nicegui_client=mock_client,
+        callback=callback,
+    )
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_skips_deleted_client() -> None:
+    """invoke_callback must be a no-op when the NiceGUI client is deleted."""
+    presence = _make_presence(deleted=True)
+
+    await presence.invoke_callback()
+
+    # The callback should NOT have been called
+    presence.callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_runs_for_live_client() -> None:
+    """invoke_callback should still work for non-deleted clients."""
+    presence = _make_presence(deleted=False)
+
+    await presence.invoke_callback()
+
+    # The callback SHOULD have been called
+    presence.callback.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Guard `invoke_callback` in `_RemotePresence` to check `nicegui_client._deleted` before entering the client context, preventing "Client has been deleted but is still being used" warnings
- Apply the same `_deleted` guard to the `run_javascript` call in `_handle_client_delete`
- Add regression test verifying `invoke_callback` is a no-op for deleted clients

## Root cause

When a client disconnects, `_handle_client_delete` iterates remaining clients to update presence (remove cursors, refresh toolbars). If a remaining client has also been deleted by the time its callback runs, `invoke_callback` enters the deleted client's context and NiceGUI warns about UI element creation on a dead client.

## Test plan

- [x] `uv run grimoire test run tests/unit/test_broadcast_deleted_client.py` — both tests pass
- [x] `uv run grimoire test all` — no regressions (3786 passed)
- [ ] Open two browser tabs on the same workspace, close both rapidly — no "Client has been deleted" warnings in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)