### PR TITLE
chore: controlled dependency upgrades 2026-03-18

### DIFF
--- a/docs/dependency-rationale.md
+++ b/docs/dependency-rationale.md
@@ -69,9 +69,23 @@ Each dependency lists: what it does, why it's here (not a stdlib/transitive alte
 **Why not alternatives:** pydantic-settings integrates natively with the existing Pydantic ecosystem (SQLModel, pydantic-ai). Provides type validation, SecretStr masking, and `.env` reading without manual `load_dotenv()`.
 **Classification:** Hard core. All application configuration flows through it.
 
-### ~~python-dotenv >= 1.0~~ (SUPERSEDED)
+### ~~python-dotenv >= 1.0~~ (REMOVED)
 
-Superseded 2026-02-13 by pydantic-settings, which reads `.env` files natively (using python-dotenv internally as a transitive dependency). Direct `load_dotenv()` calls eliminated. See design plan `2026-02-13-pydantic-settings-130.md`.
+Removed 2026-03-18 from `pyproject.toml`. Superseded 2026-02-13 by pydantic-settings, which uses python-dotenv internally as a transitive dependency. No direct imports existed. See design plan `2026-02-13-pydantic-settings-130.md`.
+
+### cryptography >= 46.0.5
+
+**Added:** pre-2026-03 (version floor pin)
+**Claim:** Version floor pin to ensure a minimum safe version across transitive dependency chains.
+**Evidence:** No direct imports in `src/promptgrimoire/`. Required transitively by authlib and google-auth. The explicit pin was added to address CVE-2026-26007 (commit `db48c343`).
+**Classification:** Protective belt. Version floor for supply-chain security.
+
+### pyasn1 >= 0.6.3
+
+**Added:** 2026-03-18 (version floor pin)
+**Claim:** Version floor pin to ensure CVE-2026-30922 patched version across transitive dependency chains.
+**Evidence:** No direct imports in `src/promptgrimoire/`. Required transitively via pydantic-ai → google-genai → google-auth → rsa → pyasn1.
+**Classification:** Protective belt. Version floor for supply-chain security.
 
 ### asyncpg >= 0.30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "structlog>=25.0",
     "httpx>=0.27",
+    "pyasn1>=0.6.3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2396,6 +2396,7 @@ dependencies = [
     { name = "mecab-python3" },
     { name = "nicegui" },
     { name = "openpyxl" },
+    { name = "pyasn1" },
     { name = "pycrdt" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
@@ -2461,6 +2462,7 @@ requires-dist = [
     { name = "mecab-python3", specifier = ">=1.0.12" },
     { name = "nicegui", specifier = "==3.8.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pycrdt", specifier = ">=0.10" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-ai", specifier = ">=1.67.0" },
@@ -2676,11 +2678,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Removed** `python-dotenv` from direct dependencies (superseded by pydantic-settings, still present as transitive dep)
- **Upgraded 14 packages** one at a time, each with changelog review, test cycle, and individual commit:
  - **Patch:** pycrdt (async tx fix), selectolax, pymupdf+pymupdf-layout, ruff, mkdocs-material, types-openpyxl
  - **Minor:** anthropic (thinking-display GA), coolname, mammoth, pydantic-ai (FallbackModel), ast-grep-cli (CSS selectors), browserstack-sdk, vulture (Python 3.14 support)
  - **Major (version realignment):** pymupdf4llm 0.3.4 → 1.27.2.1 (same API, version scheme aligned with pymupdf parent)
- **Updated** `docs/dependency-rationale.md`: added cryptography CVE rationale, removed duplicate openpyxl entry, noted mkdocs-material maintenance mode (support until Nov 2026)
- **No packages reverted**

## Test plan

- [x] `uv run grimoire test all` — 3340 tests pass after each individual upgrade
- [ ] Verify E2E tests still pass (`uv run grimoire e2e run`)
- [ ] Spot-check PDF upload (pymupdf4llm version change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)