### PR TITLE
fix(export): escape para_ref + red button on failure

### DIFF
--- a/src/promptgrimoire/export/latex_format.py
+++ b/src/promptgrimoire/export/latex_format.py
@@ -36,8 +36,8 @@ def format_annot_latex(
     Args:
         highlight: Highlight dict with ``tag``, ``author``, ``text``,
             ``comments``, ``created_at``.
-        para_ref: Paragraph reference string (e.g. ``"[45]"`` or
-            ``"[45]-[48]"``).
+        para_ref: User-authored paragraph reference (e.g. ``"[45]"``,
+            ``"fn 8 & fn 9, para [1130]."``) — LaTeX-escaped internally.
 
     Returns:
         LaTeX ``\annot{colour}{margin_content}`` command string.

--- a/src/promptgrimoire/export/latex_format.py
+++ b/src/promptgrimoire/export/latex_format.py
@@ -63,11 +63,12 @@ def format_annot_latex(
     tag_esc = NoEscape(escape_unicode_latex(tag_display))
 
     # Line 1: **Tag** [para]
-    # para_ref is inserted raw — safe because callers pass only "[N]" or
-    # "[N]-[M]" paragraph references (no LaTeX specials in brackets/digits).
+    # para_ref is user-authored free text (e.g. "fn 8 & fn 9, para [1130].")
+    # and may contain LaTeX specials — escape it like any other user content.
     tag_bold = latex_cmd("textbf", tag_esc)
     if para_ref:
-        margin_parts: list[str] = [f"{tag_bold} {para_ref}"]
+        para_ref_esc = NoEscape(escape_unicode_latex(para_ref))
+        margin_parts: list[str] = [f"{tag_bold} {para_ref_esc}"]
     else:
         margin_parts = [str(tag_bold)]
 

--- a/src/promptgrimoire/export/pdf.py
+++ b/src/promptgrimoire/export/pdf.py
@@ -244,7 +244,7 @@ async def _run_latexmk(tex_path: Path, output_dir: Path) -> Path:
     )
     try:
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=120
+            proc.communicate(), timeout=60
         )
     except TimeoutError:
         logger.warning(
@@ -254,7 +254,7 @@ async def _run_latexmk(tex_path: Path, output_dir: Path) -> Path:
         )
         os.killpg(proc.pid, signal.SIGKILL)
         raise LaTeXCompilationError(
-            "LaTeX compilation timed out after 120s",
+            "LaTeX compilation timed out after 60s",
             tex_path=tex_path,
             log_path=output_dir / (tex_path.stem + ".log"),
         ) from None

--- a/src/promptgrimoire/pages/annotation/__init__.py
+++ b/src/promptgrimoire/pages/annotation/__init__.py
@@ -315,6 +315,7 @@ class PageState:
     export_poll_timer: Any | None = None
     export_download_container: Any | None = None
     export_btn: Any | None = None
+    export_error_msg: str | None = None
 
     def __post_init__(self) -> None:
         """Derive capability booleans from effective_permission."""

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -180,6 +180,11 @@ def _wrap_refresh_with_stale_download_clear(state: PageState) -> None:
         export_btn = getattr(state, "export_btn", None)
         if export_btn is not None:
             export_btn.enable()
+            # Reset error state — the document changed, so a previous
+            # failure may no longer apply.
+            export_btn.text = "Export PDF"
+            export_btn.props("color=primary")
+            state.export_error_msg = None
         # Call the original refresh
         original(trigger=trigger)
 
@@ -230,9 +235,12 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
                 ui.label("Export failed").classes("text-h6")
                 ui.label(state.export_error_msg)
                 with ui.row():
-                    ui.button(
-                        "Retry export", on_click=lambda: (dialog.close(), _do_export())
-                    ).props("color=primary")
+
+                    async def _retry() -> None:
+                        dialog.close()
+                        await _do_export()
+
+                    ui.button("Retry export", on_click=_retry).props("color=primary")
                     ui.button("Close", on_click=dialog.close).props("flat")
             dialog.open()
         else:

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -205,14 +205,13 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
     state.export_download_container = download_container
     state.export_btn = export_btn
 
-    async def on_export_click() -> None:
-        # Reset from error state if retrying after failure
+    async def _do_export() -> None:
+        """Reset button to normal state and submit export job."""
         export_btn.text = "Export PDF"
-        export_btn._props["icon"] = "picture_as_pdf"
-        export_btn.props('color=primary tooltip=""')
+        export_btn.props("color=primary")
+        state.export_error_msg = None
         export_btn.disable()
         export_btn.props("loading")
-        # Clear any previous download button
         download_container.clear()
         try:
             job_submitted = await _handle_pdf_export(state, workspace_id)
@@ -222,8 +221,22 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
             raise
         export_btn.props(remove="loading")
         if not job_submitted:
-            # Early return (rejected, no document, etc.) — re-enable
             export_btn.enable()
+
+    async def on_export_click() -> None:
+        if state.export_error_msg:
+            # Show error dialog with retry option instead of silently retrying
+            with ui.dialog() as dialog, ui.card():
+                ui.label("Export failed").classes("text-h6")
+                ui.label(state.export_error_msg)
+                with ui.row():
+                    ui.button(
+                        "Retry export", on_click=lambda: (dialog.close(), _do_export())
+                    ).props("color=primary")
+                    ui.button("Close", on_click=dialog.close).props("flat")
+            dialog.open()
+        else:
+            await _do_export()
 
     export_btn.on_click(on_export_click)
 

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -206,6 +206,10 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
     state.export_btn = export_btn
 
     async def on_export_click() -> None:
+        # Reset from error state if retrying after failure
+        export_btn.text = "Export PDF"
+        export_btn._props["icon"] = "picture_as_pdf"
+        export_btn.props('color=primary tooltip=""')
         export_btn.disable()
         export_btn.props("loading")
         # Clear any previous download button

--- a/src/promptgrimoire/pages/annotation/pdf_export.py
+++ b/src/promptgrimoire/pages/annotation/pdf_export.py
@@ -295,6 +295,20 @@ def _show_download_button(download_token: str, state: PageState) -> None:
         export_btn.enable()
 
 
+def _show_export_error(export_btn: ui.button, error_msg: str) -> None:
+    """Turn the export button red with error tooltip on failure.
+
+    Persistent visual state so the user sees the failure even if they
+    stepped away during compilation. The button remains enabled so the
+    user can retry, but the red colour and tooltip make the error obvious.
+    """
+    export_btn.props(f'color=negative tooltip="{error_msg}"')
+    export_btn.text = "Export failed"
+    export_btn._props["icon"] = "error"
+    export_btn.enable()
+    export_btn.update()
+
+
 def _start_export_polling(
     job_id: UUID,
     state: PageState,
@@ -346,15 +360,12 @@ def _start_export_polling(
         elif job.status == "failed":
             notification.dismiss()
             timer.deactivate()
-            ui.notification(
-                f"Export failed: {(job.error_message or 'Unknown error')[:200]}",
-                type="negative",
-                timeout=10,
-            )
-            # Re-enable export button so user can retry
+            error_msg = (job.error_message or "Unknown error")[:200]
+            # Show persistent red button with error tooltip instead of
+            # a transient notification the user may miss if away.
             export_btn = getattr(state, "export_btn", None)
             if export_btn is not None:
-                export_btn.enable()
+                _show_export_error(export_btn, error_msg)
 
     timer = ui.timer(2, _poll_status)
     state.export_poll_timer = timer

--- a/src/promptgrimoire/pages/annotation/pdf_export.py
+++ b/src/promptgrimoire/pages/annotation/pdf_export.py
@@ -295,18 +295,18 @@ def _show_download_button(download_token: str, state: PageState) -> None:
         export_btn.enable()
 
 
-def _show_export_error(export_btn: ui.button, error_msg: str) -> None:
-    """Turn the export button red with error tooltip on failure.
+def _show_export_error(export_btn: ui.button, error_msg: str, state: PageState) -> None:
+    """Turn the export button red on failure and stash the error message.
 
     Persistent visual state so the user sees the failure even if they
-    stepped away during compilation. The button remains enabled so the
-    user can retry, but the red colour and tooltip make the error obvious.
+    stepped away during compilation. Clicking the red button shows a
+    dialog with the error and a retry option.
     """
-    export_btn.props(f'color=negative tooltip="{error_msg}"')
+    export_btn.props("color=negative")
     export_btn.text = "Export failed"
-    export_btn._props["icon"] = "error"
     export_btn.enable()
     export_btn.update()
+    state.export_error_msg = error_msg
 
 
 def _start_export_polling(
@@ -365,7 +365,7 @@ def _start_export_polling(
             # a transient notification the user may miss if away.
             export_btn = getattr(state, "export_btn", None)
             if export_btn is not None:
-                _show_export_error(export_btn, error_msg)
+                _show_export_error(export_btn, error_msg, state)
 
     timer = ui.timer(2, _poll_status)
     state.export_poll_timer = timer

--- a/tests/fixtures/workspace_dogs_breakfast_overflow.json
+++ b/tests/fixtures/workspace_dogs_breakfast_overflow.json
@@ -1,0 +1,523 @@
+{
+  "html_content": "<!--StartFragment--><html><head></head><body><p style=\"text-indent:0px\"><span><span lang=\"EN-US\"><u>My Will</u></span></span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">I want this to be my will.</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">I leave everything I own to my partner Jamie.</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">Jamie will also deal with my estate and make sure things are done properly.</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">If Jamie is not alive, my stuff should go to my family, but they need to look after my dog.</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">Signed: Alex</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">Date: 10 June</span></p><p style=\"text-indent:0px\"><span lang=\"EN-US\">Witness: Jami</span></p><!--EndFragment-->\n\n</body></html>",
+  "highlights": [
+    {
+      "end_char": 7.0,
+      "created_at": "2026-04-07T07:17:57.372321+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "start_char": 0.0,
+      "comments": [
+        {
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett",
+          "created_at": "2026-04-07T07:18:30.602898+00:00",
+          "text": "Title does not identify testator",
+          "id": "08113bb1-6ac7-4b1f-907d-94009baa618f"
+        }
+      ],
+      "id": "b151efe3-514d-4220-8d5c-9485564931fb",
+      "para_ref": "[1]-[2]",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "author": "Max Barnett",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "text": "My Will",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "created_at": "2026-04-07T07:57:20.409483+00:00",
+      "id": "fccc79ba-ac07-4cdb-b43a-dc4711bb1adf",
+      "comments": [
+        {
+          "id": "6f3c2e49-630d-4a2b-8b58-54cdf7606a3c",
+          "text": "Title page",
+          "created_at": "2026-04-07T07:57:34.503249+00:00",
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc"
+        }
+      ],
+      "end_char": 7.0,
+      "para_ref": "[1]-[2]",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "start_char": 6.0,
+      "text": "l",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "author": "Max Barnett",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "end_char": 8.0,
+      "start_char": 7.0,
+      "id": "1a731f2d-81c3-46bf-9de2-732f7fdc5863",
+      "text": "I",
+      "author": "Max Barnett",
+      "created_at": "2026-03-12T06:01:32.729297+00:00",
+      "comments": [
+        {
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "id": "32e8706d-4b93-439a-8d00-a87070c939ff",
+          "text": "Improper identification of testator (full name and address)",
+          "created_at": "2026-04-07T07:19:28.951646+00:00"
+        }
+      ],
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[2]",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "author": "Max Barnett",
+      "start_char": 8.0,
+      "id": "0e77c50e-083c-49d9-9b80-b6b79e07dc1d",
+      "created_at": "2026-04-07T07:19:34.748786+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "text": " ",
+      "para_ref": "[2]",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "end_char": 9.0,
+      "comments": [
+        {
+          "id": "01e08e7e-9be0-4173-ad0b-aba31bdea54e",
+          "created_at": "2026-04-07T07:19:52.996561+00:00",
+          "author": "Max Barnett",
+          "text": "Last will and testament of...",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc"
+        }
+      ],
+      "tag_name": "Missing Clause"
+    },
+    {
+      "comments": [],
+      "text": "want this to be my will",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "end_char": 32.0,
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "id": "3632eed5-bafb-4851-ad22-6221110a3c4f",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[2]",
+      "start_char": 9.0,
+      "created_at": "2026-03-12T06:01:32.729577+00:00",
+      "author": "Max Barnett",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "start_char": 32.0,
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "comments": [
+        {
+          "text": "Survivorship clause",
+          "created_at": "2026-04-07T07:20:30.822417+00:00",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett",
+          "id": "f4b868b8-f08f-459c-a930-2085d04c8b68"
+        }
+      ],
+      "id": "d76fabe5-0f74-4577-a11c-2acc01ed5993",
+      "author": "Max Barnett",
+      "text": ".",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "para_ref": "[2]-[3]",
+      "end_char": 33.0,
+      "created_at": "2026-03-12T06:01:32.729816+00:00",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "para_ref": "[3]",
+      "comments": [
+        {
+          "id": "82091119-2907-4dfc-9356-691c1ea63daa",
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:21:15.708607+00:00",
+          "text": "Insufficient identification of property"
+        }
+      ],
+      "end_char": 57.0,
+      "start_char": 41.0,
+      "created_at": "2026-04-07T07:20:56.990449+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "author": "Max Barnett",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "id": "d5dfef8c-7a73-40f8-a9c3-ef27194a30ac",
+      "text": "everything I own",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "comments": [
+        {
+          "text": "Beneficiary could be better identified (full name, address, relationship)",
+          "created_at": "2026-04-07T07:21:52.243375+00:00",
+          "author": "Max Barnett",
+          "id": "7b77e59a-e7e3-4f2c-9176-7fd6b0699a64",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc"
+        }
+      ],
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "created_at": "2026-03-12T06:01:32.730268+00:00",
+      "start_char": 61.0,
+      "para_ref": "[3]",
+      "author": "Max Barnett",
+      "text": "my partner Jamie",
+      "end_char": 77.0,
+      "id": "8d106d22-b13a-4ea6-b54e-f84c85d2f991",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "author": "Max Barnett",
+      "end_char": 78.0,
+      "created_at": "2026-03-12T06:01:32.730516+00:00",
+      "start_char": 77.0,
+      "comments": [
+        {
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett",
+          "id": "53b73723-6345-49ec-b394-f9b5c0ae2ed1",
+          "created_at": "2026-04-07T07:22:41.690678+00:00",
+          "text": "Missing residue + back-up/wipeout clause"
+        }
+      ],
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[3]-[4]",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "text": ".",
+      "id": "94c7af27-0cac-4455-b23a-296cb59e3375",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "start_char": 78.0,
+      "id": "4e78f315-a58e-4d23-b0ee-4c94dfd7f145",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "text": "Jamie will also deal with my estate and make sure things are done properly",
+      "end_char": 152.0,
+      "author": "Max Barnett",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "created_at": "2026-04-07T07:23:03.363156+00:00",
+      "para_ref": "[4]",
+      "comments": [
+        {
+          "text": "Insufficient clarity on powers and role.",
+          "created_at": "2026-04-07T07:23:27.107802+00:00",
+          "id": "c67dc230-cc97-4c34-8057-3527a873b985",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett"
+        }
+      ],
+      "tag_name": "Ambiguity"
+    },
+    {
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "para_ref": "[4]-[5]",
+      "start_char": 152.0,
+      "author": "Max Barnett",
+      "comments": [
+        {
+          "id": "d85038db-13ae-425b-9fcd-dfa06ec2415f",
+          "created_at": "2026-04-07T07:23:53.874447+00:00",
+          "author": "Max Barnett",
+          "text": "Appointment of executor clause + appointment of alternative executor clause",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc"
+        }
+      ],
+      "id": "e1de5c0a-fd83-4966-ba8e-e7903be1a4ab",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "end_char": 153.0,
+      "text": ".",
+      "created_at": "2026-03-12T06:01:32.730715+00:00",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "id": "87058e5e-16ff-490b-a0d9-6ed3bac91f70",
+      "created_at": "2026-03-12T06:01:32.730809+00:00",
+      "para_ref": "[5]",
+      "author": "Max Barnett",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "start_char": 176.0,
+      "comments": [
+        {
+          "id": "57d99f75-eb94-4b3a-89a2-8eb4a7bc903f",
+          "author": "Max Barnett",
+          "text": "Insufficient identification of property",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:24:08.340347+00:00"
+        }
+      ],
+      "end_char": 185.0,
+      "text": "my stuff ",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "created_at": "2026-03-12T06:01:32.730902+00:00",
+      "text": "my family",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "para_ref": "[5]",
+      "start_char": 198.0,
+      "author": "Max Barnett",
+      "comments": [
+        {
+          "text": "Insufficient identification of beneficiary(ies) (full names, addresses, relationship)",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:24:41.658617+00:00",
+          "author": "Max Barnett",
+          "id": "541f217a-f673-4f01-8226-16ef4ed12648"
+        }
+      ],
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "end_char": 207.0,
+      "id": "c84a1413-eaf7-408e-a0cc-92945f8b5944",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "start_char": 207.0,
+      "tag": "6da36981-bfd9-4141-9c2f-c8c9d6133b5b",
+      "para_ref": "[5]",
+      "id": "072c154c-ef9a-4ad6-85d6-b1c3ef2a0f81",
+      "author": "Max Barnett",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "end_char": 209.0,
+      "text": ", ",
+      "comments": [
+        {
+          "author": "Max Barnett",
+          "id": "051e5120-e0d7-4932-bc80-cde8930422ff",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "text": "Possible family provision claim",
+          "created_at": "2026-04-07T07:25:28.814372+00:00"
+        }
+      ],
+      "created_at": "2026-03-12T06:01:32.731019+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag_name": "Estate Litigation Risk"
+    },
+    {
+      "author": "Max Barnett",
+      "text": "but they need",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "comments": [
+        {
+          "id": "d376f7dc-7d14-4e5b-9da0-dad4d2bc6e35",
+          "text": "Conditional gift/trust",
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:29:01.723169+00:00"
+        }
+      ],
+      "start_char": 209.0,
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[5]",
+      "id": "b6d01ec0-4eed-492b-858a-f5f2275fd051",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "end_char": 222.0,
+      "created_at": "2026-04-07T07:28:40.147292+00:00",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "start_char": 231.0,
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "end_char": 243.0,
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "text": "after my dog",
+      "id": "7dce6dd1-6692-432e-bdd6-6b44a21d7d13",
+      "comments": [
+        {
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:25:44.957346+00:00",
+          "text": "Trust for pet or gift of pet clause",
+          "author": "Max Barnett",
+          "id": "f267ed0a-7ee1-445f-8eed-0dbc31a85351"
+        }
+      ],
+      "para_ref": "[5]",
+      "author": "Max Barnett",
+      "created_at": "2026-03-12T06:01:32.731123+00:00",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "comments": [
+        {
+          "created_at": "2026-04-07T07:26:04.058796+00:00",
+          "text": "Attestation clause",
+          "id": "0e828dde-45cc-49fe-b223-de34b8ada5a0",
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc"
+        }
+      ],
+      "start_char": 244.0,
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "created_at": "2026-03-12T06:01:32.731242+00:00",
+      "text": "S",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "author": "Max Barnett",
+      "end_char": 245.0,
+      "id": "6e17171e-b8b6-448b-99ca-0c2f0512270f",
+      "para_ref": "[6]",
+      "tag": "456107b9-7308-4bd9-9961-7628a6a331b3",
+      "tag_name": "Missing Clause"
+    },
+    {
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "text": "Alex",
+      "created_at": "2026-03-12T06:01:32.731342+00:00",
+      "id": "cb01183f-52ef-496a-9317-a9cfb66636b9",
+      "start_char": 252.0,
+      "comments": [
+        {
+          "id": "f943c14b-2063-4ead-b2a1-a15031f796c7",
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:26:28.881895+00:00",
+          "text": "Insufficient identification of testator"
+        }
+      ],
+      "end_char": 256.0,
+      "para_ref": "[6]-[7]",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "author": "Max Barnett",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "para_ref": "[7]-[8]",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag": "a796c428-a4b0-444d-a2b1-2cbbec8d3075",
+      "id": "4cf10444-d4e3-4d2f-ad5b-f2f6bceeb1ab",
+      "start_char": 262.0,
+      "comments": [
+        {
+          "created_at": "2026-04-07T07:26:43.816620+00:00",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "text": "Missing year",
+          "id": "c25e7724-1066-48bc-a0d3-9aa51cd5caf9",
+          "author": "Max Barnett"
+        }
+      ],
+      "author": "Max Barnett",
+      "text": "10 June",
+      "end_char": 269.0,
+      "created_at": "2026-03-12T06:01:32.731438+00:00",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "tag_name": "Ambiguity"
+    },
+    {
+      "text": "Witness:",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[8]",
+      "end_char": 277.0,
+      "id": "83eec7c7-c9ad-4ccb-ae18-1f3fb3ab4869",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag": "93d189e5-a075-4f2d-97da-9a44e674b2b4",
+      "start_char": 269.0,
+      "created_at": "2026-03-12T06:01:32.731532+00:00",
+      "author": "Max Barnett",
+      "comments": [
+        {
+          "author": "Max Barnett",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:26:55.444441+00:00",
+          "text": "Only one witness",
+          "id": "20e569cd-fc53-4d2a-ba82-a62dfa3f68d1"
+        }
+      ],
+      "tag_name": "Formal Validity"
+    },
+    {
+      "comments": [
+        {
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett",
+          "created_at": "2026-04-07T07:27:10.070527+00:00",
+          "text": "Witness is a beneficiary",
+          "id": "9c671360-3871-4c1d-b1df-2091b90ab1fd"
+        }
+      ],
+      "id": "868f1911-f53f-49e9-9648-7d00c91af87e",
+      "created_at": "2026-03-12T06:01:32.731623+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "text": "Jam",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "end_char": 281.0,
+      "author": "Max Barnett",
+      "para_ref": "[8]",
+      "start_char": 278.0,
+      "tag": "93d189e5-a075-4f2d-97da-9a44e674b2b4",
+      "tag_name": "Formal Validity"
+    },
+    {
+      "start_char": 281.0,
+      "para_ref": "[8]",
+      "tag": "fab16d08-d537-4ba3-a128-c34804df14a5",
+      "text": "i",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "end_char": 282.0,
+      "created_at": "2026-03-12T06:01:32.731717+00:00",
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "author": "Max Barnett",
+      "id": "08d0ded7-da07-45a2-9360-3ef5a87bd310",
+      "comments": [
+        {
+          "text": "Jamie's name misspelled",
+          "created_at": "2026-04-07T07:27:43.371962+00:00",
+          "id": "3a9558c8-6282-4753-98e4-b5653d5f11a1",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "author": "Max Barnett"
+        }
+      ],
+      "tag_name": "Clerical Error"
+    },
+    {
+      "text": "i",
+      "id": "f23430cb-7564-4dff-ba58-7bc0ff1cf54d",
+      "end_char": 282.0,
+      "author": "Max Barnett",
+      "created_at": "2026-04-07T07:28:07.335635+00:00",
+      "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+      "para_ref": "[8]",
+      "tag": "fab16d08-d537-4ba3-a128-c34804df14a5",
+      "comments": [
+        {
+          "author": "Max Barnett",
+          "text": "Missing page numbers",
+          "id": "f410a6cc-350a-4a18-a739-39ecdcaaae4b",
+          "user_id": "82229bd1-daa1-491c-af96-3be6ea9406cc",
+          "created_at": "2026-04-07T07:28:19.370932+00:00"
+        }
+      ],
+      "start_char": 281.0,
+      "document_id": "e86690b8-1c81-4a26-a842-892220ee933e",
+      "tag_name": "Clerical Error"
+    }
+  ],
+  "tag_colours": {
+    "93d189e5-a075-4f2d-97da-9a44e674b2b4": "#e6194b",
+    "a796c428-a4b0-444d-a2b1-2cbbec8d3075": "#3cb44b",
+    "456107b9-7308-4bd9-9961-7628a6a331b3": "#4363d8",
+    "fab16d08-d537-4ba3-a128-c34804df14a5": "#f58231",
+    "6da36981-bfd9-4141-9c2f-c8c9d6133b5b": "#911eb4"
+  },
+  "tag_names": {
+    "93d189e5-a075-4f2d-97da-9a44e674b2b4": "Formal Validity",
+    "a796c428-a4b0-444d-a2b1-2cbbec8d3075": "Ambiguity",
+    "456107b9-7308-4bd9-9961-7628a6a331b3": "Missing Clause",
+    "fab16d08-d537-4ba3-a128-c34804df14a5": "Clerical Error",
+    "6da36981-bfd9-4141-9c2f-c8c9d6133b5b": "Estate Litigation Risk"
+  },
+  "metadata": {
+    "workspace_id": "7d34508b-0648-4b96-805b-5b0e1e7c994e",
+    "title": "Dog's Breakfast",
+    "source": "Production export 2026-04-07, 23 highlights on short document",
+    "purpose": "Marginalia overflow regression fixture — too many annotations for margin column"
+  }
+}

--- a/tests/fixtures/workspace_pabai_latex_specials.json
+++ b/tests/fixtures/workspace_pabai_latex_specials.json
@@ -1,0 +1,166 @@
+{
+  "html_content": "<html><head></head><body>\n<h1>Pabai v Commonwealth of Australia (No 2) [2025] FCA 796</h1>\n<p>1114 As has already been noted, however, the applicants’ claim to be entitled to compensation forloss of fulfilment of Ailan Kastom must be assessed separately and without reference to anynative title rights or interests that they may have under the Native Title Act.</p>\n<p>1131 The critical question here, however, is whether loss of fulfilment of Ailan Kastom is a separateform of actionable damage. As the passage from Gleeson CJ’s judgment in Cattanachindicated, the answer to that question hinges on whether loss of fulfilment of Ailan Kastom canbe said to be a “right ...</p>\n<p>1275 The applicants’ primary case against the Commonwealth failed not so much because there wasno merit in their factual allegations concerning the Commonwealth’s emissions reductiontargets. Rather, it failed because the law in Australia as it currently stands provides no real oreffective avenue thr...</p>\n<p>1130 Recognised categories of actionable damage include physical injury, property damage, and insome circumstances pure economic loss. Loss or harm caused to a person’s property, or theirperson (that is, physical injury) involves an interference with “a right or interest recognised ascapable of prot...</p>\n<p>1275 The applicants’ primary case against the Commonwealth failed not so much because there wasno merit in their factual allegations concerning the Commonwealth’s emissions reductiontargets. Rather, it failed because the law in Australia as it currently stands provides no real oreffective avenue thr...</p>\n</body></html>",
+  "highlights": [
+    {
+      "start_char": 0,
+      "id": "237f1cf8-4ba9-499a-9ff3-c469f212e8d0",
+      "comments": [
+        {
+          "id": "0c26e888-b5a1-4e04-907b-787920578448",
+          "created_at": "2026-04-10T10:56:05.480902+00:00",
+          "author": "Test Student",
+          "text": "Cross-link Nicholls & Nolan / Contrast with Pabai.",
+          "user_id": "00000000-0000-0000-0000-000000000001"
+        },
+        {
+          "author": "Test Student",
+          "created_at": "2026-04-10T18:32:32.978521+00:00",
+          "text": "Where cultural loss is pleaded as freestanding negligence damage, the law stops short.",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "id": "01187f4f-7ea4-4a61-abd4-63d4a04596d8"
+        }
+      ],
+      "end_char": 267,
+      "created_at": "2026-04-10T10:55:58.528536+00:00",
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "document_id": "180d698e-77e7-4ff2-92ac-57aefbabe7e1",
+      "para_ref": "fn 60, para [1114], [1131]-[1132], [1275].",
+      "text": "1114 As has already been noted, however, the applicants’ claim to be entitled to compensation forloss of fulfilment of Ailan Kastom must be assessed separately and without reference to anynative title rights or interests that they may have under the Native Title Act.",
+      "tag": "16230ec5-de83-429d-89b1-5c3bb2a77443",
+      "author": "Test Student",
+      "tag_name": "Native Title Distinction"
+    },
+    {
+      "tag": "16230ec5-de83-429d-89b1-5c3bb2a77443",
+      "para_ref": "fn 60 & fn 67, para [1114], [1131]-[1132], [1275].",
+      "created_at": "2026-04-10T10:54:18.214435+00:00",
+      "start_char": 317,
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "id": "e3696066-24be-46b2-83d8-961f0e5f2991",
+      "text": "1131 The critical question here, however, is whether loss of fulfilment of Ailan Kastom is a separateform of actionable damage. As the passage from Gleeson CJ’s judgment in Cattanachindicated, the answer to that question hinges on whether loss of fulfilment of Ailan Kastom canbe said to be a “right or interest recognised as capable of protection by law”. None of the casesrelied on by the applicants establish, or provide any support for the proposition, that loss offulfilment of Ailan Kastom is such a right or interest. I was not taken to any case whichestablishes that the participation in, or enjoyment or observance of, any of the sorts of customs,traditions, observances and beliefs that fall within the meaning of Ailan Kastom constitutes orcomprises a right or interest that is recognised as capable of protection by law. While I havesome considerable sympathy for the applicants’ contention that Ailan Kastom should berecognised as capable of protection by law, I do not consider that it is open to me, sitting as asingle judge of this Court, to recognise, apparently for the first time, that participation in, orenjoyment or observance of, customs, traditions, observances and beliefs, can constitute orcomprise rights or interests capable of protection by law.1132 Accordingly, I decline to find that fulfilment of Ailan Kastom is a right or interest the loss orharm to which is compensable under the Australian common law of negligence.",
+      "end_char": 1768,
+      "document_id": "180d698e-77e7-4ff2-92ac-57aefbabe7e1",
+      "comments": [
+        {
+          "created_at": "2026-04-10T10:54:46.461399+00:00",
+          "id": "4aa3d91b-6c01-42fb-b4bc-9754ea7469c5",
+          "text": "Cross-link Nicholls & Nolan / Contrast with Pabai.",
+          "author": "Test Student",
+          "user_id": "00000000-0000-0000-0000-000000000001"
+        },
+        {
+          "text": "Where cultural loss is pleaded as freestanding negligence damage, the law stops short.",
+          "id": "de986810-01af-4618-b2a3-200e97018f59",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "created_at": "2026-04-10T15:17:40.090936+00:00",
+          "author": "Test Student"
+        }
+      ],
+      "author": "Test Student",
+      "tag_name": "Native Title Distinction"
+    },
+    {
+      "document_id": "180d698e-77e7-4ff2-92ac-57aefbabe7e1",
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "created_at": "2026-04-10T10:43:37.484014+00:00",
+      "para_ref": "fn 36, para [1275].",
+      "comments": [
+        {
+          "text": "Cross-link Nicholls & Nolan / Contrast with Pabai.",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "id": "998a56b8-a5ac-4239-8247-b63f5bb0d0be",
+          "author": "Test Student",
+          "created_at": "2026-04-10T10:43:57.974458+00:00"
+        },
+        {
+          "created_at": "2026-04-10T15:34:36.485266+00:00",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "text": "This is the remedial gap exposed by Pabai when contrasted with Griffiths.",
+          "id": "133d0be7-ef8d-43e9-8b3c-e7c72447269f",
+          "author": "Test Student"
+        }
+      ],
+      "text": "1275 The applicants’ primary case against the Commonwealth failed not so much because there wasno merit in their factual allegations concerning the Commonwealth’s emissions reductiontargets. Rather, it failed because the law in Australia as it currently stands provides no real oreffective avenue through which the applicants were able to pursue their claims. In particular,the common law of negligence in Australia was an unsuitable legal vehicle through which theapplicants could obtain relief in respect of the type of governmental action or inaction whichwas in issue in this case, or relief in respect of their loss of fulfilment of Ailan Kastom. Thatwill remain the case unless and until the law in Australia changes, either by the incrementaldevelopment or expansion of the common law by appellate courts, or by the enactment oflegislation. Until then, the only recourse that those in the position of the applicants and otherTorres Strait Islanders have is recourse via the ballot box.",
+      "end_char": 2810,
+      "id": "cce2eb25-a9c9-4513-9023-3ab085209133",
+      "tag": "067316ce-8c23-4ae4-8aa2-dfb38ee58a46",
+      "author": "Test Student",
+      "start_char": 1818,
+      "tag_name": "No Effective Avenue / Conclusion"
+    },
+    {
+      "end_char": 3554,
+      "author": "Test Student",
+      "comments": [
+        {
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "author": "Test Student",
+          "id": "a2d25e45-6792-484a-8f6f-1acb87e4456b",
+          "text": "Recognised categories include physical injury, property damage, and sometimes pure economic loss.",
+          "created_at": "2026-04-10T15:08:12.895009+00:00"
+        },
+        {
+          "text": "Personal injury damages may include lost cultural participation and enjoyment of life.",
+          "id": "0b0c9d49-322c-4485-bb8e-6e5c21b201fd",
+          "created_at": "2026-04-10T15:08:23.723418+00:00",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "author": "Test Student"
+        }
+      ],
+      "document_id": "180d698e-77e7-4ff2-92ac-57aefbabe7e1",
+      "tag": "72f03ed2-938e-41dd-9a9f-76d7328f932d",
+      "created_at": "2026-04-10T10:23:39.541495+00:00",
+      "start_char": 2860,
+      "text": "1130 Recognised categories of actionable damage include physical injury, property damage, and insome circumstances pure economic loss. Loss or harm caused to a person’s property, or theirperson (that is, physical injury) involves an interference with “a right or interest recognised ascapable of protection by law”. As the cases referred to earlier indicate, the award of damagesto compensate a person for personal injury may include damages for pain and suffering, or lossof amenities, or loss of enjoyment of life. Those cases also indicate that a person may becompensated for their inability to fully participate in or enjoy various cultural practices underthose recognised heads of damages.",
+      "id": "e11fcf3e-bd64-4244-95f3-0511975486f8",
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "para_ref": "fn 8 & fn 9, para [1130].",
+      "tag_name": "Actionable Damage"
+    },
+    {
+      "created_at": "2026-04-10T10:55:13.729341+00:00",
+      "para_ref": "fn 60, para [1114], [1131]-[1132], [1275].",
+      "comments": [
+        {
+          "id": "1b7f2993-a979-4b3b-a391-77a2675fbaaa",
+          "text": "Cross-link Nicholls & Nolan / Contrast with Pabai.",
+          "author": "Test Student",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "created_at": "2026-04-10T10:55:22.254959+00:00"
+        },
+        {
+          "author": "Test Student",
+          "id": "25bf0d5c-ea9c-4087-bc50-9abdd2ff0a53",
+          "user_id": "00000000-0000-0000-0000-000000000001",
+          "text": "Where cultural loss is pleaded as freestanding negligence damage, the law stops short.",
+          "created_at": "2026-04-10T15:39:38.908165+00:00"
+        }
+      ],
+      "document_id": "180d698e-77e7-4ff2-92ac-57aefbabe7e1",
+      "tag": "16230ec5-de83-429d-89b1-5c3bb2a77443",
+      "author": "Test Student",
+      "id": "d6929e14-b3db-4ef1-b16f-880c2acecc7a",
+      "text": "1275 The applicants’ primary case against the Commonwealth failed not so much because there wasno merit in their factual allegations concerning the Commonwealth’s emissions reductiontargets. Rather, it failed because the law in Australia as it currently stands provides no real oreffective avenue through which the applicants were able to pursue their claims. In particular,the common law of negligence in Australia was an unsuitable legal vehicle through which theapplicants could obtain relief in respect of the type of governmental action or inaction whichwas in issue in this case, or relief in respect of their loss of fulfilment of Ailan Kastom. Thatwill remain the case unless and until the law in Australia changes, either by the incrementaldevelopment or expansion of the common law by appellate courts, or by the enactment oflegislation. Until then, the only recourse that those in the position of the applicants and otherTorres Strait Islanders have is recourse via the ballot box.",
+      "start_char": 3604,
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "end_char": 4596,
+      "tag_name": "Native Title Distinction"
+    }
+  ],
+  "tag_colours": {
+    "067316ce-8c23-4ae4-8aa2-dfb38ee58a46": "#9467bd",
+    "16230ec5-de83-429d-89b1-5c3bb2a77443": "#ff7f0e",
+    "72f03ed2-938e-41dd-9a9f-76d7328f932d": "#d62728"
+  },
+  "tag_names": {
+    "067316ce-8c23-4ae4-8aa2-dfb38ee58a46": "No Effective Avenue / Conclusion",
+    "16230ec5-de83-429d-89b1-5c3bb2a77443": "Native Title Distinction",
+    "72f03ed2-938e-41dd-9a9f-76d7328f932d": "Actionable Damage"
+  },
+  "metadata": {
+    "workspace_id": "f4a930d4-9573-4a69-82cb-b918f4d4d1a4",
+    "title": "Pabai v Commonwealth (LaTeX special chars fixture)",
+    "source": "production-scrubbed-2026-04-11",
+    "purpose": "Reproduce LaTeX compilation failure from unescaped & in para_ref and comment text. GH incident 2026-04-11."
+  }
+}

--- a/tests/integration/test_latex_specials_export.py
+++ b/tests/integration/test_latex_specials_export.py
@@ -1,0 +1,95 @@
+"""Integration test: LaTeX special characters in annotations compile successfully.
+
+Uses the Pabai workspace fixture (5 highlights with & in para_ref and
+comment text) which caused a production LaTeX compilation failure on
+2026-04-11.  The fix escapes para_ref via escape_unicode_latex().
+
+This test proves the fix works end-to-end through the full pipeline:
+Python escaping → Pandoc → Lua filter → LuaLaTeX compilation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from promptgrimoire.export.pdf_export import export_annotation_pdf
+from tests.conftest import requires_full_latexmk
+from tests.integration.conftest import extract_pdf_text_pymupdf
+
+FIXTURE_PATH = (
+    Path(__file__).parents[1] / "fixtures" / "workspace_pabai_latex_specials.json"
+)
+
+
+def _load_fixture() -> dict:
+    with FIXTURE_PATH.open() as f:
+        return json.load(f)
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def specials_result(tmp_path_factory):
+    """Compile the latex-specials fixture once for all tests in this module."""
+    output_dir = tmp_path_factory.mktemp("pabai_specials")
+    fixture = _load_fixture()
+
+    pdf_path = await export_annotation_pdf(
+        html_content=fixture["html_content"],
+        highlights=fixture["highlights"],
+        tag_colours=fixture["tag_colours"],
+        output_dir=output_dir,
+    )
+
+    tex_path = output_dir / "annotated_document.tex"
+    tex_content = tex_path.read_text()
+    pdf_text = extract_pdf_text_pymupdf(pdf_path)
+
+    return {
+        "pdf_path": pdf_path,
+        "tex_path": tex_path,
+        "tex_content": tex_content,
+        "pdf_text": pdf_text,
+        "output_dir": output_dir,
+        "fixture": fixture,
+    }
+
+
+@requires_full_latexmk
+class TestLatexSpecialsCompile:
+    """Annotations with LaTeX specials must compile without error."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_pdf_is_produced(self, specials_result) -> None:
+        """Export must succeed despite & in para_ref and comments."""
+        pdf_path = specials_result["pdf_path"]
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 1000
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_all_annotation_numbers_present(self, specials_result) -> None:
+        """Every annotation number (1-5) must appear in the PDF."""
+        pdf_text = specials_result["pdf_text"]
+        fixture = specials_result["fixture"]
+        n_highlights = len(fixture["highlights"])
+
+        for i in range(1, n_highlights + 1):
+            assert str(i) in pdf_text, f"Annotation {i} not found in PDF text"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_ampersand_rendered_in_pdf(self, specials_result) -> None:
+        """The & character must appear as literal text in the PDF output."""
+        pdf_text = specials_result["pdf_text"]
+        # The para_ref "fn 8 & fn 9" should render with a visible &
+        assert "&" in pdf_text, "Escaped & not rendered as literal ampersand in PDF"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_comment_text_present(self, specials_result) -> None:
+        """Comment text with & must appear in the PDF."""
+        pdf_text = specials_result["pdf_text"]
+        # "Nicholls & Nolan" appears in multiple comments
+        assert "Nicholls" in pdf_text, (
+            "Comment text 'Nicholls & Nolan' not found in PDF"
+        )

--- a/tests/integration/test_marginalia_overflow_export.py
+++ b/tests/integration/test_marginalia_overflow_export.py
@@ -1,0 +1,166 @@
+"""Integration test: marginalia overflow produces all annotations in PDF.
+
+Uses the "Dog's Breakfast" workspace fixture (23 highlights on a short
+document) which overflows the margin column.  The current workaround
+(PR #477) detects overflow and recompiles with ALL annotations as
+endnotes.  The xfail test marks the desired behaviour: per-page
+selective routing where margin-fit annotations stay in the margin.
+
+See: https://github.com/MQFacultyOfArts/PromptGrimoireTool/issues/478
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from promptgrimoire.export.pdf_export import export_annotation_pdf
+from tests.conftest import requires_full_latexmk
+from tests.integration.conftest import extract_pdf_text_pymupdf
+
+# Smart quote → ASCII mapping for PDF text comparison.
+_QUOTE_TABLE = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+    }
+)
+
+
+def _normalize_for_pdf(text: str) -> str:
+    """Collapse whitespace and normalise smart quotes for PDF matching."""
+    return re.sub(r"\s+", " ", text).translate(_QUOTE_TABLE)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parents[1] / "fixtures" / "workspace_dogs_breakfast_overflow.json"
+)
+
+
+def _load_fixture() -> dict:
+    with FIXTURE_PATH.open() as f:
+        return json.load(f)
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def overflow_result(tmp_path_factory):
+    """Compile the overflow fixture once for all tests in this module."""
+    output_dir = tmp_path_factory.mktemp("dogs_breakfast")
+    fixture = _load_fixture()
+
+    pdf_path = await export_annotation_pdf(
+        html_content=fixture["html_content"],
+        highlights=fixture["highlights"],
+        tag_colours=fixture["tag_colours"],
+        output_dir=output_dir,
+    )
+
+    tex_path = output_dir / "annotated_document.tex"
+    tex_content = tex_path.read_text()
+    pdf_text = extract_pdf_text_pymupdf(pdf_path)
+
+    return {
+        "pdf_path": pdf_path,
+        "tex_path": tex_path,
+        "tex_content": tex_content,
+        "pdf_text": pdf_text,
+        "output_dir": output_dir,
+        "fixture": fixture,
+    }
+
+
+@requires_full_latexmk
+class TestOverflowAllAnnotationsPresent:
+    """All 23 annotations must appear in the PDF output."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_pdf_is_produced(self, overflow_result) -> None:
+        """Export must succeed (not crash) despite overflow."""
+        pdf_path = overflow_result["pdf_path"]
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 1000
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_all_annotation_numbers_present(self, overflow_result) -> None:
+        """Every annotation number (1-23) must appear in the PDF text."""
+        pdf_text = overflow_result["pdf_text"]
+        fixture = overflow_result["fixture"]
+        n_highlights = len(fixture["highlights"])
+
+        for i in range(1, n_highlights + 1):
+            assert str(i) in pdf_text, (
+                f"Annotation {i} not found in PDF text — "
+                f"likely clipped by margin overflow"
+            )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_all_comments_present(self, overflow_result, subtests) -> None:
+        """Every annotation comment text must appear in the PDF."""
+        pdf_norm = _normalize_for_pdf(overflow_result["pdf_text"])
+        fixture = overflow_result["fixture"]
+
+        for i, h in enumerate(fixture["highlights"]):
+            for comment in h.get("comments", []):
+                text = comment.get("text", "")
+                if text:
+                    text_norm = _normalize_for_pdf(text)
+                    with subtests.test(msg=f"hl-{i}-comment"):
+                        assert text_norm in pdf_norm, (
+                            f"Highlight {i} comment {text!r} not found in PDF"
+                        )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_endnotes_section_present(self, overflow_result) -> None:
+        """The endnotes section must exist (overflow fallback)."""
+        pdf_text = overflow_result["pdf_text"]
+        assert "Annotations" in pdf_text, (
+            "Annotations endnotes section not found — "
+            "overflow fallback may not have triggered"
+        )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_force_endnotes_flag_injected(self, overflow_result) -> None:
+        r"""The recompiled .tex must contain \annotforceendnotestrue."""
+        tex = overflow_result["tex_content"]
+        assert r"\annotforceendnotestrue" in tex, (
+            "Force-endnotes flag not found — "
+            "marginalia overflow detection may have failed"
+        )
+
+
+@requires_full_latexmk
+class TestSelectiveOverflowRouting:
+    """Desired behaviour: only overflow annotations go to endnotes.
+
+    These tests are xfail until #478 implements per-page density
+    routing.  Currently ALL annotations go to endnotes on overflow.
+    """
+
+    @pytest.mark.xfail(
+        reason="PR #477 sends ALL to endnotes; #478 will route selectively",
+        strict=True,
+    )
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_some_annotations_remain_in_margin(self, overflow_result) -> None:
+        r"""At least some annotations should stay in the margin.
+
+        The current workaround routes ALL to endnotes.  A smarter
+        implementation would keep annotations that fit in the margin
+        and only overflow the excess.  Detected by checking for
+        \marginalia commands in the final .tex (force-endnotes mode
+        skips all \marginalia calls).
+        """
+        tex = overflow_result["tex_content"]
+        # In force-endnotes mode, \annot never calls \marginalia.
+        # If selective routing works, some \marginalia calls should
+        # still appear in the compiled output.
+        assert r"\annotforceendnotestrue" not in tex, (
+            "All annotations sent to endnotes — "
+            "selective routing not yet implemented (#478)"
+        )

--- a/tests/unit/export/test_latex_string_functions.py
+++ b/tests/unit/export/test_latex_string_functions.py
@@ -220,6 +220,56 @@ class TestFormatAnnot:
         assert "Carol" in result
         assert "I agree" in result
 
+    def test_para_ref_with_ampersand_is_escaped(self) -> None:
+        """para_ref containing & must be LaTeX-escaped (production incident 2026-04-11).
+
+        Student entered 'fn 8 & fn 9, para [1130].' as a para_ref,
+        producing fatal 'Misplaced alignment tab character &' in LaTeX.
+        """
+        highlight = {
+            "tag": "actionable_damage",
+            "tag_name": "Actionable Damage",
+            "author": "Student",
+            "text": "some text",
+            "comments": [],
+        }
+        result = format_annot_latex(highlight, para_ref="fn 8 & fn 9, para [1130].")
+        # Raw & must be escaped to \&
+        assert r"\&" in result
+        # No bare & outside of \& sequences
+        parts = result.split(r"\&")
+        for part in parts:
+            assert "&" not in part, (
+                f"Bare & found in output (not escaped): ...{part[:60]}..."
+            )
+
+    def test_para_ref_with_percent_is_escaped(self) -> None:
+        """para_ref containing % must be LaTeX-escaped."""
+        highlight = {
+            "tag": "tag",
+            "author": "User",
+            "text": "some text",
+            "comments": [],
+        }
+        result = format_annot_latex(highlight, para_ref="100% relevant")
+        assert r"\%" in result
+
+    def test_para_ref_with_all_latex_specials(self) -> None:
+        """All LaTeX special characters in para_ref must be escaped."""
+        highlight = {
+            "tag": "tag",
+            "author": "User",
+            "text": "some text",
+            "comments": [],
+        }
+        result = format_annot_latex(
+            highlight, para_ref="s 51(xxxi) & s 75(v), $0, #1, 100%"
+        )
+        assert r"\&" in result
+        assert r"\$" in result
+        assert r"\#" in result
+        assert r"\%" in result
+
     def test_escapes_special_characters_in_author(self) -> None:
         """Special characters in author should be escaped."""
         highlight = {


### PR DESCRIPTION
## Summary

- **Fix:** `para_ref` field in annotations is user-authored free text (e.g. `fn 8 & fn 9, para [1130].`) but was inserted raw into LaTeX — unescaped `&` caused fatal compilation error. Now escaped via `escape_unicode_latex()`.
- **UI:** Export button turns red on failure with "Export failed" text. Clicking shows error dialog with retry option. Error state resets on document change.
- **Timeout:** LaTeX compile timeout reduced from 120s to 60s.

Production incident 2026-04-11: workspace f4a930d4, same user retried 9 times overnight without seeing the transient error notification.

## Test plan

- [x] 3 unit tests for `&`, `%`, `$`, `#` in para_ref (`test_latex_string_functions.py`)
- [x] 4 integration tests with real latexmk compilation (`test_latex_specials_export.py`, runs in `e2e slow`)
- [x] PII-scrubbed production fixture (`workspace_pabai_latex_specials.json`)
- [x] 4043 unit tests passing
- [ ] `e2e slow` latexmk lane (running locally)
- [ ] Manual: trigger export failure, verify red button + error dialog + retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)