### PR TITLE
fix: jittered 503 reload and stagger delay (#419)

### DIFF
--- a/deploy/503.http
+++ b/deploy/503.http
@@ -9,7 +9,6 @@ Connection: close
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="refresh" content="5">
 <title>PromptGrimoire — Restarting</title>
 <style>
   body {
@@ -46,5 +45,11 @@ Connection: close
   <div class="spinner"></div>
   <p>This page will reload automatically in a few seconds.</p>
 </div>
+<script>
+  // Jittered reload: 5–35 seconds to prevent thundering herd on restart.
+  // Without this, all clients refresh at the same instant and overwhelm
+  // the connection pool. See #419.
+  setTimeout(function() { location.reload(); }, 5000 + Math.random() * 30000);
+</script>
 </body>
 </html>

--- a/deploy/restart.sh
+++ b/deploy/restart.sh
@@ -9,12 +9,14 @@
 #   1. git pull (as promptgrimoire)
 #   2. uv sync --no-dev (as promptgrimoire)
 #   3. unit tests (optional, e-stop on failure)
-#   4. HAProxy drain (stop new connections, let in-flight finish)
-#   5. Wait for active connections to drain
-#   6. HAProxy maintenance mode (serves friendly 503)
-#   7. systemctl restart
-#   8. Wait for /healthz
-#   9. HAProxy back to ready
+#   4. Update HAProxy 503 page
+#   5. HAProxy drain (stop new connections, let in-flight finish)
+#   6. Wait for active connections to drain
+#   7. HAProxy maintenance mode (serves friendly 503 with jittered reload)
+#   8. systemctl restart
+#   9. Wait for /healthz
+#  10. Stagger delay (let clients land on 503 and get jittered timers)
+#  11. HAProxy back to ready
 set -euo pipefail
 
 SOCK=/run/haproxy/admin.sock
@@ -78,7 +80,11 @@ else
     step "Skipping tests (--skip-tests)"
 fi
 
-# 4. Drain — stop sending new connections, let in-flight requests finish
+# 4. Update HAProxy 503 page (picks up jittered reload, etc.)
+step "Updating HAProxy 503 page"
+cp "$APP_DIR/deploy/503.http" /etc/haproxy/errors/503.http
+
+# 5. Drain — stop sending new connections, let in-flight requests finish
 haproxy_touched=true
 step "HAProxy → drain (new connections blocked, in-flight finishing)"
 echo "set server be_promptgrimoire/app state drain" | socat stdio "$SOCK"
@@ -124,7 +130,14 @@ until curl -sf "$HEALTHZ" > /dev/null 2>&1; do
     fi
 done
 
-# 9. Back to ready
+# 10. Stagger delay — hold maintenance mode while clients land on the
+#     jittered 503 page (5–35s random reload). This prevents thundering
+#     herd when HAProxy switches back to ready. See #419.
+STAGGER_WAIT=20
+step "Stagger delay (${STAGGER_WAIT}s — clients landing on jittered 503)"
+sleep "$STAGGER_WAIT"
+
+# 11. Back to ready
 step "HAProxy → ready"
 echo "set server be_promptgrimoire/app state ready" | socat stdio "$SOCK"
 haproxy_touched=false


### PR DESCRIPTION
## Summary

- Replace fixed 5s `meta http-equiv=refresh` in `deploy/503.http` with JS `setTimeout` jittered 5–35s
- Add 20s stagger delay in `deploy/restart.sh` after `/healthz` passes, before switching HAProxy back to ready
- Auto-copy updated 503 page to HAProxy errors dir during deploy

## Context

During restart, all NiceGUI socket.io clients disconnect simultaneously. Without jitter, they all hit the 503 page and refresh at exactly the same 5s interval, causing a thundering herd that can exhaust the connection pool (see #419, incident 2026-03-24).

The stagger delay keeps HAProxy in maintenance mode for 20s after the app is healthy, ensuring clients have time to land on the 503 page and receive their randomised reload timer.

Does **not** close #419 — clean app shutdown (CRDT flush before disconnect) is still outstanding.

## Test plan

- [x] shellcheck passes
- [x] BATS tests pass
- [x] All 8 E2E lanes pass
- [ ] Deploy to production and verify staggered client reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)