### PR TITLE
fix(export): marginalia overflow fallback + user-facing error

### DIFF
--- a/scripts/setup_latex.py
+++ b/scripts/setup_latex.py
@@ -67,6 +67,7 @@ REQUIRED_PACKAGES = [
     # Speaker turns
     "tcolorbox",  # Breakable coloured boxes for speaker turns with left border
     "pdfcol",  # Colour stack management (tcolorbox breakable dependency)
+    "tikzfill",  # TikZ fill libraries (tcolorbox tcbskins dependency)
     # Unicode/CJK support (Issue #101)
     "emoji",  # Emoji rendering in LuaLaTeX
     "accsupp",  # PDF /ActualText annotations for emoji accessibility (#274)

--- a/src/promptgrimoire/export/pdf.py
+++ b/src/promptgrimoire/export/pdf.py
@@ -117,6 +117,51 @@ def get_latexmk_path() -> str:
     raise FileNotFoundError(msg)
 
 
+def has_marginalia_placement_warnings(log_file: Path) -> bool:
+    """Check LaTeX log for marginalia placement problem warnings.
+
+    Marginalia emits 'Package marginalia Warning: Problems in placement'
+    when annotations overflow the margin column (clashes, items pushed
+    beyond page boundaries).
+    """
+    if not log_file.exists():
+        return False
+    content = log_file.read_text(errors="replace")
+    return "Package marginalia Warning: Problems in placement" in content
+
+
+def inject_annot_force_endnotes(tex_path: Path) -> None:
+    r"""Insert ``\annotforceendnotestrue`` into a .tex file.
+
+    Placed immediately after ``\usepackage{promptgrimoire-export}`` so the
+    flag is set before any ``\annot`` commands execute.
+    """
+    content = tex_path.read_text()
+    if r"\annotforceendnotestrue" in content:
+        return  # Already injected
+    target = r"\usepackage{promptgrimoire-export}"
+    if target not in content:
+        logger.warning(
+            "annot_force_endnotes_injection_failed",
+            tex_path=str(tex_path),
+            reason="usepackage line not found",
+        )
+        return
+    content = content.replace(
+        target,
+        target + "\n\\annotforceendnotestrue  % margin overflow fallback",
+    )
+    tex_path.write_text(content)
+
+
+def clean_latexmk_aux(output_dir: Path, stem: str) -> None:
+    """Remove latexmk auxiliary files so a recompile starts fresh."""
+    for suffix in (".aux", ".log", ".fls", ".fdb_latexmk", ".endnotes"):
+        aux = output_dir / (stem + suffix)
+        if aux.exists():
+            aux.unlink()
+
+
 async def compile_latex(tex_path: Path, output_dir: Path | None = None) -> Path:
     """Compile LaTeX to PDF using latexmk with LuaLaTeX.
 
@@ -124,6 +169,10 @@ async def compile_latex(tex_path: Path, output_dir: Path | None = None) -> Path:
     LuaLaTeX provides:
     - fontspec for system fonts (Times New Roman, Arial)
     - lua-ul for robust underlining/highlighting
+
+    If marginalia reports placement problems (annotation overflow), the
+    .tex is patched with ``\\annotforceendnotestrue`` and recompiled so
+    all annotations appear as endnotes instead of invisible margin notes.
 
     Args:
         tex_path: Path to the .tex file.
@@ -143,7 +192,25 @@ async def compile_latex(tex_path: Path, output_dir: Path | None = None) -> Path:
         raise LaTeXCompileStageShortCircuit(tex_path)
 
     async with _get_compile_semaphore():
-        return await _run_latexmk(tex_path, output_dir)
+        pdf_path = await _run_latexmk(tex_path, output_dir)
+
+        # Check for marginalia placement warnings — annotations overflowed
+        # the margin column and are invisible in the PDF.  Recompile with
+        # all annotations routed to endnotes.
+        log_file = output_dir / (tex_path.stem + ".log")
+        if has_marginalia_placement_warnings(log_file):
+            logger.warning(
+                "marginalia_placement_overflow",
+                export_stage="latex_compile",
+                tex_path=str(tex_path),
+                action="recompile_with_endnotes",
+            )
+            inject_annot_force_endnotes(tex_path)
+            clean_latexmk_aux(output_dir, tex_path.stem)
+            pdf_path.unlink(missing_ok=True)
+            pdf_path = await _run_latexmk(tex_path, output_dir)
+
+        return pdf_path
 
 
 async def _run_latexmk(tex_path: Path, output_dir: Path) -> Path:

--- a/src/promptgrimoire/export/promptgrimoire-export.sty
+++ b/src/promptgrimoire/export/promptgrimoire-export.sty
@@ -125,6 +125,10 @@
 % by \flushannotendnotes which \input{}s the file.
 \newwrite\annotendfile
 \newif\ifannothasendnotes
+% When true, ALL annotations go to endnotes (margin overflow fallback).
+% Set by the Python export pipeline on recompilation when marginalia
+% reports placement problems from the first pass.
+\newif\ifannotforceendnotes
 \AtBeginDocument{%
   \immediate\openout\annotendfile=\jobname.endnotes\relax
 }
@@ -132,7 +136,11 @@
   \immediate\closeout\annotendfile
   \ifannothasendnotes
     \clearpage
-    \section*{Long Annotations}
+    \ifannotforceendnotes
+      \section*{Annotations}
+    \else
+      \section*{Long Annotations}
+    \fi
     \input{\jobname.endnotes}%
   \fi
 }
@@ -147,7 +155,26 @@
   % tokens from multi-paragraph annotations — \savebox scans in
   % restricted horizontal mode which forbids \par.
   \setbox\annotbox=\vbox{\hsize=4.3cm\footnotesize\textbf{\theannotnum.} #2}%
-  \ifdim\ht\annotbox>\annotmaxht
+  \ifannotforceendnotes
+    % Margin overflow fallback: ALL annotations go to endnotes.
+    % Triggered by the Python pipeline when the first compilation pass
+    % produced marginalia placement warnings.
+    \phantomsection\label{annot-inline:\theannotnum}%
+    \hyperref[annot-endnote:\theannotnum]{%
+      \textsuperscript{\textcolor{#1}{\textbf{\theannotnum}}}\,\linkicon
+    }%
+    \global\annothasendnotestrue
+    \immediate\write\annotendfile{%
+      \noexpand\phantomsection
+      \noexpand\label{annot-endnote:\theannotnum}%
+      \noexpand\par\noexpand\noindent
+      \noexpand\hyperref[annot-inline:\theannotnum]{%
+        \noexpand\textcolor{#1}{\noexpand\textbf{\theannotnum.}}\noexpand\linkicon
+      }%
+      \unexpanded{#2}%
+      \noexpand\par\noexpand\medskip
+    }%
+  \else\ifdim\ht\annotbox>\annotmaxht
     % Long annotation → write to endnotes file, show stub in margin
     \phantomsection\label{annot-inline:\theannotnum}%
     \hyperref[annot-endnote:\theannotnum]{%
@@ -177,7 +204,7 @@
         \usebox{\annotbox}%
       }%
     }%
-  \fi
+  \fi\fi
 }
 
 % Table-safe annotation reference: superscript number only (no \par).

--- a/src/promptgrimoire/export/worker.py
+++ b/src/promptgrimoire/export/worker.py
@@ -25,6 +25,7 @@ from promptgrimoire.db.export_jobs import (
     fail_job,
     fail_orphaned_jobs,
 )
+from promptgrimoire.export.pdf import LaTeXCompilationError
 from promptgrimoire.export.pdf_export import export_annotation_pdf
 
 if TYPE_CHECKING:
@@ -33,6 +34,24 @@ if TYPE_CHECKING:
     from promptgrimoire.db.models import ExportJob
 
 logger = structlog.get_logger()
+
+_LATEX_USER_MESSAGE = (
+    "PDF export failed due to a server configuration issue."
+    " Retrying will not help."
+    " Please email your workspace URL to your instructor"
+    " so they can forward it to the system administrator."
+)
+
+
+def user_facing_error(exc: Exception) -> str:
+    """Translate internal exceptions into student-friendly messages.
+
+    LaTeX compilation errors expose server file paths that are
+    meaningless to students.  Replace with actionable guidance.
+    """
+    if isinstance(exc, LaTeXCompilationError):
+        return _LATEX_USER_MESSAGE
+    return str(exc)
 
 
 async def _process_job(job: ExportJob) -> None:
@@ -86,7 +105,7 @@ async def _process_job(job: ExportJob) -> None:
         # CancelledError is not a subclass of Exception, so it propagates
         # to the outer loop for clean worker shutdown.
         log.exception("export_worker_job_failed")
-        await fail_job(job.id, str(exc))
+        await fail_job(job.id, user_facing_error(exc))
         # Clean up the temp dir — failed jobs have no pdf_path,
         # so cleanup_expired_jobs would never delete it.
         shutil.rmtree(output_dir, ignore_errors=True)

--- a/tests/unit/export/test_endnote_crossref.py
+++ b/tests/unit/export/test_endnote_crossref.py
@@ -108,13 +108,13 @@ class TestAnnotMacroShortPath:
     r"""AC2.4: \annot short-annotation path does NOT have hyperref linking."""
 
     def test_short_path_no_label(self) -> None:
-        r"""The short path (\else branch) must NOT contain \label{annot-inline:...}."""
+        r"""Short path must NOT contain \label{annot-inline:...}."""
         sty = _read_sty()
         annot = _extract_macro(sty, "annot")
-        # Split at \else to isolate the short path
+        # The short path is the last \else branch (after \ifannotforceendnotes
+        # and \ifdim branches).  Extract everything after the last \else.
         parts = annot.split(r"\else")
-        assert len(parts) == 2, r"Expected exactly one \else in \annot"
-        short_path = parts[1]
+        short_path = parts[-1]
         assert r"\label{annot-inline:" not in short_path
         assert r"\hyperref[annot-endnote:" not in short_path
 
@@ -174,7 +174,9 @@ class TestLinkAffordance:
         """
         sty = _read_sty()
         annot = _extract_macro(sty, "annot")
-        long_path = annot.split(r"\else")[0]
+        # Skip the \ifannotforceendnotes branch to reach the \ifdim long path
+        after_force = annot.split(r"\else\ifdim", maxsplit=1)[-1]
+        long_path = after_force.split(r"\else")[0]
         assert "see endnotes" in long_path
         # Extract only the marginalia block (up to the next %}%)
         margin_start = long_path.find(r"\marginalia")

--- a/tests/unit/export/test_marginalia_overflow.py
+++ b/tests/unit/export/test_marginalia_overflow.py
@@ -1,0 +1,152 @@
+"""Tests for marginalia overflow detection and endnote fallback.
+
+When annotations overflow the margin column, marginalia emits placement
+warnings in the LaTeX log.  The export pipeline detects these warnings
+and recompiles with all annotations routed to endnotes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from promptgrimoire.export.pdf import (
+    LaTeXCompilationError,
+    has_marginalia_placement_warnings,
+    inject_annot_force_endnotes,
+)
+from promptgrimoire.export.worker import user_facing_error
+
+
+class TestHasMarginaliaPlacementWarnings:
+    """Detection of marginalia placement problems in LaTeX logs."""
+
+    def test_detects_placement_warning(self, tmp_path: Path) -> None:
+        log = tmp_path / "test.log"
+        log.write_text(
+            "Some preamble output\n"
+            "Package marginalia Warning: Problems in placement."
+            " Here are the problems:\n"
+            "p1 (1) Moveable item < ysep page bottom\n"
+            "p1 (1) Clash: moveable items\n"
+        )
+        assert has_marginalia_placement_warnings(log) is True
+
+    def test_no_warning_returns_false(self, tmp_path: Path) -> None:
+        log = tmp_path / "test.log"
+        log.write_text("Some preamble output\nOutput written on test.pdf (1 page)\n")
+        assert has_marginalia_placement_warnings(log) is False
+
+    def test_missing_log_returns_false(self, tmp_path: Path) -> None:
+        log = tmp_path / "nonexistent.log"
+        assert has_marginalia_placement_warnings(log) is False
+
+    def test_empty_log_returns_false(self, tmp_path: Path) -> None:
+        log = tmp_path / "test.log"
+        log.write_text("")
+        assert has_marginalia_placement_warnings(log) is False
+
+
+class TestInjectAnnotForceEndnotes:
+    r"""Injection of \annotforceendnotestrue into .tex files."""
+
+    def test_injects_after_usepackage(self, tmp_path: Path) -> None:
+        tex = tmp_path / "test.tex"
+        tex.write_text(
+            "\\documentclass{article}\n"
+            "\\usepackage{promptgrimoire-export}\n"
+            "\\begin{document}\n"
+            "Hello\n"
+            "\\end{document}\n"
+        )
+        inject_annot_force_endnotes(tex)
+        content = tex.read_text()
+        assert "\\annotforceendnotestrue" in content
+        # Must appear AFTER \usepackage{promptgrimoire-export}
+        pkg_pos = content.find("\\usepackage{promptgrimoire-export}")
+        flag_pos = content.find("\\annotforceendnotestrue")
+        assert flag_pos > pkg_pos
+
+    def test_idempotent_injection(self, tmp_path: Path) -> None:
+        """Injecting twice doesn't duplicate the flag."""
+        tex = tmp_path / "test.tex"
+        tex.write_text(
+            "\\documentclass{article}\n"
+            "\\usepackage{promptgrimoire-export}\n"
+            "\\begin{document}\n"
+            "\\end{document}\n"
+        )
+        inject_annot_force_endnotes(tex)
+        inject_annot_force_endnotes(tex)
+        content = tex.read_text()
+        assert content.count("\\annotforceendnotestrue") == 1
+
+    def test_no_usepackage_line_is_noop(self, tmp_path: Path) -> None:
+        """If the .tex doesn't have the expected line, don't crash."""
+        tex = tmp_path / "test.tex"
+        tex.write_text("\\documentclass{article}\n\\begin{document}\n\\end{document}\n")
+        inject_annot_force_endnotes(tex)
+        content = tex.read_text()
+        assert "\\annotforceendnotestrue" not in content
+
+
+class TestStyForceEndnotesFlag:
+    r"""The .sty file defines \ifannotforceendnotes correctly."""
+
+    def test_flag_defined_in_sty(self) -> None:
+        sty_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "promptgrimoire"
+            / "export"
+            / "promptgrimoire-export.sty"
+        )
+        content = sty_path.read_text()
+        assert r"\newif\ifannotforceendnotes" in content
+
+    def test_annot_checks_flag(self) -> None:
+        sty_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "promptgrimoire"
+            / "export"
+            / "promptgrimoire-export.sty"
+        )
+        content = sty_path.read_text()
+        assert r"\ifannotforceendnotes" in content
+
+    def test_force_endnotes_path_has_no_marginalia(self) -> None:
+        r"""When forcing endnotes, \annot must NOT call \marginalia."""
+        sty_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "promptgrimoire"
+            / "export"
+            / "promptgrimoire-export.sty"
+        )
+        content = sty_path.read_text()
+        # Extract the \ifannotforceendnotes branch (up to \else\ifdim)
+        start = content.find(r"\ifannotforceendnotes")
+        end = content.find(r"\else\ifdim", start)
+        force_branch = content[start:end]
+        assert r"\marginalia" not in force_branch, (
+            "Force-endnotes path must not place anything in the margin"
+        )
+
+
+class TestUserFacingError:
+    """LaTeX errors become student-friendly messages."""
+
+    def test_latex_error_gives_actionable_message(self) -> None:
+        exc = LaTeXCompilationError(
+            "LaTeX compilation failed (exit 12): PDF not created",
+            tex_path=Path("/tmp/test.tex"),
+            log_path=Path("/tmp/test.log"),
+        )
+        msg = user_facing_error(exc)
+        assert "/tmp" not in msg
+        assert "instructor" in msg
+        assert "Retrying will not help" in msg
+
+    def test_generic_error_passes_through(self) -> None:
+        exc = RuntimeError("something broke")
+        assert user_facing_error(exc) == "something broke"


### PR DESCRIPTION
## Summary

- When annotations overflow the margin column (more than fit on one page), detect marginalia placement warnings in the LaTeX log and recompile with all annotations routed to endnotes instead of invisible margin notes
- Translate `LaTeXCompilationError` into a student-friendly message: "PDF export failed due to a server configuration issue. Retrying will not help. Please email your workspace URL to your instructor so they can forward it to the system administrator."
- Add `tikzfill` to `setup_latex.py` required packages (tcolorbox transitive dependency)

## Test plan

- [ ] 12 new unit tests in `test_marginalia_overflow.py` covering log detection, .tex injection (including idempotency), .sty flag structure, and user-facing error translation
- [ ] 595 export unit tests pass
- [ ] Verify on prod with workspace `7d34508b` after deploying: export should produce PDF with all annotations in endnotes section
- [ ] Verify student sees friendly error message (not file paths) when LaTeX fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)