### PR TITLE
docs: update incident playbook with automated tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ scripts/smoke_data/*.md
 !scripts/smoke_data/*.md.example
 scripts/smoke_data/*.log
 
+# Incident analysis SQLite databases (per-incident, ephemeral)
+*.db
+
 # Runtime logs
 log/
 

--- a/docs/postmortems/incident-analysis-playbook.md
+++ b/docs/postmortems/incident-analysis-playbook.md
@@ -2,7 +2,7 @@
 
 *Standing playbook for production incident investigation. Applies the methodology from the `incident-analysis` skill to PromptGrimoire's specific infrastructure.*
 
-*Last updated: 2026-03-16. Created from lessons learned during the 2026-03-16 morning and afternoon incidents.*
+*Last updated: 2026-03-20. Created from lessons learned during the 2026-03-16 morning and afternoon incidents. Updated with automated tooling (`collect-telemetry.sh`, `incident_db.py`) and corrected pool configuration.*
 
 ## Log Sources
 
@@ -27,7 +27,47 @@ The server runs `Australia/Sydney`. This is AEDT (UTC+11) during daylight saving
 
 **Positive control:** After setting up any time filter, verify it works by searching for a known event (e.g., a service restart). If a filter returns zero results, verify the filter before reporting zero. On 2026-03-16, a PG log search for afternoon errors returned zero because the analyst used local-time prefixes against UTC timestamps. 13 errors were missed.
 
-### Collection Procedure
+### Collection Procedure (Automated)
+
+The `collect-telemetry.sh` script automates collection of all sources into a single tarball. Times are server-local.
+
+On the server:
+```bash
+# Collect all telemetry for a time window into a tarball
+sudo bash /opt/promptgrimoire/deploy/collect-telemetry.sh \
+  --start "2026-03-20 14:00" --end "2026-03-20 16:00"
+# Produces: /tmp/telemetry-YYYYMMDD-HHMM.tar.gz
+# Prints next-steps with exact commands for local ingestion
+```
+
+The script prints next-steps after completion. Follow them in order:
+```bash
+# 1. Copy tarball to local machine
+scp grimoire.drbbs.org:/tmp/telemetry-YYYYMMDD-HHMM.tar.gz /tmp/
+
+# 2. Fetch Beszel metrics (requires SSH tunnel to monitoring hub)
+ssh -L 8090:localhost:8090 brian.fedarch.org  # in a separate terminal
+uv run scripts/incident_db.py beszel \
+  --start "YYYY-MM-DD HH:MM" --end "YYYY-MM-DD HH:MM" \
+  --hub http://localhost:8090 --db incident.db
+
+# 3. Ingest tarball + GitHub data
+uv run scripts/incident_db.py ingest /tmp/telemetry-YYYYMMDD-HHMM.tar.gz --db incident.db
+uv run scripts/incident_db.py github \
+  --start "YYYY-MM-DD HH:MM" --end "YYYY-MM-DD HH:MM" --db incident.db
+
+# 4. Check provenance manifest
+uv run scripts/incident_db.py sources --db incident.db
+
+# 5. Generate review report (extract db-snapshot.json from tarball for counts)
+tar xzf /tmp/telemetry-YYYYMMDD-HHMM.tar.gz ./db-snapshot.json -O > /tmp/db-snapshot.json
+uv run scripts/incident_db.py review --db incident.db \
+  --counts-json /tmp/db-snapshot.json --output report.md
+```
+
+### Collection Procedure (Manual Fallback)
+
+If the automated script is unavailable or you need individual sources:
 
 On the server:
 ```bash
@@ -97,7 +137,37 @@ SELECT json_build_object(
 
 Pass to the review report: `uv run scripts/incident_db.py review --counts-json counts.json`
 
-## JSONL Analysis
+## Automated Analysis (incident_db.py)
+
+After ingesting a tarball, use `incident_db.py` for cross-source querying. All times are local (server timezone).
+
+```bash
+# Provenance manifest — verify what was ingested
+uv run scripts/incident_db.py sources --db incident.db
+
+# Cross-source timeline for a window
+uv run scripts/incident_db.py timeline \
+  --start "2026-03-20 14:00" --end "2026-03-20 16:00" --db incident.db
+
+# Event breakdown by source and level
+uv run scripts/incident_db.py breakdown --db incident.db
+
+# Fetch Beszel system metrics (requires SSH tunnel to hub)
+uv run scripts/incident_db.py beszel \
+  --start "2026-03-20 14:00" --end "2026-03-20 16:00" \
+  --hub http://localhost:8090
+
+# Fetch GitHub PR activity for context
+uv run scripts/incident_db.py github \
+  --start "2026-03-20 00:00" --end "2026-03-20 23:59" --db incident.db
+
+# Generate operational review report (with optional DB counts)
+uv run scripts/incident_db.py review --db incident.db --counts-json counts.json --output report.md
+```
+
+## JSONL Analysis (Manual)
+
+Use these `jq` commands for ad-hoc queries when `incident_db.py` doesn't cover your need, or when working directly with uningested files.
 
 **The JSONL file is not windowed by default.** It accumulates across restarts. Always filter to your analysis window first.
 
@@ -229,11 +299,15 @@ sudo -u postgres psql -c "SELECT state, count(*) FROM pg_stat_activity WHERE dat
 
 ## Pool Configuration
 
-Current (post-commit `a85c1226`): `pool_size=10`, `max_overflow=20` (ceiling: 30 connections).
+Current (see `src/promptgrimoire/db/engine.py`): `pool_size=80`, `max_overflow=15` (ceiling: 95 connections). `pool_pre_ping=True`, `pool_recycle=3600`.
 
-Previous: `pool_size=5`, `max_overflow=10` (ceiling: 15).
+Previous configurations:
+- `pool_size=10`, `max_overflow=20` (ceiling: 30) — post-commit `a85c1226`
+- `pool_size=5`, `max_overflow=10` (ceiling: 15) — original
 
-When analysing INVALIDATE events, check the `size` field to confirm which pool configuration was active. Mixed `size=5` and `size=10` events in the same analysis indicate the JSONL spans a config change — filter to the correct window.
+When analysing INVALIDATE events, check the `size` field to confirm which pool configuration was active. Mixed pool sizes in the same analysis indicate the JSONL spans a config change — filter to the correct window.
+
+**Test environment:** Uses `NullPool` (fresh connection per request, no pooling). Pool contention cannot be reproduced in E2E tests. See `_is_test_environment()` in `engine.py`.
 
 ## Known Error Categories
 
@@ -258,5 +332,7 @@ From the 2026-03-16 afternoon analysis (680 afternoon-only errors across 169 stu
 | `docs/postmortems/2026-03-16-new-errors.md` | Errors observed after #360/#361 deploy |
 | `docs/postmortems/2026-03-16-proposed-analysis-tools.md` | Proposed automated analysis tooling (under review) |
 | `docs/postmortems/2026-03-15-production-oom.md` | Previous day's OOM incident |
+| `.claude/skills/incident-analysis/SKILL.md` | General methodology: source provenance, falsification, confidence calibration |
+| `docs/postmortems/2026-03-18-page-load-latency-377.md` | #377 page load latency investigation — instrumentation, findings, peer review |
 | `.claude/skills/incident-analysis/SKILL.md` | General methodology: source provenance, falsification, confidence calibration |
 | `.claude/skills/incident-analysis/CREATION-LOG.md` | Catalogued errors from 2026-03-16 analysis that motivated the methodology |


### PR DESCRIPTION
## Summary

- Updates `docs/postmortems/incident-analysis-playbook.md` to reference `collect-telemetry.sh` and `incident_db.py` as the primary workflow (manual commands demoted to fallback)
- Adds Beszel metrics collection steps via SSH tunnel
- Fixes stale pool config: was `pool_size=10/max_overflow=20`, now `pool_size=80/max_overflow=15` (matches `engine.py`)
- Notes NullPool in test environment (pool contention not reproducible in E2E)
- Adds `#377` postmortem to cross-reference table
- Gitignores `*.db` (ephemeral incident analysis SQLite files)

## Context

A parallel session was using the playbook with outdated manual commands and stale pool numbers. This brings the playbook in sync with the tooling that's been built since 2026-03-16.

## Test plan

- [ ] Verify `collect-telemetry.sh` commands in playbook match script's actual `--help` output
- [ ] Verify `incident_db.py` commands match CLI `--help`
- [ ] Confirm pool config matches `src/promptgrimoire/db/engine.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)