### PR TITLE
fix: invalidate sessions on all restart paths

### DIFF
--- a/src/promptgrimoire/pages/auth.py
+++ b/src/promptgrimoire/pages/auth.py
@@ -7,6 +7,7 @@ Uses either real Stytch or MockAuthClient based on DEV__AUTH_MOCK setting.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
@@ -27,6 +28,21 @@ logging.getLogger(__name__).setLevel(logging.INFO)
 
 # Time to display error message before redirecting (seconds)
 _ERROR_DISPLAY_SECONDS = 0.5
+
+_SAFE_RETURN_RE = re.compile(r"^/([^/].*)?$")
+
+
+def _post_login_destination() -> str:
+    """Return the URL to navigate to after successful login.
+
+    Reads and clears ``post_login_return`` from ``app.storage.user``.
+    Falls back to ``"/"`` if absent or invalid (open-redirect guard).
+    """
+    raw = app.storage.user.pop("post_login_return", "/")
+    if isinstance(raw, str) and _SAFE_RETURN_RE.match(raw):
+        return raw
+    return "/"
+
 
 # Allowed email domains for magic link login
 _ALLOWED_MAGIC_LINK_DOMAINS: frozenset[str] = frozenset(
@@ -494,9 +510,14 @@ def _build_mock_login_section() -> None:
 @ui.page("/login")
 async def login_page() -> None:
     """Login page with AAF SSO, Google OAuth, magic link, and GitHub OAuth."""
+    # Stash ?return= so post-auth callbacks can redirect back
+    raw_return = _get_query_param("return")
+    if raw_return and isinstance(raw_return, str) and _SAFE_RETURN_RE.match(raw_return):
+        app.storage.user["post_login_return"] = raw_return
+
     user = _get_session_user()
     if user:
-        ui.navigate.to("/")
+        ui.navigate.to(_post_login_destination())
         return
 
     # Inject before login UI so the overlay covers the form immediately.
@@ -556,7 +577,7 @@ async def _handle_magic_link_callback(token: str | None) -> None:
             user_id=user_id,
             is_admin=is_admin,
         )
-        ui.navigate.to("/")
+        ui.navigate.to(_post_login_destination())
     else:
         logger.warning("Magic link auth failed: %s", result.error)
         ui.label(f"Error: {result.error}").classes("text-red-500").props(
@@ -619,7 +640,7 @@ async def _handle_sso_callback(token: str | None) -> None:
             user_id=user_id,
             is_admin=is_admin,
         )
-        ui.navigate.to("/")
+        ui.navigate.to(_post_login_destination())
     else:
         logger.warning("SSO auth failed: %s", result.error)
         ui.label(f"Error: {result.error}").classes("text-red-500").props(
@@ -665,7 +686,7 @@ async def _handle_oauth_callback(token: str | None) -> None:
             user_id=user_id,
             is_admin=is_admin,
         )
-        ui.navigate.to("/")
+        ui.navigate.to(_post_login_destination())
     else:
         logger.warning("OAuth auth failed: %s", result.error)
         ui.label(f"Error: {result.error}").classes("text-red-500").props(

--- a/src/promptgrimoire/pages/restart.py
+++ b/src/promptgrimoire/pages/restart.py
@@ -151,6 +151,11 @@ async def pre_restart_handler(request: Request) -> JSONResponse:
     # Persist all dirty CRDT state to database
     await get_persistence_manager().persist_all_dirty_workspaces()
 
+    # Invalidate all sessions so no stale auth survives the restart
+    from promptgrimoire.diagnostics import _invalidate_all_sessions  # noqa: PLC0415
+
+    await _invalidate_all_sessions()
+
     # Navigate all connected clients to the restarting page
     for client in list(Client.instances.values()):
         if not client.has_socket_connection:

--- a/src/promptgrimoire/pages/restarting.py
+++ b/src/promptgrimoire/pages/restarting.py
@@ -80,6 +80,9 @@ async def restarting_page() -> None:
         ui.label("Server updating, please wait...").classes(
             "text-2xl font-bold mt-4"
         ).props('data-testid="restarting-message"')
+        ui.label("You will need to log in again once the server is ready.").classes(
+            "text-md text-grey-7 mt-2"
+        )
         ui.label("Waiting for server...").classes("text-lg text-grey-7 mt-2").props(
             'data-testid="restarting-status"'
         )
@@ -106,7 +109,7 @@ async def restarting_page() -> None:
                     if (btnContainer) {{
                         btnContainer.innerHTML = '';
                         const btn = document.createElement('button');
-                        btn.textContent = "Return to " + returnTitle;
+                        btn.textContent = "Log in and return to " + returnTitle;
                         btn.className = 'q-btn q-btn--flat q-btn--rectangle '
                             + 'text-white bg-blue-500 q-mt-md';
                         btn.style.padding = '12px 32px';
@@ -114,7 +117,8 @@ async def restarting_page() -> None:
                         btn.style.cursor = 'pointer';
                         btn.setAttribute('data-testid', 'restarting-return-btn');
                         btn.onclick = function() {{
-                            window.location.href = returnUrl;
+                            window.location.href = "/login?return="
+                                + encodeURIComponent(returnUrl);
                         }};
                         btnContainer.appendChild(btn);
                     }}
@@ -148,9 +152,10 @@ async def restarting_page() -> None:
                     const jitter = 1000 + Math.random() * 4000;
                     const sel = '[data-testid="restarting-status"]';
                     const el = document.querySelector(sel);
-                    if (el) el.textContent = "Server ready, redirecting...";
+                    if (el) el.textContent = "Server ready, redirecting to login...";
                     setTimeout(function() {{
-                        window.location.href = returnUrl;
+                        window.location.href = "/login?return="
+                            + encodeURIComponent(returnUrl);
                     }}, jitter);
                     return;
                 }}

--- a/tests/integration/test_pre_restart.py
+++ b/tests/integration/test_pre_restart.py
@@ -200,6 +200,99 @@ class TestPreRestartFlush:
         assert resp.status_code == 200
 
 
+class TestPreRestartSessionInvalidation:
+    """Session invalidation must run during pre-restart."""
+
+    @pytest.mark.asyncio
+    async def test_pre_restart_calls_invalidate_all_sessions(self) -> None:
+        """Manual restart via restart.sh must invalidate sessions."""
+        from promptgrimoire.pages.restart import pre_restart_handler
+
+        mock_persist_mgr = MagicMock()
+        mock_persist_mgr.persist_all_dirty_workspaces = AsyncMock()
+
+        mock_client_class = MagicMock()
+        mock_client_class.instances = {}
+
+        invalidate_called = False
+
+        async def tracking_invalidate() -> None:
+            nonlocal invalidate_called
+            invalidate_called = True
+
+        with (
+            patch(
+                "promptgrimoire.pages.restart.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch("nicegui.Client", mock_client_class),
+            patch(
+                "promptgrimoire.pages.restart._get_annotation_state",
+                return_value=({}, None),
+            ),
+            patch(
+                "promptgrimoire.crdt.persistence.get_persistence_manager",
+                return_value=mock_persist_mgr,
+            ),
+            patch(
+                "promptgrimoire.diagnostics._invalidate_all_sessions",
+                AsyncMock(side_effect=tracking_invalidate),
+            ),
+        ):
+            resp = await pre_restart_handler(_make_request(token="test-token"))
+
+        assert resp.status_code == 200
+        assert invalidate_called, (
+            "pre_restart_handler must call _invalidate_all_sessions"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalidation_runs_after_persist(self) -> None:
+        """Sessions must be invalidated after CRDT state is persisted."""
+        from promptgrimoire.pages.restart import pre_restart_handler
+
+        call_order: list[str] = []
+
+        mock_persist_mgr = MagicMock()
+
+        async def tracking_persist() -> None:
+            call_order.append("persist")
+
+        mock_persist_mgr.persist_all_dirty_workspaces = AsyncMock(
+            side_effect=tracking_persist
+        )
+
+        async def tracking_invalidate() -> None:
+            call_order.append("invalidate")
+
+        mock_client_class = MagicMock()
+        mock_client_class.instances = {}
+
+        with (
+            patch(
+                "promptgrimoire.pages.restart.get_settings",
+                return_value=_mock_settings(),
+            ),
+            patch("nicegui.Client", mock_client_class),
+            patch(
+                "promptgrimoire.pages.restart._get_annotation_state",
+                return_value=({}, None),
+            ),
+            patch(
+                "promptgrimoire.crdt.persistence.get_persistence_manager",
+                return_value=mock_persist_mgr,
+            ),
+            patch(
+                "promptgrimoire.diagnostics._invalidate_all_sessions",
+                AsyncMock(side_effect=tracking_invalidate),
+            ),
+        ):
+            resp = await pre_restart_handler(_make_request(token="test-token"))
+
+        assert resp.status_code == 200
+        assert call_order == ["persist", "invalidate"]
+
+
 class TestConnectionCount:
     """Test GET /api/connection-count."""
 

--- a/tests/unit/pages/test_auth_post_login.py
+++ b/tests/unit/pages/test_auth_post_login.py
@@ -1,0 +1,85 @@
+"""Unit tests for post-login return URL handling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _mock_storage(data: dict | None = None) -> MagicMock:
+    """Create a mock app.storage.user dict."""
+    storage = MagicMock()
+    _data = dict(data) if data else {}
+    storage.pop = lambda key, default=None: _data.pop(key, default)
+    storage.__getitem__ = lambda _, key: _data[key]
+    storage.__setitem__ = lambda _, key, val: _data.__setitem__(key, val)
+    storage.__contains__ = lambda _, key: key in _data
+    return storage
+
+
+class TestPostLoginDestination:
+    """Tests for _post_login_destination return URL resolution."""
+
+    def test_returns_root_when_no_stash(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage()
+            assert _post_login_destination() == "/"
+
+    def test_returns_stashed_url(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage(
+                {"post_login_return": "/annotation?workspace_id=abc"}
+            )
+            result = _post_login_destination()
+            assert result == "/annotation?workspace_id=abc"
+
+    def test_clears_stash_after_read(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        data: dict[str, str] = {"post_login_return": "/courses"}
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage(data)
+            _post_login_destination()
+            # Second call should return "/" since stash was consumed
+            assert _post_login_destination() == "/"
+
+    def test_rejects_absolute_url(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage(
+                {"post_login_return": "https://evil.com/steal"}
+            )
+            assert _post_login_destination() == "/"
+
+    def test_rejects_protocol_relative(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage({"post_login_return": "//evil.com"})
+            assert _post_login_destination() == "/"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [42, None, True, ["/"]],
+    )
+    def test_rejects_non_string(self, bad_value: object) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage({"post_login_return": bad_value})
+            assert _post_login_destination() == "/"
+
+    def test_accepts_path_with_hash(self) -> None:
+        from promptgrimoire.pages.auth import _post_login_destination
+
+        with patch("promptgrimoire.pages.auth.app") as mock_app:
+            mock_app.storage.user = _mock_storage(
+                {"post_login_return": "/annotation?ws=abc#highlight-5"}
+            )
+            assert _post_login_destination() == "/annotation?ws=abc#highlight-5"


### PR DESCRIPTION
## Summary

- **Manual restart gap closed**: `pre_restart_handler()` (called by `deploy/restart.sh`) now calls `_invalidate_all_sessions()` after persisting CRDT state. Previously only the automatic memory-threshold restart path invalidated sessions.
- **Post-restart login flow**: `/restarting` page tells users they'll need to log in again and redirects through `/login?return=<original_url>`
- **Login return URL**: `/login` honours `?return=` query param — stashes in `app.storage.user["post_login_return"]`, all four auth success paths (magic link, SSO, Google OAuth, GitHub OAuth) use `_post_login_destination()` to redirect after auth. Open-redirect guard rejects absolute/protocol-relative URLs.

Closes #438

## Test plan

- [x] Unit tests: `_post_login_destination()` — root default, stashed URL, stash clearing, open-redirect rejection, non-string rejection, hash/query preservation (8 tests)
- [x] Integration tests: `pre_restart_handler` calls `_invalidate_all_sessions`, invalidation runs after persist (2 tests)
- [x] Full test suite: 3723 unit, 954 integration, 45 Playwright E2E, 12 NiceGUI — all pass
- [ ] Manual deploy test: run `restart.sh`, verify users see "You will need to log in again" on `/restarting`, get redirected to `/login?return=...`, and land back on their original page after auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)