### PR TITLE
test: scrub pydantic settings env vars from unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from uuid import UUID
 
@@ -9,6 +10,34 @@ import emoji as emoji_lib
 import pytest
 
 from promptgrimoire.db.models import User
+
+
+@pytest.fixture(autouse=True)
+def _scrub_test_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a pristine environment for all unit tests by removing app config.
+
+    Prevents user sandbox variables (e.g. STYTCH__SSO_CONNECTION_ID)
+    from causing pydantic-settings validation errors in tests that
+    instantiate Settings(_env_file=None).
+    """
+    from promptgrimoire.config import Settings
+
+    # Dynamically get all top-level config groups (e.g. "STYTCH", "APP")
+    config_prefixes = {f.upper() for f in Settings.model_fields}
+
+    for key in list(os.environ):
+        if "__" in key:
+            prefix = key.split("__")[0]
+            if prefix in config_prefixes and key not in (
+                # Keep these DB variables because the test harness explicitly
+                # sets them before pytest starts to route tests to the
+                # isolated test database. Scrubbing them causes connections
+                # to fall back to the dev/production DB.
+                "DATABASE__URL",
+                "DEV__TEST_DATABASE_URL",
+            ):
+                monkeypatch.delenv(key, raising=False)
+
 
 # Standard UUIDs for test references
 SAMPLE_USER_ID = UUID("12345678-1234-5678-1234-567812345678")


### PR DESCRIPTION
## Summary

- Add autouse fixture `_scrub_test_environment` to `tests/unit/conftest.py` that dynamically removes app config env vars (`STYTCH__*`, `APP__*`, etc.) before each unit test
- Prevents local `.env` files and shell variables from causing pydantic-settings validation errors when tests instantiate `Settings(_env_file=None)`
- Uses `Settings.model_fields` introspection to auto-discover config prefixes — new config groups are scrubbed automatically without manual updates
- Preserves `DATABASE__URL` and `DEV__TEST_DATABASE_URL` (needed for test DB connection)

## Context

When developers have `STYTCH__SSO_CONNECTION_ID` set (e.g. from a local `.env`), the cross-field validator in `StytchConfig` requires `STYTCH__PUBLIC_TOKEN` to also be set. Tests using `Settings(_env_file=None)` still pick up shell env vars, causing spurious `ValidationError` failures.

## Test plan

- [x] 3360 unit tests pass
- [x] All 7 E2E lanes pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)