### PR TITLE
fix(export): escaped brace depth tracking + remove retry button

### DIFF
--- a/src/promptgrimoire/export/pandoc.py
+++ b/src/promptgrimoire/export/pandoc.py
@@ -129,13 +129,32 @@ def _strip_textquotesingle(latex: str) -> str:
 # processing pass moves any \annot at brace depth > 0 to depth 0.
 
 
+def _is_escaped_brace(latex: str, pos: int) -> bool:
+    r"""Return True if the brace at *pos* is LaTeX-escaped (``\{`` or ``\}``).
+
+    Counts consecutive backslashes before *pos*.  An odd count means the
+    brace is escaped (e.g. ``\}`` = literal brace); an even count (including
+    zero) means it is structural (e.g. ``\\}`` = line-break + structural ``}``).
+    """
+    backslashes = 0
+    i = pos - 1
+    while i >= 0 and latex[i] == "\\":
+        backslashes += 1
+        i -= 1
+    return backslashes % 2 == 1
+
+
 def _brace_depth_at(latex: str, pos: int) -> int:
-    """Calculate brace nesting depth at a position in a LaTeX string."""
+    r"""Calculate brace nesting depth at a position in a LaTeX string.
+
+    Skips LaTeX-escaped braces (``\{``, ``\}``) which produce literal
+    brace characters and do not affect structural nesting.
+    """
     depth = 0
     for j in range(pos):
-        if latex[j] == "{":
+        if latex[j] == "{" and not _is_escaped_brace(latex, j):
             depth += 1
-        elif latex[j] == "}":
+        elif latex[j] == "}" and not _is_escaped_brace(latex, j):
             depth -= 1
     return depth
 
@@ -143,12 +162,15 @@ def _brace_depth_at(latex: str, pos: int) -> int:
 def _find_closing_brace_at_depth(
     latex: str, start: int, start_depth: int, target_depth: int
 ) -> int:
-    """Find ``}`` reducing depth to *target_depth* from *start*."""
+    r"""Find ``}`` reducing depth to *target_depth* from *start*.
+
+    Skips LaTeX-escaped braces (``\{``, ``\}``).
+    """
     depth = start_depth
     for i in range(start, len(latex)):
-        if latex[i] == "{":
+        if latex[i] == "{" and not _is_escaped_brace(latex, i):
             depth += 1
-        elif latex[i] == "}":
+        elif latex[i] == "}" and not _is_escaped_brace(latex, i):
             depth -= 1
             if depth == target_depth:
                 return i
@@ -156,7 +178,9 @@ def _find_closing_brace_at_depth(
 
 
 def _find_matching_brace(latex: str, open_pos: int) -> int:
-    """Find the position of the matching closing brace.
+    r"""Find the position of the matching closing brace.
+
+    Skips LaTeX-escaped braces (``\{``, ``\}``).
 
     Args:
         latex: LaTeX string.
@@ -167,9 +191,9 @@ def _find_matching_brace(latex: str, open_pos: int) -> int:
     """
     depth = 0
     for i in range(open_pos, len(latex)):
-        if latex[i] == "{":
+        if latex[i] == "{" and not _is_escaped_brace(latex, i):
             depth += 1
-        elif latex[i] == "}":
+        elif latex[i] == "}" and not _is_escaped_brace(latex, i):
             depth -= 1
             if depth == 0:
                 return i

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -230,17 +230,13 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
 
     async def on_export_click() -> None:
         if state.export_error_msg:
-            # Show error dialog with retry option instead of silently retrying
+            # Show error dialog — no retry because LaTeX failures are
+            # deterministic (same content → same error).  The button
+            # resets automatically when the document changes.
             with ui.dialog() as dialog, ui.card():
                 ui.label("Export failed").classes("text-h6")
                 ui.label(state.export_error_msg)
                 with ui.row():
-
-                    async def _retry() -> None:
-                        dialog.close()
-                        await _do_export()
-
-                    ui.button("Retry export", on_click=_retry).props("color=primary")
                     ui.button("Close", on_click=dialog.close).props("flat")
             dialog.open()
         else:

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlencode
 
 import structlog
 from nicegui import ui
@@ -233,10 +234,22 @@ def _render_export_button(state: PageState, workspace_id: UUID) -> None:
             # Show error dialog — no retry because LaTeX failures are
             # deterministic (same content → same error).  The button
             # resets automatically when the document changes.
-            with ui.dialog() as dialog, ui.card():
-                ui.label("Export failed").classes("text-h6")
-                ui.label(state.export_error_msg)
-                with ui.row():
+            ws_url = f"/annotation?{urlencode({'workspace_id': str(workspace_id)})}"
+            with ui.dialog() as dialog, ui.card().classes("w-96"):
+                ui.label("Export failed").classes("text-h6 text-red-800")
+                ui.label(
+                    "Your export failed. Please communicate this to your "
+                    "instructor, with your workspace URL and the message "
+                    "below. Export of this workspace has been disabled "
+                    "until the error is resolved by the developer."
+                ).classes("text-sm")
+                ui.label(f"Workspace: {ws_url}").classes(
+                    "text-xs font-mono bg-grey-2 pa-2 rounded"
+                )
+                ui.label(state.export_error_msg).classes(
+                    "text-xs font-mono bg-grey-2 pa-2 rounded"
+                )
+                with ui.row().classes("w-full justify-end mt-2"):
                     ui.button("Close", on_click=dialog.close).props("flat")
             dialog.open()
         else:

--- a/tests/unit/test_move_annots_outside_restricted.py
+++ b/tests/unit/test_move_annots_outside_restricted.py
@@ -67,6 +67,74 @@ def _load_fixture() -> tuple[str, list[dict], dict[str, str]]:
     return content, highlights, tag_colours
 
 
+class TestBraceDepthEscaping:
+    r"""_brace_depth_at must skip LaTeX-escaped braces (\{ and \}).
+
+    Production failure: student comment containing literal '}' is escaped to
+    '\}' by escape_unicode_latex. The naive brace counter treated '\}' as a
+    structural closing brace, throwing off depth for all subsequent content.
+    _move_annots_outside_restricted then saw the wrong depth and failed to
+    move \annot out of \textbf{}.
+    """
+
+    def test_escaped_close_brace_not_counted(self) -> None:
+        r"""\} inside a group does not reduce structural depth."""
+        # \textbf{ opens depth 1; \} is NOT structural; } closes to depth 0
+        latex = r"\textbf{hello\}world}"
+        # Position after the final '}' — depth should be 0
+        assert _brace_depth_at(latex, len(latex)) == 0
+        # Position just before the final '}' — depth should be 1 (still inside \textbf)
+        final_close = latex.rfind("}")
+        assert _brace_depth_at(latex, final_close) == 1
+
+    def test_escaped_open_brace_not_counted(self) -> None:
+        r"""\{ inside a group does not increase structural depth."""
+        latex = r"\textbf{hello\{world}"
+        assert _brace_depth_at(latex, len(latex)) == 0
+        final_close = latex.rfind("}")
+        assert _brace_depth_at(latex, final_close) == 1
+
+    def test_double_backslash_then_brace_is_structural(self) -> None:
+        r"""\\{ is escaped backslash + structural open brace."""
+        # \\{ = line break + structural {
+        latex = r"\\{hello}"
+        # After \\{ we're at depth 1, after } at depth 0
+        assert _brace_depth_at(latex, len(latex)) == 0
+        brace_pos = latex.index("{")
+        assert _brace_depth_at(latex, brace_pos + 1) == 1
+
+    def test_annot_with_escaped_brace_in_comment(self) -> None:
+        r"""Reproduces production bug: \annot comment text with literal '}'.
+
+        The annot at depth 0 contains \} in its content. The NEXT \annot
+        after it, which is inside \textbf{}, must be correctly detected
+        as depth 1 (not 0) so the post-processor moves it out.
+        """
+        latex = (
+            r"\annot{red}{comment [2\}}"  # depth 0 annot with escaped brace
+            r"\textbf{hello\annot{blue}{note\par}world}"  # depth 1 annot
+        )
+        # The second \annot should be at depth 1 (inside \textbf{})
+        second_annot = latex.find(r"\annot{blue}")
+        assert second_annot > 0
+        assert _brace_depth_at(latex, second_annot) == 1
+
+    def test_move_annots_with_escaped_brace_in_prior_annot(self) -> None:
+        r"""Post-processor must move \annot out despite escaped braces earlier.
+
+        This is the end-to-end regression test for the production failure.
+        """
+        latex = (
+            r"\annot{red}{comment [2\}}"
+            r"\textbf{hello\annot{blue}{note\par}world}"
+        )
+        result = _move_annots_outside_restricted(latex)
+        # The blue annot must now be at depth 0
+        blue_idx = result.find(r"\annot{blue}")
+        assert blue_idx >= 0
+        assert _brace_depth_at(result, blue_idx) == 0
+
+
 class TestMoveAnnotsOutsideRestricted:
     """Unit tests for the annot-extraction post-processor."""
 


### PR DESCRIPTION
## Summary

- **Escaped brace bug:** `_brace_depth_at` naively counted all `{`/`}` including LaTeX-escaped `\{`/`\}`. When a student's annotation comment contained a literal `}` (escaped to `\}` by `escape_unicode_latex`), the depth tracker drifted by -1, causing `_move_annots_outside_restricted` to miss `\annot` commands still nested inside `\textbf{}` — producing "Paragraph ended before \text@command was complete" in LuaLaTeX.
- **Retry removal:** The red "Export failed" button previously offered a "Retry export" dialog. LaTeX failures are deterministic (same content → same error), so retry just wastes server resources. Now the button only shows the error with a Close option. It resets automatically when the document changes.

## Test plan

- [x] 5 new unit tests for escaped brace handling (`TestBraceDepthEscaping`)
- [x] All 8 existing `test_move_annots_outside_restricted` tests pass
- [x] 21 Lua filter integration tests pass
- [x] Full test suite: 4047 passed
- [x] CLI export of `fabdaff2` workspace (previously failing) produces 77KB PDF
- [x] CLI export of `c0aaa812` workspace succeeds
- [ ] Manual: verify red button shows error dialog without retry option

🤖 Generated with [Claude Code](https://claude.com/claude-code)
