### PR TITLE
fix(export): strikeout/soul conflict + dangling tag colours

### DIFF
--- a/src/promptgrimoire/cli/export.py
+++ b/src/promptgrimoire/cli/export.py
@@ -200,11 +200,14 @@ def _extract_crdt_highlights(
         if isinstance(val, dict):
             highlights.append(val)
 
-    # Enrich with display names (tag UUIDs -> human names)
+    # Filter to highlights whose tag still exists (dangling highlights
+    # reference deleted tags and have no colour defined in the preamble,
+    # causing xcolor "Undefined color" errors).  Matches the UI export
+    # path's filtering in pdf_export.py.
     tag_name_map = {str(t.id): t.name for t in tags}
+    valid = [hl for hl in highlights if str(hl.get("tag", "")) in tag_name_map]
     return [
-        {**hl, "tag_name": tag_name_map.get(str(hl.get("tag", "")))}
-        for hl in highlights
+        {**hl, "tag_name": tag_name_map.get(str(hl.get("tag", "")))} for hl in valid
     ]
 
 

--- a/src/promptgrimoire/export/filters/highlight.lua
+++ b/src/promptgrimoire/export/filters/highlight.lua
@@ -97,6 +97,20 @@ function Underline(el)
   return result
 end
 
+--- Strikeout callback: override Pandoc's default <del>/<s> → \st{} (soul) emission.
+--- soul's \st tokenizes its argument and crashes with nested lua-ul commands
+--- (\underLine, \highLight) inside it — same conflict class as Underline above.
+--- We emit lua-ul's \underLine at strikethrough height (0.4ex above baseline)
+--- instead, which is robust across nested lua-ul commands.
+function Strikeout(el)
+  if FORMAT ~= "latex" then return el end
+  local result = pandoc.List({pandoc.RawInline("latex",
+    "\\underLine[height=0.4pt, bottom=-0.4ex]{")})
+  result:extend(el.content)
+  result:insert(pandoc.RawInline("latex", "}"))
+  return result
+end
+
 --- Span callback: transform highlighted spans into LaTeX commands.
 function Span(el)
   if FORMAT ~= "latex" then return el end

--- a/tests/integration/test_highlight_lua_filter.py
+++ b/tests/integration/test_highlight_lua_filter.py
@@ -323,6 +323,53 @@ class TestNoHlAttribute:
         assert "plain text" in latex
 
 
+class TestStrikeoutWithHighlight:
+    r"""Strikeout (<del>/<s>) wrapping highlighted content.
+
+    soul's \st{} tokenizes its argument and crashes when it contains
+    lua-ul commands (\underLine, \highLight). The Strikeout callback
+    must replace \st{} with lua-ul's \underLine at strikethrough height,
+    same pattern as the Underline callback replacing \ul{} (#372).
+    """
+
+    def test_strikeout_with_highlight_no_soul_st(self) -> None:
+        r"""Highlighted text inside <del> must not produce \st{}."""
+        html = (
+            "<p>"
+            '<del><span data-hl="0" data-colors="tag-jurisdiction-light">'
+            "deleted highlighted"
+            "</span></del>"
+            "</p>"
+        )
+        latex = _run_pandoc_with_filter(html)
+
+        assert r"\st{" not in latex, f"soul's \\st should not appear, got:\n{latex}"
+        assert r"\highLight[tag-jurisdiction-light]{" in latex
+        assert "deleted" in latex
+        assert "highlighted" in latex
+
+    def test_strikeout_without_highlight_still_renders(self) -> None:
+        """Plain strikethrough (no highlight) should still produce strikethrough."""
+        html = "<p><del>deleted text</del></p>"
+        latex = _run_pandoc_with_filter(html)
+
+        assert "deleted text" in latex
+        # Should use \underLine at strikethrough height, not \st
+        assert r"\st{" not in latex
+
+    def test_strikeout_content_preserved(self) -> None:
+        """Content inside strikeout is preserved."""
+        html = (
+            "<p>"
+            '<del><span data-hl="0" data-colors="tag-jurisdiction-light">'
+            ","
+            "</span></del>"
+            "</p>"
+        )
+        latex = _run_pandoc_with_filter(html)
+        assert "," in latex
+
+
 class TestEdgeCases:
     """Edge cases: empty colors, empty hl."""
 


### PR DESCRIPTION
## Summary

- **Strikeout/soul conflict:** Pandoc emits `\st{}` (soul) for `<del>`/`<s>` tags. soul tokenizes its argument and crashes when it contains nested lua-ul commands (`\underLine`, `\highLight`). Same conflict class as #372. Added a `Strikeout` callback in highlight.lua that emits `\underLine` at strikethrough height instead.
- **Dangling tag colours:** CLI export path included highlights referencing deleted tags (no filtering, unlike the UI path). The deleted tag's colour was never `\definecolor`'d in the preamble, causing xcolor "Undefined color" errors. Now filters to highlights whose tag still exists, matching `pdf_export.py`.

Discovered via full production DB export (3568 succeeded, 2 failed → 0 failed after fix).

## Test plan

- [x] 3 new integration tests for Strikeout with highlights (`TestStrikeoutWithHighlight`)
- [x] All 24 Lua filter integration tests pass
- [x] Full test suite: 4049 passed
- [x] CLI export of 5eb98ff9 (strikeout + highlight) succeeds
- [x] CLI export of a28b42fd (strikeout + highlight) succeeds
- [x] CLI export of ba1a8a16 (dangling tag) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
