### PR TITLE
Toolchain single-sourcing, raw-SQL convention, and the ADR 0004-0007 campaign

### DIFF
--- a/.claude/hooks/final_lint.py
+++ b/.claude/hooks/final_lint.py
@@ -14,6 +14,10 @@ import os
 import subprocess
 import sys
 
+# `git status --porcelain` lines are "XY filename": 2 status chars, a space,
+# then at least 1 filename char. Shorter lines are not valid entries.
+_MIN_PORCELAIN_LINE_LENGTH = 4
+
 
 def get_modified_python_files() -> list[str]:
     """Get list of modified .py files from git status."""
@@ -29,7 +33,7 @@ def get_modified_python_files() -> list[str]:
 
     files = []
     for line in result.stdout.splitlines():
-        if len(line) < 4:
+        if len(line) < _MIN_PORCELAIN_LINE_LENGTH:
             continue
         # Format: "XY filename" where X=index, Y=worktree
         status = line[:2]
@@ -98,7 +102,7 @@ def main() -> int:
 
     # Step 4: ty check on all modified files
     result = subprocess.run(
-        ["uvx", "ty@0.0.24", "check", *files],
+        ["uv", "run", "--quiet", "ty", "check", *files],
         capture_output=True,
         text=True,
         cwd=project_dir,

--- a/.claude/hooks/python_lint.py
+++ b/.claude/hooks/python_lint.py
@@ -75,7 +75,7 @@ def main() -> int:
     if code != 0:
         findings.append(f"ruff check:\n{output}")
 
-    code, output = _run(["uvx", "--quiet", "ty@0.0.24", "check", file_path], timeout=60)
+    code, output = _run(["uv", "run", "--quiet", "ty", "check", file_path], timeout=60)
     if code != 0:
         findings.append(f"ty check:\n{output}")
 

--- a/.github/workflows/act-ci.yml
+++ b/.github/workflows/act-ci.yml
@@ -89,7 +89,7 @@ jobs:
           AUDIT_GATE
 
       - name: Run ty type check
-        run: uvx ty@0.0.24 check
+        run: uv run ty check
 
   test-all:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           AUDIT_GATE
 
       - name: Run ty type check
-        run: uvx ty@0.0.24 check
+        run: uv run ty check
 
   test-all:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
 repos:
-  # Ruff: lint with autofix, then format
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+  # Ruff: lint with autofix, then format. Runs the uv-locked ruff so the hook
+  # can never disagree with `uv run ruff` — the version lives in uv.lock only.
+  - repo: local
     hooks:
-      # Run the linter with autofix
       - id: ruff-check
-        args: [--fix]
-      # Run the formatter
+        name: ruff lint (autofix)
+        entry: uv run ruff check --fix
+        language: system
+        types: [python]
       - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types: [python]
 
   # Shell script linting
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -30,7 +35,7 @@ repos:
     hooks:
       - id: ty-check
         name: ty type check
-        entry: uvx ty@0.0.24 check
+        entry: uv run ty check
         language: system
         types: [python]
         pass_filenames: false
@@ -45,26 +50,20 @@ repos:
         files: ^docs/.*\.md$
         pass_filenames: false
 
-  # Cognitive complexity gate — blocks commits with functions > 15
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v5.1.0
+  # Cognitive complexity gate — blocks commits with functions > 15.
+  # Runs the uv-locked complexipy (same single-source-of-truth rule as ruff/ty).
+  - repo: local
     hooks:
       - id: complexipy
-        args: ['--max-complexity-allowed=15']
-        # _server_script.py: standalone subprocess script, not a regular module.
-        # tests/: test code is not subject to complexity gates.
-        # cli_loadtest.py, roleplay.py: pre-existing complexity, tracked in #253.
-        # tag_management.py, tag_management_rows.py: pre-existing complexity.
-        # html_input.py: pre-existing complexity, addressed in Phase 5 (#109).
-        # courses.py: open_activity_settings pre-existing complexity (18).
-        # pandoc.py: _move_annots_outside_restricted pre-existing complexity (22).
-        # html_normaliser.py: strip_scripts_and_styles pre-existing complexity (25).
-        # placement.py: _build_activity_cascade pre-existing complexity (16).
-        # highlights.py: _add_highlight pre-existing complexity (17).
-        # pdf_export.py: _handle_pdf_export pre-existing complexity (28).
-        # The following files also contain pre-existing functions above the
-        # threshold; keep the exception file-scoped so new files remain gated.
-        exclude: '(_server_script\.py$|^tests/|cli_loadtest\.py$|pages/roleplay\.py$|pages/courses\.py$|tag_management\.py$|tag_management_rows\.py$|html_input\.py$|pandoc\.py$|html_normaliser\.py$|placement\.py$|highlights\.py$|annotation/pdf_export\.py$|scripts/(analyse_fixture|jsonl_to_md)\.py$|export/(latex_render|span_boundaries)\.py$|pages/text_selection\.py$)'
+        name: complexipy (max cognitive complexity 15)
+        entry: uv run complexipy --max-complexity-allowed=15
+        language: system
+        types: [python]
+        # tests/: test code is not subject to complexity gates. The former
+        # 16-file production exclude list was emptied by the 2026-08-17
+        # refactor campaign (ty-bump branch) — every src/ and scripts/
+        # function now passes at 15. Do not re-add entries; refactor instead.
+        exclude: '^tests/'
 
   # Prune orphaned .pyc files (source deleted, stale bytecode remains)
   - repo: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ uv run grimoire e2e perf                # Performance baseline tests (@pytest.ma
 # Code Quality
 uv run ruff check .         # Linting
 uv run ruff format .        # Formatting
-uvx ty@0.0.24 check         # Type checking
+uv run ty check         # Type checking
 
 # Execution & Data
 uv run grimoire seed run            # Idempotent development data seeding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,14 @@ Six failure-mode classes surfaced by the April 2026 independent-workspace load i
 
 Claude Code hooks automatically run on every `.py` file write:
 
-1. `ruff check --fix` - autofix lint issues
-2. `ruff format` - format code
-3. `ty@0.0.24 check` - type checking
+1. `ruff format` - format the file in place
+2. `ruff check --ignore F401` - report issues (no autofix)
+3. `ty check` - type checking (uv-locked version)
 
-All three must pass before code is considered complete.
+The write hook is informational: findings describe the file's state right
+now, which legitimately fails mid-batch or on a TDD red. The gates are the
+Stop hook (final_lint.py), explicit verification runs, and pre-commit — all
+three checks must pass there before code is considered complete.
 
 ### Pre-commit Hooks
 
@@ -192,7 +195,7 @@ uv run grimoire e2e perf
 uv run ruff check .
 
 # Run type checking
-uvx ty@0.0.24 check
+uv run ty check
 
 # Seed development data (idempotent)
 uv run grimoire seed run

--- a/alembic/versions/c9d1e7a40b21_add_promoted_partial_indices.py
+++ b/alembic/versions/c9d1e7a40b21_add_promoted_partial_indices.py
@@ -1,0 +1,100 @@
+"""add promoted partial indices
+
+Four EXPLAIN-verified partial indices promoted by the 2026-08-17 index
+audit (docs/implementation-plans/2026-08-17-ty-bump-toolchain/
+index-candidates.md §6): admin-id lookups, the two shared-with-class
+navigator arms, and the search_dirty worker claim scan.
+
+CREATE INDEX CONCURRENTLY cannot run inside Alembic's transaction, so
+each create sits in an autocommit block. ``if_not_exists`` keeps the
+migration idempotent against environments where the indices were
+created manually during measurement.
+
+Revision ID: c9d1e7a40b21
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-17 21:30:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d1e7a40b21"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the four promoted partial indices concurrently."""
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_user_is_admin_true",
+            "user",
+            ["id"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("is_admin"),
+        )
+        op.create_index(
+            "ix_workspace_activity_id_shared",
+            "workspace",
+            ["activity_id"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_with_class"),
+        )
+        op.create_index(
+            "ix_workspace_course_id_shared",
+            "workspace",
+            ["course_id"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_with_class"),
+        )
+        op.create_index(
+            "ix_workspace_search_dirty",
+            "workspace",
+            ["id"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("search_dirty"),
+        )
+
+
+def downgrade() -> None:
+    """Drop the four promoted partial indices."""
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_workspace_search_dirty",
+            table_name="workspace",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_workspace_course_id_shared",
+            table_name="workspace",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_workspace_activity_id_shared",
+            table_name="workspace",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_user_is_admin_true",
+            table_name="user",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -21,6 +21,7 @@ library references during development.
 - [Context Diagram (Level 0)](architecture/dfd/0-context-diagram.md)
 - [[1] Learning Workspace — Level 1 Decomposition](architecture/dfd/1-level-1-decomposition.md)
 - [[5] Annotate Texts — Level 2 Decomposition](architecture/dfd/5-annotate-texts.md)
+- [Raw SQL convention](architecture/raw-sql-convention.md)
 
 ## asyncpg
 
@@ -48,6 +49,10 @@ library references during development.
 - [0001 — Shelve the wargame feature, retain its tables](decisions/0001-shelve-wargame-retain-tables.md)
 - [0002 — Expunge BrowserStack rather than keep it quarantined](decisions/0002-expunge-browserstack.md)
 - [0003 — Upgrade dependencies one package at a time, transitives included](decisions/0003-controlled-dependency-upgrades.md)
+- [0004 — Raw SQL is the convention for query-shaped reads](decisions/0004-raw-sql-for-reads.md)
+- [0005 — Run SQLAlchemy 2.1.0b3 under SQLModel via a bounded uv override](decisions/0005-sqlalchemy-21-beta-override.md)
+- [0006 — Lint/type toolchain versions live in uv.lock and nowhere else](decisions/0006-toolchain-single-sourced-in-uv-lock.md)
+- [0007 — Enforce the Pylint refactor rules; ignores must be scoped and argued](decisions/0007-plr-rules-enforced.md)
 - [Architecture Decision Register](decisions/adr-register.md)
 
 ## design-notes

--- a/docs/architecture/raw-sql-convention.md
+++ b/docs/architecture/raw-sql-convention.md
@@ -1,0 +1,130 @@
+# Raw SQL convention
+
+Decision authority: [ADR 0004](../decisions/0004-raw-sql-for-reads.md) (raw
+SQL for reads) and [ADR 0005](../decisions/0005-sqlalchemy-21-beta-override.md)
+(SQLAlchemy 2.1 for `tstring()`).
+
+## The split
+
+- **Query-shaped reads: raw SQL via `tstring(t"...")`.** New reads are
+  written this way; existing ORM reads migrate when touched.
+- **Schema, migrations, simple writes: SQLModel/ORM.** Model classes own the
+  tables and Alembic autogeneration. `session.add()` / `session.get()` /
+  `session.delete()` / attribute-mutation-then-commit stay as they are.
+- Not a target: rewriting working ORM writes into hand-rolled `UPDATE`
+  statements, or migrating reads that nothing currently touches.
+
+## The idiom
+
+```python
+from sqlalchemy import tstring
+
+user_id = ...  # UUID
+rows = (
+    await session.execute(
+        tstring(
+            t"""
+            SELECT w.id, w.name, a.permission
+            FROM workspace w
+            JOIN acl_entry a ON a.workspace_id = w.id
+            WHERE a.user_id = {user_id}
+            ORDER BY w.created_at
+            """
+        )
+    )
+).all()
+```
+
+Interpolated Python values become bound parameters automatically (`{user_id}`
+renders as `:param_1`); there is no params dict to keep in sync. SQLAlchemy
+expressions interpolate as clause elements. Never pre-render a value into the
+string with an f-string — the t-string is the safety mechanism.
+
+**Identifiers are the one exception.** Postgres cannot bind table/column
+names. Interpolating an identifier is permitted only when it comes from a
+trusted catalog source (e.g. `pg_tables`), is individually quoted, and the
+site carries a comment saying so. Existing example:
+`cli/_shared.py` TRUNCATE helper.
+
+## Row handling
+
+- Result stays inside one function → use the `Row` tuple directly
+  (`row[0]`, or `row.name` by label). No wrapper.
+- Result crosses a module boundary → a frozen slots dataclass plus one
+  mapping function (`NavigatorRow` in `db/navigator.py` is the model).
+  Boilerplate is deliberate and visible; do not build a generic mapper.
+- Need hydrated model instances (identity map, later mutation)? That's a
+  sign the site is a write path or genuinely relational — leave it ORM.
+- **ORDER BY is a raw-SQL signal** (Brian's rule, 2026-08-17): an ordered
+  query is a display read, and display reads migrate. Unit-of-work fetches
+  (get-to-mutate, get-to-delete) don't order. Named exceptions: ordered
+  queue-claiming (`ORDER BY ... FOR UPDATE SKIP LOCKED`), and reads that
+  depend on ORM-only loading machinery — `defer()`ed columns or
+  identity-map instance sharing (workspace_documents.py's header reads are
+  the live example). Those stay ORM, fetch unordered, and sort in Python;
+  a string `.order_by("col")` is never the answer.
+
+## Tests
+
+Every migrated query gets (or keeps) integration coverage that executes the
+SQL against Postgres. A column rename breaks a SQL string at runtime, not at
+type-check; the test is what turns that into a CI failure. A migration PR
+that removes the last executing test for a query is wrong by definition.
+
+## ty gotchas (measured on ty 0.0.72, 2026-08-17)
+
+- **Read raw-SQL rows by attribute, never by index or destructuring.**
+  SQLModel's `session.execute()` stub returns `Result[Any]`, which ty binds
+  as a 1-tuple: `row[1]` and `for a, b in rows:` are flagged as
+  out-of-bounds regardless of the actual SELECT width. `row.column_label`
+  is clean.
+- **Use `session.exec()`, not `session.execute()`, when you need
+  `.rowcount`** (INSERT/UPDATE). It is also the non-deprecated SQLModel API
+  and types as `CursorResult[Any]`.
+- **`sqlmodel.select` and `sqlalchemy.select` are not interchangeable.**
+  Only the SQLModel wrapper types `Model.field == x` in `.where()`. An
+  accidental `from sqlalchemy import select` produces spurious diagnostics.
+- **For sites that legitimately stay ORM** (hydrated instances needed for
+  `session.delete()` etc.): `Model.metadata.tables[Model.__tablename__].c.field`
+  is a real Core `Column` (not a cast trick) for `.in_()`/`.is_()`/
+  `.returning()`; single-arg `.join(Target)` auto-infers a real FK. The
+  Core-column form is the ONLY sanctioned stay-ORM idiom — and a stay-ORM
+  site never orders (see the ORDER BY rule above). `sqlmodel.delete` is a
+  bare re-export of the Core `delete` — its `.where()` always needs the
+  Core-column form.
+- **Sentinel defaults:** ty narrows `is not _UNSET` only when the sentinel
+  is an enum literal, not a module-level `object()`. Use a single-member
+  `Enum` token, or type the union honestly with `EllipsisType`.
+- **Monkey-patching a module function:** ty pins a module `async def`'s
+  attribute type to that exact function object, rejecting even a
+  signature-identical replacement via `mod.name = fn`. Use
+  `setattr(mod, "name", fn)` (with `# noqa: B010` so ruff doesn't autofix it
+  back). Test-harness pattern; see cli/e2e/_server_script.py.
+- **`to_jsonb(table.*)` hydration: allowlist, not "scalar-only"** (DBA
+  review 2026-08-17 — every excluded type below is also a scalar, so
+  "scalar-only" is the wrong predicate). Safe through to_jsonb →
+  `model_validate`: **uuid, text/varchar, bool, int, timestamptz, date.**
+  Excluded, with mechanism:
+  - `bytea`: hex text representation (2n+2 chars) → pydantic lax str→bytes
+    coerces the hex TEXT to bytes — silent corruption (verified on
+    `Workspace.crdt_state`, 181,257 real bytes → 362,516 garbage).
+  - `numeric`: to_jsonb emits a full-precision JSON number, but the
+    driver's `json.loads` collapses it to float BEFORE pydantic sees it —
+    silent precision loss on Decimal fields.
+  - `float` NaN/Infinity: rendered as JSON strings; round-trips only by
+    coincidence of two lax layers.
+  - `interval`: text form pydantic rejects — loud, but still a trap.
+  Entities owning excluded types hydrate from real columns
+  (`w.*` + `Model.model_validate(row, from_attributes=True)`). A guard test
+  enforces the allowlist for to_jsonb-hydrated models.
+  Timezone note: to_jsonb yields fixed-offset tzinfo (session TZ), the
+  direct-column path yields UTC tzinfo — same instant, different tzinfo
+  object; never compare tzinfo identity across the two paths.
+
+## Lint/type interplay
+
+The migration exists partly because ty cannot type SQLModel column
+expressions (`Model.field` in `.where()` / `.order_by()` / `.in_()`), and
+will not before its 1.0 (astral-sh/ty#3421). Do not "fix" those diagnostics
+with `# ty: ignore` or `sqlmodel.col()` in new code — migrate the query.
+`col()` is tolerated only inside a function already scheduled for migration.

--- a/docs/decisions/0004-raw-sql-for-reads.md
+++ b/docs/decisions/0004-raw-sql-for-reads.md
@@ -1,0 +1,66 @@
+# 0004 — Raw SQL is the convention for query-shaped reads
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Deciders:** Brian Ballsun-Stanton
+
+## Context
+
+The ty 0.0.24 → 0.0.72 upgrade surfaced ~77 diagnostics across 45 functions
+where SQLModel column expressions (`Model.field` in `.where()` / `.join()` /
+`.order_by()` / `.in_()`) resolve to instance types under ty. The April 2026
+design (`docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md`, DR1) had
+already chosen raw SQL over `sqlmodel.col()` wrapping for these sites, but was
+never executed: none of its phases shipped, its `deadline_worker.py` prior-art
+module has since been deleted, and its diagnostic estimate (~180) does not
+match what is measurable today (~77).
+
+A code survey (2026-08-17) established what the ORM layer actually carries
+here: zero `relationship()` declarations across 19 tables, zero
+`model_validate()` calls anywhere (the one untrusted-input path, character-card
+upload, uses plain dataclasses), and 68/79/13 `session.add`/`get`/`delete`
+sites that produce no ty diagnostics at all. The genuinely hard queries — the
+navigator's four-way `UNION ALL` CTE and `acl.py::list_importable_workspaces`
+— went raw years before any convention required it. The main cost identified:
+multi-model hydration such as `resolve_annotation_context`'s five-object
+outerjoin becomes hand-written row mapping.
+
+ty will not fix the descriptor inference: the tracking issue (astral-sh/ty
+#3421) has a maintainer statement that it will not be prioritised before ty's
+stable release, for which no timeline exists.
+
+## Decision
+
+Raw SQL is the convention for query-shaped reads. SQLModel remains the owner
+of schema definitions, Alembic autogeneration, and simple unit-of-work writes
+(`session.add` / `session.get` / `session.delete` / attribute mutation).
+
+The write idiom for migrated reads is `tstring(t"...")` (SQLAlchemy 2.1, PEP
+750), adopted directly so no site is migrated twice — see ADR 0005 for the
+dependency ruling. Fallback if 2.1 fails validation: `text("...")` with
+`:name` binding on stable 2.0, with tstring as the named successor.
+
+Migration scope now: the ty-flagged functions. Other ORM reads migrate as
+they are touched; new reads are written raw. `sqlmodel.col()` remains
+rejected (per DR1) except as an interim measure inside a function already
+scheduled for migration.
+
+Every migrated query keeps or gains integration-test coverage, because a
+column rename in a SQL string fails at runtime, not at type-check — this is
+the accepted price, inherited from DR1's own analysis.
+
+## Consequences
+
+- The 45 flagged functions across `db/`, `cli/export.py`, `cli_loadtest.py`
+  and tests get migrated; ty passes without suppressions or wrappers.
+- Multi-model hydration sites pay tens of lines of explicit row mapping
+  (`NavigatorRow` pattern); this is visible, greppable boilerplate rather
+  than descriptor magic, and is the deliberate trade.
+- Identifier interpolation (table/column names from trusted catalog queries)
+  cannot use bind parameters; the planned `text()`/tstring safety guard must
+  permit that narrow case (`cli/_shared.py::TRUNCATE` is the existing
+  example) while rejecting value interpolation.
+- The unexecuted 2026-04-23 design plan is superseded in its mechanism
+  (tstring, not text; no `EXPLAIN`-gated index phase bundled in) but
+  confirmed in its direction. Its index-candidate enumeration remains a good
+  follow-up and is not part of this decision.

--- a/docs/decisions/0005-sqlalchemy-21-beta-override.md
+++ b/docs/decisions/0005-sqlalchemy-21-beta-override.md
@@ -1,0 +1,55 @@
+# 0005 — Run SQLAlchemy 2.1.0b3 under SQLModel via a bounded uv override
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Deciders:** Brian Ballsun-Stanton
+
+## Context
+
+ADR 0004 adopts `tstring(t"...")` as the raw-SQL idiom. tstring exists only in
+SQLAlchemy 2.1 (landed 2.1.0b1, January 2026); stable is 2.0.x. SQLModel —
+including latest 0.0.39 — pins `SQLAlchemy >=2.0.14,<2.1.0`, so the two are
+formally incompatible.
+
+Evidence gathered 2026-08-17 before deciding:
+
+- The SQLModel cap is stated precaution, not known breakage: the maintainers
+  closed a pin-relaxation PR (fastapi/sqlmodel#1884) with "until SQLAlchemy
+  2.1 released, they can still break things... Let's wait for the release."
+  The same PR's author self-reports SQLModel 0.0.38 on 2.1.0b2 in production.
+- The 2.1 beta tracker has no open correctness or data-integrity bugs; the
+  GA-blocking milestone holds two internal refactors. The one 2.1-introduced
+  regression found (dataclass validation, #13227) was fixed 2026-08-07.
+- The asyncpg cancellation bug (#13381 — connection returned to the pool with
+  an open transaction after task cancellation in a cursor-execute hook, a
+  real risk on this stack) is fixed in 2.1.0b3 itself; the fix is not
+  confirmed backported to 2.0.x. On this point b3 is *safer* than stable.
+- Local smoke: SQLModel 0.0.38 imports, model classes register, and selects
+  compile on 2.1.0b3.
+- Honest caveat: tstring's clean bug record partly reflects thin adoption —
+  it requires Python 3.14 to exercise. This project has run 3.14 since
+  before GA and accepts early-adopter position knowingly.
+
+## Decision
+
+Override SQLModel's cap with `[tool.uv] override-dependencies =
+["sqlalchemy==2.1.0b3"]` — an exact pin, so no later beta is admitted
+silently. The operator accepts a beta dependency that has been in
+release-candidate state since June with GA targeted "end of summer 2026".
+
+Gate: the full suite (`uv run grimoire e2e all`) must be green on 2.1.0b3
+before this ships. If the suite exposes SQLModel-on-2.1 breakage that cannot
+be trivially resolved, this ADR is reversed: fall back to stable 2.0.x and
+`text()` per ADR 0004's fallback clause.
+
+## Consequences
+
+- We run an upstream-declared incompatibility in production, on our own test
+  evidence rather than SQLModel's. The mitigation is the suite plus the
+  exact pin.
+- When SQLAlchemy 2.1 goes GA and SQLModel lifts its cap, the override is
+  deleted and the dependency moves to a normal constraint. Whoever bumps
+  either package checks this ADR.
+- Until then, `uv lock` output must show sqlalchemy 2.1.0b3 exactly; any
+  resolver movement of it is collateral in the ADR 0003 sense and halts the
+  step.

--- a/docs/decisions/0006-toolchain-single-sourced-in-uv-lock.md
+++ b/docs/decisions/0006-toolchain-single-sourced-in-uv-lock.md
@@ -1,0 +1,57 @@
+# 0006 — Lint/type toolchain versions live in uv.lock and nowhere else
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Deciders:** Brian Ballsun-Stanton
+
+## Context
+
+The ty version was pinned as a `uvx ty@0.0.24` literal in eight places:
+pre-commit, two CI workflows, two Claude Code hooks, CLAUDE.md (twice) and
+AGENTS.md. Every bump was a sweep, sweeps get missed, and this branch exists
+because one was overdue by forty-one releases. ruff and complexipy had the
+same disease in different forms: ruff's pre-commit hook came from the
+external `ruff-pre-commit` repo at its own rev, which drifts from the
+uv-locked ruff the hooks and developers actually run; complexipy was a dev
+dependency at 5.2.0 while pre-commit ran an external hook at 5.1.0.
+
+Separately, `uvx ty@<version>` is subject to the global uv `exclude-newer`
+cooldown at every invocation, which made "run the latest ty" fail in
+confusing ways unrelated to the project lockfile.
+
+## Decision
+
+ty, ruff and complexipy are uv dev dependencies, resolved in `uv.lock`, and
+every consumer invokes them as `uv run ty check`, `uv run ruff ...`,
+`uv run complexipy ...`. Pre-commit uses `repo: local` hooks for all three.
+No external pre-commit repos for tools we lock; no `uvx <tool>@<version>`
+literals anywhere.
+
+ty is exact-pinned (`ty==0.0.72`): it is pre-1.0 and its diagnostic set
+changes per release, so it moves only deliberately. ruff and complexipy use
+`>=` floors and move with deliberate relocks under the cooldown.
+
+Adopting the current releases required piercing the 14-day cooldown:
+by operator ruling (2026-08-17), a 3-day gate is acceptable for the
+lint/type toolchain being refactored around. Recorded as bounded
+`exclude-newer-package` entries (the ADR 0003 / nicegui precedent), each
+cut immediately after its release's last wheel upload so nothing later is
+admitted accidentally. Versions taken: ty 0.0.72, ruff 0.16.3,
+complexipy 7.0.1.
+
+In the same pass, ruff 0.16's new markdown code-block formatting is disabled
+(`[tool.ruff.format] exclude = ["*.md"]`): it rewrote deliberate fragments in
+historical plan documents, in one case changing an excerpt's meaning.
+
+## Consequences
+
+- A toolchain bump is now one pyproject edit plus `uv lock`; CI, pre-commit,
+  hooks and docs follow automatically. The eight-site sweep cannot recur.
+- Developers and CI cannot disagree about tool versions: there is one
+  resolved copy.
+- The Claude Code hook and CLAUDE.md now describe `uv run ty check` with no
+  version literal; documentation goes stale one place fewer.
+- The `exclude-newer-package` entries are standing exceptions and must be
+  pruned when the packages age past the global cooldown — they are harmless
+  left in place but accumulate as noise; whoever next touches `[tool.uv]`
+  may delete any entry older than the cooldown window.

--- a/docs/decisions/0007-plr-rules-enforced.md
+++ b/docs/decisions/0007-plr-rules-enforced.md
@@ -1,0 +1,48 @@
+# 0007 — Enforce the Pylint refactor rules; ignores must be scoped and argued
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Deciders:** Brian Ballsun-Stanton
+
+## Context
+
+`PLR0913` (too many arguments) and `PLR2004` (magic value comparison) were
+globally ignored in the initial project-infrastructure commit and never
+revisited. When ruff 0.16 stabilised `PLR0917` (too many positional
+arguments), the path of least resistance was to add it to the same list.
+The operator rejected that and asked what the existing ignores were hiding.
+
+Measured 2026-08-17 (ruff 0.16.1): PLR2004 suppressed 816 sites — 694 in
+tests, and of the 104 in src the bulk are Unicode codepoint boundaries in
+`export/unicode_latex.py` and `word_count.py` where the hex literal is the
+clearest form. PLR0913 suppressed 118 (85 src). PLR0917 would have
+suppressed 55 (39 src).
+
+## Decision
+
+Remove all three from the global ignore list. Ruling: fix everything, with
+these scoped exceptions, each carrying its rationale in
+`pyproject.toml`:
+
+- `tests/**`: PLR2004 and PLR0913 stay per-file-ignored. Expected-value
+  literals in assertions are correct test style — naming them invites
+  tautology tests — and factory/fixture functions legitimately take many
+  optional arguments. PLR0917 is *not* ignored in tests; keyword-only
+  factories are strictly better.
+- `export/unicode_latex.py`, `word_count.py`: PLR2004 per-file-ignored;
+  Unicode block boundaries stay as hex literals.
+- Everything else is fixed, not suppressed: PLR0917 by keyword-only `*`
+  markers; PLR0913 by decomposition or cohesive parameter objects; PLR2004
+  residue by naming genuine thresholds. Line-level `# noqa: PLR2004` is
+  permitted only where a literal is demonstrably clearer than any name.
+
+## Consequences
+
+- ~85 src signatures get restructured — a deliberate campaign accepted with
+  eyes open, executed per-module alongside the ADR 0004 query migration and
+  the cognitive-complexity reductions so each file is touched once.
+- New code cannot silently accumulate fat positional signatures or magic
+  thresholds; the gate reports them.
+- The per-file-ignore list is the pattern for future rule adoption: a new
+  rule is either fixed, or its ignore is scoped and argued in place —
+  never added to the global list because a sibling rule was already there.

--- a/docs/decisions/adr-register.md
+++ b/docs/decisions/adr-register.md
@@ -18,3 +18,7 @@ record and mark the old one.
 | [0001](0001-shelve-wargame-retain-tables.md) | Shelve the wargame feature, retain its tables | Accepted | 2026-08-06 |
 | [0002](0002-expunge-browserstack.md) | Expunge BrowserStack rather than keep it quarantined | Accepted | 2026-08-06 |
 | [0003](0003-controlled-dependency-upgrades.md) | Upgrade dependencies one package at a time, transitives included | Accepted | 2026-08-07 |
+| [0004](0004-raw-sql-for-reads.md) | Raw SQL is the convention for query-shaped reads | Accepted | 2026-08-17 |
+| [0005](0005-sqlalchemy-21-beta-override.md) | Run SQLAlchemy 2.1.0b3 under SQLModel via a bounded uv override | Accepted | 2026-08-17 |
+| [0006](0006-toolchain-single-sourced-in-uv-lock.md) | Lint/type toolchain versions live in uv.lock and nowhere else | Accepted | 2026-08-17 |
+| [0007](0007-plr-rules-enforced.md) | Enforce the Pylint refactor rules; ignores must be scoped and argued | Accepted | 2026-08-17 |

--- a/docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md
+++ b/docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md
@@ -1,5 +1,13 @@
 # ty SQLAlchemy Typing Cleanup Design
 
+> **Superseded in mechanism, 2026-08-17.** This design was never executed.
+> Its direction (raw SQL over `col()`, DR1) is confirmed by
+> [ADR 0004](../decisions/0004-raw-sql-for-reads.md), which updates the idiom
+> to `tstring()` on SQLAlchemy 2.1 ([ADR 0005](../decisions/0005-sqlalchemy-21-beta-override.md))
+> and drops the bundled index phase. DR3 (hold ty at 0.0.24) is reversed by
+> [ADR 0006](../decisions/0006-toolchain-single-sourced-in-uv-lock.md); ty is now a
+> uv-locked dev dependency. Diagnostic counts below reflect ty 0.0.32 and no longer match.
+
 **GitHub Issue:** None
 
 ## Summary

--- a/docs/implementation-plans/2026-08-17-ty-bump-toolchain/index-candidates.md
+++ b/docs/implementation-plans/2026-08-17-ty-bump-toolchain/index-candidates.md
@@ -1,0 +1,818 @@
+# Index candidates — ADR 0004 follow-up (tracker ledger 11)
+
+**Status:** measurement plan only. No migration file, no index created, no
+query run. Written by static read of `db/*.py`, `search_worker.py`,
+`cli/export.py`, `cli_loadtest.py`, `db/models.py`, and every
+`alembic/versions/*.py` create/drop-index call, on the ty-bump branch,
+2026-08-17. Measurement (the `EXPLAIN (ANALYZE, BUFFERS)` before/after pairs)
+is deferred until `e2e all` finishes and a `grimoire loadtest`-scale dataset
+exists — see the exact commands in §4.
+
+**Scope note vs. the original 2026-04-23 design plan:** that plan's Phase 6
+required a production `pg_restore`, paused without one, and bundled a
+5-vote `EXPLAIN`-gated effectiveness test. ADR 0004 supersedes the mechanism
+(tstring, not text) and explicitly drops the bundled index phase, deferring
+"index-candidate enumeration" as a standalone follow-up (its own §
+"Consequences", and tracker ledger item 11). This document is that
+follow-up's first half — enumeration — not the measurement gate. §4 gives
+the exact before/after commands for whoever runs the measurement.
+
+## Method
+
+1. Read every raw-SQL (`tstring`/`text`) and remaining ORM query in the
+   target files, recording tables/JOIN/WHERE/ORDER BY columns.
+2. Derived the **actual current index state** by replaying every
+   `op.create_index`/`op.drop_index` call across all 41 `alembic/versions/`
+   files in migration-chain order (via `down_revision` links), not by
+   trusting `models.py`'s `index=True` annotations alone. This matters: many
+   indices exist in the DB with no model-level annotation at all (see §1).
+3. Classified frequency by tracing actual callers (`rg` into `pages/`,
+   `cli/`, `auth/`) rather than guessing from function names — several
+   functions turned out to have **zero** production callers despite
+   plausible names and docstrings (§5.B).
+4. Ranked candidates by **row count × call frequency**, not either alone. A
+   query with an "uncovered" sort column that only ever touches a dozen rows
+   (e.g. weeks-per-course, capped at ~13-20 by academic-calendar reality)
+   is explicitly *not* a candidate no matter how hot the call path is —
+   Postgres sorts a dozen rows in microseconds regardless of index. A
+   query with the same shape touching hundreds-to-low-thousands of rows,
+   run on every page load, is.
+
+## §1. Current index inventory (verified, not just `models.py`)
+
+`models.py` reports only 4 columns with `index=True`-equivalent Field
+markers as flagged by the original April design's survey. That count is
+misleading: most FK indices in this schema were added by **hand-written
+`op.create_index` calls in early migrations**, with no matching
+`index=True` back on the model. Trusting `models.py` alone would have
+produced a report full of false "missing index" candidates. Verified table
+(PK/unique always create an implicit backing btree in Postgres, so those
+count as coverage too):
+
+| Table | Indices (all confirmed live at HEAD) |
+|---|---|
+| `permission` | PK(name), UNIQUE(level) |
+| `course_role` | PK(name), UNIQUE(level) |
+| `user` | PK(id), UNIQUE+idx(email), UNIQUE+idx(stytch_member_id), UNIQUE(student_id) |
+| `course` | PK(id), idx(code), idx(semester) |
+| `course_enrollment` | PK(id), UNIQUE(course_id, user_id) composite, idx(user_id) standalone |
+| `week` | PK(id), UNIQUE(course_id, week_number) composite |
+| `activity` | PK(id), UNIQUE(id, type) composite, UNIQUE(template_workspace_id), idx(week_id) standalone |
+| `wargame_config` | PK(activity_id) — shelved feature (2026-08-06), excluded below |
+| `wargame_team` | PK(id), UNIQUE(activity_id, codename) composite, idx(activity_id) — shelved |
+| `wargame_message` | PK(id), UNIQUE(team_id, sequence_no) composite, idx(team_id) — shelved |
+| `workspace` | PK(id), idx(activity_id), idx(course_id), idx(updated_at), GIN idx(search_text) — **`created_at` NOT indexed, `search_dirty` NOT indexed, `shared_with_class` NOT indexed** |
+| `workspace_document` | PK(id), idx(workspace_id), idx(source_document_id), GIN idx(content) — **`type` NOT indexed, `order_index` NOT indexed** |
+| `tag_group` | PK(id), UNIQUE(workspace_id, name) composite, idx(workspace_id) standalone — **`order_index` NOT indexed** |
+| `tag` | PK(id), UNIQUE(workspace_id, name) composite, idx(workspace_id) standalone, idx(group_id) standalone — **`order_index` NOT indexed** |
+| `acl_entry` | PK(id), idx(user_id) standalone, partial UNIQUE idx(workspace_id, user_id) WHERE workspace_id IS NOT NULL, partial UNIQUE idx(team_id, user_id) WHERE team_id IS NOT NULL — **`permission` NOT indexed** |
+| `student_group` | PK(id), UNIQUE(course_id, name) composite, idx(course_id) standalone |
+| `export_job` | PK(id), idx(user_id), idx(workspace_id), idx(status), idx(created_at), idx(token_expires_at), partial UNIQUE idx(download_token) WHERE NOT NULL, partial UNIQUE idx(user_id) WHERE status IN ('queued','running') — fully covered on every model column |
+| `student_group_membership` | PK(id), UNIQUE(student_group_id, user_id) composite, idx(student_group_id), idx(user_id) |
+
+A composite UNIQUE/index on `(A, B)` covers equality on `A` alone
+(leftmost-prefix rule) but not `B` alone — used throughout below. Partial
+indices with `WHERE X IS NOT NULL` still serve plain `WHERE col = :x`
+queries, because the planner can prove the equality implies the partial
+predicate.
+
+**FK columns without a dedicated index** (Postgres never auto-indexes the
+referencing side of a FK): exactly three exist in this schema —
+`course.default_instructor_permission`, `course_enrollment.role`, and
+`acl_entry.permission` — all three reference a 4-5-row reference table
+(`permission`/`course_role`). In every query site read for this report,
+each appears only as a **secondary residual filter on an already-narrowed
+row set** (e.g. `acl.permission = 'owner'` after `acl.workspace_id = w.id`
+has already cut to a handful of rows), never as the sole driving predicate
+against a large table. Not recommended — flagged here per the task brief,
+not carried into §3.
+
+## §2. Query catalogue by frequency class
+
+Full site-by-site notes are folded into §3/§5 to avoid a 900-line wall of
+tables; this section gives the frequency-class groupings the ranking in §3
+depends on, with the caller evidence for each.
+
+### Page-load-critical (confirmed via caller trace, not inferred)
+
+- **`resolve_annotation_context`** (`db/workspaces.py:436`) — annotation
+  page load, single round trip by design (`pages/annotation/workspace.py:221`).
+- **`load_navigator_page` / `search_navigator`** (`db/navigator.py:457,558`)
+  — route `/`, called on every page load and every search keystroke.
+- **`is_user_banned`** (`db/users.py:247`) — runs before every
+  `page_route`-gated page handler (confirmed against `pages/registry.py`
+  per CLAUDE.md). Already PK-covered; no candidate.
+- Everything `resolve_annotation_context` calls inline: `_resolve_effective_permission`
+  → `_resolve_enrollment_permission` (course_enrollment composite exact
+  match), `_resolve_privileged_user_ids` (user.is_admin scan — §3.1), the
+  inline tag/tag_group fetch (§3.5), `get_active_job_for_user` (§3.6).
+- **`list_documents_with_first_content`** (`db/workspace_documents.py:120`)
+  — confirmed caller `pages/annotation/workspace.py:242`, same page load.
+- **`list_tags_for_workspace` / `list_tag_groups_for_workspace`**
+  (`db/tags.py:311,623`) — called a second time from
+  `crdt/annotation_doc.py:_ensure_crdt_tag_consistency`, whose own docstring
+  says "Called on every workspace load."
+
+### Confirmed page-load-adjacent (course/week navigation, not every page but frequent)
+
+- `get_user_workspace_for_activity`, `check_clone_eligibility` (`db/workspaces.py`)
+  — confirmed callers in `pages/courses.py` and `pages/navigator/_cards.py`
+  (per-click "Start/Resume" handler, not a per-card render loop — verified,
+  not an N+1).
+- `list_activities_for_week` (`db/activities.py:219`) — confirmed callers
+  `pages/courses.py:551`, `pages/annotation/placement.py:103`.
+- `get_visible_weeks` (`db/weeks.py:291`) — student course-navigation;
+  page-load-hot by call site, but `week` rows are capped at ~13-20 per
+  course by academic-calendar reality, so no index changes its cost (§3, Tier 3).
+
+### Admin / instructor-only
+
+`courses.py` (course CRUD, enrolment roster, `list_students_without_workspaces`),
+`weeks.py` (publish/schedule), `enrolment.py` (bulk XLSX import),
+`db/users.py`'s `get_banned_users`/`list_users`, `acl.py`'s `grant_share`/
+sharing-audit paths, `export_jobs.py`'s `create_export_job`/`get_job_by_token`.
+Bounded row counts even at loadtest scale (≤ ~1200 enrollments/course, 30
+courses, few hundred export jobs) — evaluated in §3 Tier 3, none promoted.
+
+### Background worker
+
+`search_worker.py::process_dirty_workspaces` (30s poll, tighter under
+backlog) and `export_jobs.py::claim_next_job`/`fail_orphaned_jobs`.
+
+### CLI-only
+
+`cli/export.py` (batch PDF export tooling) and `cli_loadtest.py` (seed-data
+generation, `uv run grimoire loadtest`). Catalogued in full for
+completeness (§5.D) but ranked below every page-load/admin candidate
+regardless of coverage, per the task's own framing.
+
+### Confirmed unreachable from any page or CLI (tested only)
+
+See §5.B — six functions in `acl.py` and `workspaces.py`, including the
+entire `check_workspace_access → resolve_permission` chain, have zero
+production callers. Excluded from the ranking below; their query shapes are
+recorded in §5.B in case the decision is "wire it up" rather than "delete it."
+
+## §3. Candidate index table, ranked
+
+### Tier 1 — confirmed page-load-hot, real row counts at scale
+
+| # | Column(s) | Table | Site(s) | Shape | Scale driver |
+|---|---|---|---|---|---|
+| 1 | `id` WHERE `is_admin` | `user` | `db/workspaces.py:392` (`_resolve_privileged_user_ids`, inline UNION), `db/acl.py:762` (dead-code twin, §5.B) | Full-table boolean scan → tiny admin subset | Every annotation-page load scans the **entire `user` table** (loadtest: 30 courses × up to ~1195 enrolled per course, tens of thousands of rows) to find ~5-10 admins |
+| 2a | `activity_id` WHERE `shared_with_class` | `workspace` | `db/navigator.py:219-236` (section 4a) | Filter FK-indexed already, but the *selective* predicate (`shared_with_class`) is unindexed and applied only after the activity join, so every workspace under a matched activity is scanned | One popular activity can have up to 1100 workspaces (one per student); navigator scans all of them per page load to find the tiny opted-in-to-peer-sharing subset |
+| 2b | `course_id` WHERE `shared_with_class` | `workspace` | `db/navigator.py:269-283` (section 4b, loose workspaces) | Same shape, course-scoped instead of activity-scoped | Smaller population (loose workspaces are rarer than activity clones) but same missing predicate |
+| 3 | `id` WHERE `search_dirty` | `workspace` | `search_worker.py:52` | Full-table boolean scan every poll cycle | Continuous background poll (30s, tighter under load) over the **entire** `workspace` table across all courses |
+| 4 | `(workspace_id, order_index)` | `workspace_document` | `db/workspace_documents.py:108,134-152,164` (`list_document_headers`, `list_documents_with_first_content`, `list_documents`) | `workspace_id` indexed, `order_index` sort has no covering index — index-scan-then-sort instead of pure ordered index scan | Every annotation page load builds the document tab bar from this exact query |
+| 5a | `(workspace_id, order_index)` | `tag_group` | `db/tags.py:311` | Same shape as #4 | Runs from `resolve_annotation_context` AND from `crdt/annotation_doc.py`'s "every workspace load" CRDT-consistency check — called up to twice per page load |
+| 5b | `(workspace_id, order_index)` | `tag` | `db/tags.py:623` | Same shape as #4 | Same double-call pattern as 5a |
+| 6 | `(user_id, workspace_id)` | `export_job` | `db/export_jobs.py:203-212` (`get_active_job_for_user`) | Two separately-indexed columns filtered together — planner must BitmapAnd two index scans or pick one and residually filter the other, instead of one composite scan | Called from `resolve_annotation_context` on **every** annotation page load (line 548 of `db/workspaces.py`) — small per-query cost, but it's the sixth query on the hottest path in the app |
+
+### Tier 2 — real shape, bounded or lower-frequency; worth measuring, not urgent
+
+| # | Column(s) | Table | Site(s) | Why lower priority |
+|---|---|---|---|---|
+| 7 | `(status, created_at)` | `export_job` | `db/export_jobs.py:94-99` (`claim_next_job`) | Background-worker poll, but table size is *self-limiting*: the existing partial unique index caps concurrent `queued`/`running` rows at one per user, so the candidate set `claim_next_job` sorts is bounded by concurrently-exporting users, not total export history |
+| 8 | `(week_id, created_at)` | `activity` | `db/activities.py:219-225` (`list_activities_for_week`) | Confirmed page-load-adjacent (course/week nav), `week_id` already covered — but activities-per-week is small (a handful), so the missing sort index saves microseconds per call, not a meaningful win until proven otherwise |
+
+### Tier 3 — evaluated and explicitly NOT recommended (small/reference-scale tables)
+
+Recorded so nobody re-discovers these and proposes them without the
+row-count context:
+
+- `week.is_published`, `week.visible_from` (`get_visible_weeks`,
+  page-load-hot by call site) — capped at ~13-20 rows/course by academic
+  calendar structure. No index changes the cost of scanning 20 rows.
+- `course.is_archived`, `course.semester` composite (`list_courses`) — 30
+  courses total even at loadtest scale.
+- `user.is_banned` (`get_banned_users`) — admin-only, small result set,
+  same unindexed-boolean shape as #1/#3 but at admin-page frequency, not
+  page-load frequency. If #1 lands and the pattern proves out, this is the
+  next cheapest follow-up, not before.
+- `course_enrollment.role` sort in `list_course_enrollments`/`list_enrollment_rows`
+  (admin roster view) — bounded to ≤ ~1200 rows even for the largest
+  loadtest course; an in-memory sort of ~1200 rows costs microseconds,
+  dwarfed by render/network overhead. Composite index would be measurable
+  noise, not signal.
+- The FK-without-index trio from §1 (`permission`-referencing columns) —
+  always a residual filter on an already-narrowed set in every site read.
+- `export_job.completed_at` (`export_jobs.py::cleanup_expired_jobs`) —
+  unindexed, but this is a periodic background sweep over a table whose
+  total row count stays small (PDF export volume is low); the function also
+  does a SELECT-then-DELETE-by-id-list instead of one
+  `DELETE ... WHERE completed_at < :cutoff`, a two-round-trip shape worth
+  noting alongside the missing index but, again, not worth acting on at
+  this table's size.
+
+## §4. Measurement plan per Tier-1 candidate
+
+Not run. Requires the suite currently in progress to finish, plus
+`grimoire loadtest`-scale data (`uv run grimoire loadtest run` — NOT run as
+part of this report per the task's read-only constraint). Each candidate
+gets: BEFORE plan → apply index → AFTER plan → verdict (index name appears
+in the AFTER plan's Index Scan/Bitmap Index Scan node AND both cost and
+actual time drop). Run each `EXPLAIN` **3×**, record the median, per DR5 in
+the superseded design plan (still the right discipline even though DR5's
+formal gate isn't binding here).
+
+### 1. `user` partial index on `is_admin`
+
+```sql
+-- BEFORE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id FROM "user" WHERE is_admin = true;
+
+-- CREATE INDEX CONCURRENTLY (run manually via psql, or in an Alembic
+-- migration's op.get_context().autocommit_block() — CONCURRENTLY cannot
+-- run inside Alembic's default transaction wrapper)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_user_is_admin_true
+    ON "user" (id) WHERE is_admin;
+
+-- AFTER
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id FROM "user" WHERE is_admin = true;
+```
+
+Alembic snippet (for whoever writes the eventual migration — not created here):
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_user_is_admin_true",
+            "user",
+            ["id"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("is_admin"),
+        )
+```
+
+### 2a/2b. `workspace` partial indices on `shared_with_class`
+
+```sql
+-- BEFORE (representative: one enrolled course from the seeded dataset)
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT w.id
+FROM workspace w
+JOIN acl_entry owner_acl ON owner_acl.workspace_id = w.id
+    AND owner_acl.permission = 'owner'
+JOIN activity a ON a.id = w.activity_id
+JOIN week wk ON wk.id = a.week_id
+JOIN course c ON c.id = wk.course_id
+WHERE c.id = ANY(ARRAY['<enrolled_course_uuid>']::uuid[])
+  AND owner_acl.user_id != '<requesting_user_uuid>'
+  AND w.shared_with_class = true;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_workspace_activity_id_shared
+    ON workspace (activity_id) WHERE shared_with_class;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_workspace_course_id_shared
+    ON workspace (course_id) WHERE shared_with_class;
+
+-- AFTER: re-run both BEFORE queries (activity-placed and loose variants),
+-- plus the full load_navigator_page() query for a representative
+-- heavily-enrolled test user, since the isolated arm's plan can differ
+-- from the arm's contribution inside the full 5-way UNION ALL.
+```
+
+Alembic snippet:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_workspace_activity_id_shared",
+            "workspace",
+            ["activity_id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_with_class"),
+        )
+        op.create_index(
+            "ix_workspace_course_id_shared",
+            "workspace",
+            ["course_id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_with_class"),
+        )
+```
+
+### 3. `workspace` partial index on `search_dirty`
+
+```sql
+-- BEFORE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT w.id, w.crdt_state, COALESCE(w.title, '') AS ws_title,
+       COALESCE(a.title, '') AS activity_title
+FROM workspace w
+LEFT JOIN activity a ON a.id = w.activity_id
+WHERE w.search_dirty = true
+LIMIT 500
+FOR UPDATE OF w SKIP LOCKED;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_workspace_search_dirty
+    ON workspace (id) WHERE search_dirty;
+
+-- AFTER: re-run the BEFORE query verbatim.
+```
+
+Alembic snippet:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_workspace_search_dirty",
+            "workspace",
+            ["id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("search_dirty"),
+        )
+```
+
+### 4. `workspace_document (workspace_id, order_index)`
+
+```sql
+-- BEFORE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM workspace_document
+WHERE workspace_id = '<workspace_uuid>'
+ORDER BY order_index;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_workspace_document_workspace_id_order
+    ON workspace_document (workspace_id, order_index);
+
+-- AFTER: re-run the BEFORE query.
+```
+
+Alembic snippet:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_workspace_document_workspace_id_order",
+            "workspace_document",
+            ["workspace_id", "order_index"],
+            postgresql_concurrently=True,
+        )
+```
+
+### 5a/5b. `tag_group` / `tag` `(workspace_id, order_index)`
+
+```sql
+-- BEFORE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM tag_group WHERE workspace_id = '<workspace_uuid>' ORDER BY order_index;
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM tag WHERE workspace_id = '<workspace_uuid>' ORDER BY order_index;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_tag_group_workspace_id_order
+    ON tag_group (workspace_id, order_index);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_tag_workspace_id_order
+    ON tag (workspace_id, order_index);
+
+-- AFTER: re-run both BEFORE queries.
+```
+
+Alembic snippet:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_tag_group_workspace_id_order",
+            "tag_group",
+            ["workspace_id", "order_index"],
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_tag_workspace_id_order",
+            "tag",
+            ["workspace_id", "order_index"],
+            postgresql_concurrently=True,
+        )
+```
+
+### 6. `export_job (user_id, workspace_id)`
+
+```sql
+-- BEFORE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM export_job
+WHERE user_id = '<user_uuid>' AND workspace_id = '<workspace_uuid>'
+  AND (
+    status IN ('queued', 'running')
+    OR (status = 'completed' AND token_expires_at > now())
+  )
+ORDER BY created_at DESC
+LIMIT 1;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_export_job_user_id_workspace_id
+    ON export_job (user_id, workspace_id);
+
+-- AFTER: re-run the BEFORE query.
+```
+
+Alembic snippet:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_export_job_user_id_workspace_id",
+            "export_job",
+            ["user_id", "workspace_id"],
+            postgresql_concurrently=True,
+        )
+```
+
+### Tier 2 (measure only if Tier 1 lands and there's appetite to continue)
+
+```sql
+-- #7
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM export_job WHERE status = 'queued' ORDER BY created_at ASC LIMIT 1
+FOR UPDATE SKIP LOCKED;
+-- candidate: CREATE INDEX CONCURRENTLY ix_export_job_status_created_at
+--     ON export_job (status, created_at);
+
+-- #8
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM activity WHERE week_id = '<week_uuid>' ORDER BY created_at;
+-- candidate: CREATE INDEX CONCURRENTLY ix_activity_week_id_created_at
+--     ON activity (week_id, created_at);
+```
+
+## §5. Findings beyond indexing (report only, not fixed here)
+
+### A. Metadata full-text search has no index at all — already tracked
+
+`navigator.py`'s `search_navigator()` metadata-FTS arm
+(`_META_MATCH`/`_META_DISPLAY`, lines 319-397) is a sequential scan over
+every workspace visible to the user, and **the code says so itself**:
+
+> `-- No GIN index — sequential scan on visible workspaces. See #316 phase-2.`
+
+This corroborates the existing GitHub issue #316 phase-2 rather than
+discovering something new. It's structurally different from the other
+Tier-1 candidates: `_META_MATCH` concatenates columns across five joined
+tables (`workspace`, `user`, `activity`, `week`, `course`), so a plain
+`CREATE INDEX ... USING gin(to_tsvector(...))` — the pattern already used
+for `idx_workspace_document_fts` and `idx_workspace_search_text_fts` — is
+not directly applicable; those two existing GIN indices are each scoped to
+one table's own column. Closing this gap needs the same denormalization
+pattern `workspace.search_text` already uses: a materialized text column
+populated by (an extension of) `search_worker.py`, then a GIN index on
+that column. That's a design decision, not an index-audit line item —
+noted here so it isn't lost, not sized as part of this report.
+
+### B. Fourteen functions across `acl.py`/`activities.py`/`workspaces.py`/`auth/__init__.py` are unreachable from any page or CLI
+
+Confirmed by tracing every caller across `pages/`, `cli/`, and `auth/` (not
+just grepping the function's own file):
+
+- `acl.py::list_accessible_workspaces`, `list_course_workspaces`,
+  `list_activity_workspaces`, `list_peer_workspaces` (the non-`_with_owners`
+  variant), `get_privileged_user_ids_for_workspace`, `list_entries_for_user`
+- `activities.py::list_activities_for_course`
+- `workspaces.py::list_workspaces_for_activity`, `list_loose_workspaces_for_course`
+- **`auth/__init__.py::check_workspace_access`** and everything it alone
+  calls — `acl.py::resolve_permission` → `_resolve_permission_with_session`
+  → `_derive_enrollment_permission` → `_resolve_workspace_course`. All four
+  are exported, documented (CLAUDE.md describes `check_workspace_access` as
+  the ACL resolution entry point), covered by `tests/integration/`, and
+  called by **nothing else in `src/`**.
+
+Two more are *plausibly* dead but only checked against non-test production
+code in one pass, not confirmed with the same rigor as the list above —
+flagged with less confidence rather than silently dropped:
+`courses.py::list_course_enrollments` (the admin roster page uses the
+similarly-named `list_enrollment_rows` instead) and `weeks.py::can_access_week`.
+
+The annotation page uses `resolve_annotation_context`'s own inline
+permission resolution instead (verified: `pages/annotation/*.py` imports
+`resolve_annotation_context`, never `check_workspace_access` or
+`resolve_permission`). This reads as consolidation debt from the
+`AnnotationContext` refactor (its own docstring says it "replaces 5+
+separate DB function calls") rather than a live authorization gap — but
+it's worth a decision either way, same shape as tracker ledger item 12
+(`_parallel.py::_run_parallel_e2e`, also dead-but-tested, also a decide:
+delete-or-wire-up call for Brian). If `check_workspace_access` is supposed
+to be *the* general-purpose access gate for non-annotation pages, its
+current unreachability is worth flagging on its own regardless of this
+report's indexing focus.
+
+### C. `_resolve_workspace_course`'s sequential round trips (only relevant if §5.B decides "wire it up")
+
+`acl.py::_resolve_workspace_course` walks Workspace → Activity → Week →
+Course via up to four sequential `session.get()` calls. Every hop is a PK
+lookup (no index gap), so this is a round-trip-count observation, not an
+indexing one — and it's currently dead code per §5.B, so it costs nothing
+in production today. `resolve_annotation_context` solves the identical
+problem with one joined query (`workspaces.py:459-482`); if `check_workspace_access`
+is revived, the fix is "reuse that pattern," not "add an index." Feeds the
+deferred `ty-sa-n-plus-one-audit` follow-up issue referenced in the
+superseded 2026-04-23 design plan.
+
+### D. Per-row loops instead of batched writes (recurring shape, several sites, none urgent)
+
+All of these are write-side, not read-side, so outside this report's
+literal scope — noted because the task asked for "any query shape that
+suggests a problem beyond indexing":
+
+- `tags.py::reorder_tags`/`reorder_tag_groups`, `workspace_documents.py::reorder_documents`
+  — one `session.get()`+update per item in a caller-supplied order list.
+  Item counts are small (tags/documents per workspace), low impact.
+- `courses.py::delete_course`, `weeks.py::delete_week` — both carry their
+  own `# TODO(perf)` comments already acknowledging "one count query per
+  activity" for the student-workspace guard. Corroborated, not
+  newly discovered.
+- `enrolment.py::_resolve_users`/`_create_enrolments`/`_create_groups_and_memberships`
+  — one find-or-create + one enroll + one group-upsert-and-select-back
+  **per roster row**. At the loadtest-scale roster size (up to ~1100
+  students), a single import run is several thousand round trips. This is
+  a real, user-triggered (course-coordinator) admin action with a large N,
+  not a rare background task — the most worth revisiting of this group if
+  bulk-enrolment latency ever becomes a complaint, but it is a write-batching
+  problem, not a missing-index one.
+- `cli_loadtest.py::_create_activity_workspaces_for_student` (existence
+  check per student × activity, ~8,800 round trips at 1100-student ×
+  8-activity scale) and `_fetch_candidate_workspaces` (one session per
+  course in a 30-course loop). Both already-covered by existing indices
+  (§1); CLI-only, developer-run, out of scope for prioritization.
+
+### E. `list_students_without_workspaces` — plan-shape risk, not a coverage gap
+
+`courses.py::list_students_without_workspaces` (admin analytics) is a
+`NOT EXISTS` subquery correlated on `acl.user_id = ce.user_id`, conceptually
+re-evaluated once per enrolled student. Every join/filter column already
+carries a covering index (§1), so there is no missing-index candidate here
+— the open question is whether Postgres produces a cheap Hash/Merge
+Anti-Join or degrades to a Nested Loop re-executing the subplan per outer
+row at the 1100-student loadtest tier. That's a plan-shape question,
+answerable only by `EXPLAIN (ANALYZE, BUFFERS)` against loadtest-scale data,
+not by adding an index sight unseen. Add to the measurement queue in §4 if
+the admin analytics page is ever reported slow.
+
+### F. Leading-wildcard `LIKE` in `cli_loadtest.py` — an index-*shape* problem, not a coverage gap
+
+`cli_loadtest.py::_print_summary` (loadtest-only, `uv run grimoire loadtest`)
+filters `"user".email LIKE '%@test.local'`. This is a distinct problem class
+from every other row in this report: a **leading-wildcard** `LIKE` cannot be
+served by a plain B-tree index at all (B-tree serves a prefix pattern like
+`'foo%'`, never a suffix pattern like `'%foo'`), so `CREATE INDEX ... (email)`
+would not change this query's plan regardless of the existing unique index
+on `email`. The actual fix, if this predicate is ever hot enough to matter,
+is a `pg_trgm` GIN index or a functional index on `reverse(email)` —
+neither proposed here since this is CLI-only, developer-run, once-per-invocation
+code, ranked below every page-load/admin candidate per the task's own framing.
+Noted because the task asked for shapes that suggest a problem beyond
+indexing, and "no index of this kind will ever help" is exactly that.
+
+### G. One suspected duplication, checked and ruled out
+
+`pages/annotation/header.py::_render_placement_chip` takes a
+`prefetched_ctx: PlacementContext | None` and only calls
+`get_placement_context()` (a second DB round trip) when re-rendering after
+an explicit `.refresh()` — i.e. after the user edits placement via the
+dialog, when a fresh read is actually required. The initial page load uses
+the context `resolve_annotation_context` already computed. Not a Class-C
+duplicate-registry-pass (per CLAUDE.md's page-load failure-mode taxonomy);
+verified by reading the call site rather than assumed from the
+function-pair's names.
+
+## Summary
+
+| Frequency class | Candidates found |
+|---|---|
+| Page-load-critical (Tier 1) | 6 |
+| Page-load-adjacent / bounded background (Tier 2) | 2 |
+| Evaluated, not recommended (Tier 3) | 5 column groups, explicit reasoning |
+| FK columns without index | 3, all low-risk reference-table targets |
+| Beyond-indexing findings | 7 (A-G): one already-tracked FTS gap, 14
+  confirmed unreachable/dead-code functions across `acl.py`/`activities.py`/
+  `workspaces.py`/`auth/__init__.py` (incl. the apparent ACL-gate entry-point
+  chain) plus 2 more flagged with lower confidence, one dead-code round-trip
+  chain, five write-batching sites, one correlated-subquery plan-shape
+  risk, one index-shape mismatch (leading-wildcard `LIKE`), one ruled-out
+  false lead |
+
+Query shapes suggesting a problem beyond indexing, surfaced per the task
+brief: **§5.A** (FTS gap, already tracked as #316 phase-2), **§5.B**
+(the `check_workspace_access`/`resolve_permission` chain — 5 functions —
+plus 9 further functions across `acl.py`/`activities.py`/`workspaces.py`
+have zero production callers — worth a decision independent of this
+report's indexing scope), **§5.E** (`list_students_without_workspaces`'s
+correlated subquery — measure the plan shape before deciding anything), and
+**§5.F** (`cli_loadtest.py`'s leading-wildcard `LIKE` — no B-tree index
+could ever serve this predicate; a different index type entirely, and only
+worth building if this CLI-only query ever becomes a bottleneck).
+
+## §6. Measurement results, 2026-08-17
+
+**Environment.** Dev database `promptgrimoire_ty_bump` (this worktree's
+branch-suffixed DB per `config.py`'s per-worktree isolation — never
+production). It held schema but zero data at the start of this pass;
+`alembic upgrade head` brought it to the 41-migration HEAD, then
+`uv run load-test-data` (the correct invocation — `uv run grimoire
+loadtest` from the task brief does not exist; see "Surprising things"
+below) seeded it. All Tier-1/Tier-2 tables `ANALYZE`d before every BEFORE
+run and again after every `CREATE INDEX`. Every `EXPLAIN (ANALYZE,
+BUFFERS)` below ran 3× per DR5 discipline; costs/times quoted are the
+median run except where noted. **All 8 candidate indices remain live in
+`promptgrimoire_ty_bump` as of this writing. No Alembic migration file was
+created** — migration authoring is deferred until the branch stack is
+assembled (this branch rebases onto another; chain order matters), per the
+task brief's explicit constraint.
+
+**Actual seeded scale** (`uv run load-test-data`, full run, ~4 min):
+3 courses (LT-LAWS1100: 1100 students, LT-LAWS2200: 80, LT-ARTS1000: 15),
+1159 users, 1201 enrollments, 14 activities, 7683 workspaces (5663
+activity-placed + 2020 loose), 17610 workspace_documents, 77 ACL shares,
+1187 `shared_with_class` workspaces. `export_job` stayed at **0 rows** —
+`load-test-data` does not seed it at all (§ Surprising things).
+
+### Verdict table
+
+| # | Candidate | Chosen? | Cost before → after | Time before → after (median) | Buffers before → after | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | `user(id) WHERE is_admin` | Yes — Index Only Scan | 28.59 → 4.14 | 0.105 ms → 0.032 ms | 17 hit → 2 hit | **PROMOTE** |
+| 2a | `workspace(activity_id) WHERE shared_with_class` | Yes — Bitmap Index Scan | 1870.47 → 1108.69 (whole-query) | 5.09 ms → 3.15 ms | ~1542 hit (workspace scan alone) → 596 hit (whole query) | **PROMOTE** |
+| 2b | `workspace(course_id) WHERE shared_with_class` | Partially — see note | 790.78 → 355.61 (whole-query) | 2.70 ms → 0.09 ms | 997 hit → 472 hit | **PROMOTE** (with caveat) |
+| 3 | `workspace(id) WHERE search_dirty` | Yes — Bitmap Index Scan | 3059.60 → 191.42 | 5.23 ms → 0.15 ms | 2971 hit → 17 hit | **PROMOTE** |
+| 4 | `workspace_document(workspace_id, order_index)` | Yes, but Sort node stayed | 16.02 → 16.02 (unchanged) | 0.14 ms → 0.07 ms (noise) | 5-6 → 4-6 (noise) | **REJECT** |
+| 5a | `tag_group(workspace_id, order_index)` | Yes, but Sort node stayed | 11.73 → 11.73 (unchanged) | 0.08 ms → 0.08 ms (noise) | 6 → 6 (noise) | **REJECT** |
+| 5b | `tag(workspace_id, order_index)` | Yes, but Sort node stayed | 30.60 → 30.60 (unchanged) | 0.21 ms → 0.06 ms (noise) | 6 → 6 (noise) | **REJECT** |
+| 6 | `export_job(user_id, workspace_id)` | N/A — 0 rows | 0.02 → 0.02 | 0.028 ms → 0.027 ms | 3 → 3 | **INCONCLUSIVE** — table empty at this data scale |
+| 7 | `export_job(status, created_at)` | N/A — 0 rows | trivial both | trivial both | trivial both | **INCONCLUSIVE** — table empty at this data scale |
+| 8 | `activity(week_id, created_at)` | No — still Seq Scan | 1.21 → 1.21 (unchanged) | 0.11 ms → 0.09 ms (noise) | 4 → 4 (unchanged) | **REJECT** |
+
+**§5.E plan-shape answer:** `list_students_without_workspaces` at
+LT-LAWS1100 scale (1100 enrolled students, 7683 workspaces, 7683 owner
+`acl_entry` rows) produces a **`Hash Right Anti Join`**, not a Nested
+Loop. Postgres flattens the correlated `NOT EXISTS` subquery into a
+proper anti-join, building the hash table once from the
+`workspace ⋈ acl_entry ⋈ activity ⋈ week` chain (dominant cost: two Seq
+Scans, `workspace` at 3047.97 and `acl_entry` at 186.00) rather than
+re-executing the subplan per outer row. Total query cost 3611.59, median
+execution 7.9-8.5 ms, zero rows returned (every enrolled non-staff student
+in this course already owns a workspace, so there's nothing to list — the
+query still had to build the full anti-join to determine that). This
+confirms the report's §5.E hope: no missing-index candidate here, and the
+plan-shape risk it flagged does not materialise at loadtest scale.
+
+### Detail per candidate
+
+**#1 `user.is_admin`.** Only 1 admin user existed in the 1159-row seeded
+set (report's own §3 Tier-1 text assumed "~5-10 admins" — see Surprising
+things). `Index Only Scan` chosen cleanly, `Heap Fetches: 0`. Clear win
+even at this small scale; the report's own justification ("tens of
+thousands of rows") did not hold at the actual seeded scale (§ Surprising
+things), but the win holds regardless of table size once `is_admin` stays
+a small minority.
+
+**#2a/2b `workspace.shared_with_class`.** Measured against LT-LAWS1100
+(1100 students) using the exact representative query from §4, with a
+real enrolled-but-non-owning student UUID as `:requesting_user_uuid`.
+`shared_with_class` is **not** a small subset at this scale — 1187 of
+7697 workspaces (15.4%) — so a naive `col = true` index risked the
+planner preferring the existing seq scan (high-selectivity partial
+indices can lose to seq scans). It didn't: the planner picked
+`ix_workspace_activity_id_shared` via `Bitmap Index Scan` inside a
+per-activity `Nested Loop`, because the partial index's *population* is
+exactly the 1187-row `shared_with_class` set, independent of the 15.4%
+figure against the whole table. For the loose-workspace variant (2b),
+`pg_stat_user_indexes` showed **`ix_workspace_course_id_shared` at
+`idx_scan = 0`** after all three representative-query runs — the planner
+instead reused `ix_workspace_activity_id_shared` (matching `activity_id
+IS NULL` directly) `BitmapAnd`-ed with the pre-existing plain
+`ix_workspace_course_id`. Isolating a direct
+`WHERE course_id = :c AND shared_with_class = true` query (no
+`activity_id IS NULL` companion predicate) *did* select
+`ix_workspace_course_id_shared` (`Index Scan`, cost 524.86, 0.07 ms) —
+so the index is real and gets chosen for its own query shape, just not
+inside the specific §4 loose-workspace representative query, where a
+different combination of existing + new indices already covers it. Net
+effect on the query the report cared about: PROMOTE both, but note 2b's
+value is partly redundant with 2a's for this exact call site — flag for
+whoever writes the migration to decide if 2b earns its write-amplification
+cost given 2a already covers the compound case in practice.
+
+**#3 `workspace.search_dirty`.** First BEFORE run showed **all 7697
+workspaces** with `search_dirty = true` — 100% of the table, a seeding
+artifact (the background `search_worker.py` poller had never run against
+this freshly-seeded, freshly-migrated dev DB — see Surprising things). At
+100% selectivity a partial index gives zero benefit over a seq scan by
+construction, so that measurement would have been misleading either way.
+Corrected to a realistic steady-state backlog by setting
+`search_dirty = false` on all rows then `true` on a random 50 (0.65% of
+the table, modelling the small backlog a 30s-interval worker leaves under
+normal load) before re-measuring. This is a **deliberate, disclosed data
+mutation** made for measurement validity, not a change requested by the
+task — recorded here so it isn't mistaken for organic seed data if anyone
+re-queries `promptgrimoire_ty_bump` later. At corrected selectivity: the
+clearest win of the whole set — cost 3059.60 → 191.42 (16×), execution
+~5.7 ms → ~0.15 ms (30-40×), buffers 2971 hit → 17 hit.
+
+**#4/5a/5b (`workspace_document`, `tag_group`, `tag` — `(workspace_id,
+order_index)`).** Real per-workspace row counts turned out to be tiny:
+`workspace_document` averages **2.29** rows/workspace (max 3);
+`tag_group` is **exactly 2** per workspace, no variance; `tag` is
+**exactly 7** per workspace, no variance (loadtest data generation is
+deterministic per workspace here, not sampled). This is precisely the
+Tier-3 "weeks capped at ~13-20, sorts in microseconds regardless of
+index" pattern the report itself used to reject other candidates — it
+just wasn't applied to these three before the row counts were known. All
+three planner choices did switch the underlying `Bitmap Index Scan` to
+the new composite index, but the `Sort` node above it never disappeared
+(cost identical before/after to 2 decimal places) because there are too
+few rows for an index-order scan to be worth choosing over a quicksort of
+2-7 rows. REJECT all three — the report's Tier-1 classification for #4/5a/5b
+was frequency-driven (called on every page load) without checking the
+per-workspace row count, which is the same mistake the report's own
+method explicitly warns against in the Tier-3 section for `week`.
+
+**#6/7 `export_job`.** Zero rows — `load-test-data` never populates this
+table (§ Surprising things). Both BEFORE and AFTER plans are trivial
+`Seq Scan (cost=0.00..0.00)` regardless of index; no signal either
+direction. Indices created and left in place per the task's Tier-1/Tier-2
+scope, but genuinely unmeasured — re-run once `export_job` has
+loadtest-representative data (either extend `cli_loadtest.py` to seed
+some, or measure against a DB that has organic dev usage).
+
+**#8 `activity.week_id`.** Whole `activity` table is 14 rows; max 3
+activities/week (avg 2.00, matches the report's own Tier-2 "activities
+per week is small" caveat exactly). Planner didn't even switch indices —
+still `Seq Scan`, cost unchanged 1.18→1.18. REJECT, exactly as the report
+predicted going in; measured for completeness per the task brief.
+
+### Surprising things
+
+1. **`uv run grimoire loadtest` does not exist.** The task brief's
+   suggested invocation is wrong — there is no `loadtest` subcommand
+   under `grimoire`. The actual entry point is `uv run load-test-data`
+   (a `[project.scripts]` entry in `pyproject.toml` wrapping
+   `cli_loadtest.py:load_test_data`), confirmed by reading
+   `pyproject.toml` and `cli_loadtest.py` directly. It has no `--help`
+   handler either — passing `--help` runs the full seed with `--help`
+   silently ignored as an unrecognised sys.argv token... except in this
+   case it failed first on `DATABASE__URL` pointing at a database that
+   didn't exist yet (see next point), which is what actually surfaced the
+   real command name.
+2. **No dev database existed for this worktree.** Per-worktree DB
+   isolation (`config.py::_suffix_db_url`) means branch `ty-bump` reads
+   `promptgrimoire_ty_bump`, which had never been created — not even an
+   empty one (only `promptgrimoire_test_ty_bump` and its
+   `_clone_source` template existed, both test-lane artifacts). Had to
+   `createdb` and `alembic upgrade head` (all 41 migrations, clean run,
+   no errors) before seeding could start. `promptgrimoire_dev` (the
+   template I first tried) turned out to be empty too — every
+   schema-bearing dev DB on this box is worktree- or test-scoped; there
+   is no shared baseline dev DB with organic data at all.
+3. **The report's "30 courses" scale assumption doesn't match the actual
+   generator.** `cli_loadtest.py::COURSE_DEFS` is a fixed 3-course list
+   (1100/80/15 students) — there is no configurable course count. The
+   report's Tier-3 reasoning for `course.is_archived`/`course.semester`
+   ("30 courses total even at loadtest scale") appears to have
+   generalised from a different figure (course *capacity*, or a stale
+   assumption) rather than reading `COURSE_DEFS` directly. Doesn't change
+   any Tier-3 verdict — 3 courses is smaller than 30, so the "trivial
+   either way" conclusion holds even more strongly — but it's worth
+   correcting for whoever reads this report next.
+4. **Real `user` table scale (1159 rows) is nowhere near the report's
+   "tens of thousands" claim for candidate #1**, and only 1 of those 1159
+   is an admin (report assumed "~5-10"). The mechanism justification
+   (full seq scan for a rare boolean) is still correct in kind, and the
+   measured win (§ #1 above) holds regardless — but the magnitude
+   argument in the original report was inflated relative to what the
+   project's own loadtest generator actually produces. If the "tens of
+   thousands" figure was meant to model post-launch, multi-semester
+   accumulation rather than a single loadtest run, that's worth stating
+   explicitly next time rather than presenting it as the loadtest number.
+5. **`workspace.search_dirty` was 100% `true` for the entire table
+   immediately after seeding** (all 7697 rows) — not a "continuous
+   background poll keeps this small" steady state at all, but a seeding
+   artifact from the fact that nothing had run `search_worker.py`'s
+   poller against this DB yet. Anyone measuring this candidate against a
+   freshly-seeded DB without correcting for it would get a **wrong
+   REJECT** (100%-selective partial index is worse than useless) for what
+   is actually the strongest PROMOTE in the whole set once the backlog is
+   corrected to a realistic size. This is the single most consequential
+   methodological trap in this measurement pass — flagging prominently
+   in case anyone else runs `load-test-data` fresh and measures this
+   candidate without noticing.
+6. **`export_job` has zero loadtest coverage.** Not a bug in this task,
+   but worth a decision: either `cli_loadtest.py` should seed a
+   representative export-job backlog (queued/running/completed mix) so
+   candidates #6/#7 and the export worker's own query shapes can ever be
+   measured against realistic data, or that's explicitly out of scope for
+   the load-test generator and someone should say so in its docstring.
+7. **Real per-workspace `workspace_document`/`tag_group`/`tag` counts are
+   far smaller than the report's row-count framing implied** (§ #4/5a/5b
+   above) — this is the same failure mode the report itself named and
+   guarded against for `week` in Tier 3, just not applied to these three
+   before now. Worth a general lesson for future index-candidate audits
+   on this codebase: check the *per-parent* row count from real data
+   before trusting "called on every page load" as sufficient justification
+   for a sort-covering index, even when the call-frequency evidence is
+   solid.

--- a/docs/implementation-plans/2026-08-17-ty-bump-toolchain/tracker.md
+++ b/docs/implementation-plans/2026-08-17-ty-bump-toolchain/tracker.md
@@ -1,0 +1,186 @@
+# ty-bump Toolchain & Conventions Campaign — Tracker
+
+**Goal:** Latest uv-locked toolchain (ty 0.0.72 / ruff 0.16.3 / complexipy
+7.0.1), zero ty and ruff diagnostics without suppressions, every function
+≤15 cognitive complexity, PLR rules enforced. Decision authority: ADRs
+0004–0007. Query idiom: `tstring()` per docs/architecture/raw-sql-convention.md.
+
+**Branch:** `ty-bump`. Everything uncommitted until final gates pass.
+
+**Statuses:** `[x]` done+verified · `[~]` done, awaiting gate · `[ ]` pending
+
+---
+
+## Phases
+
+- [x] **P1 Toolchain single-sourcing** (ADR 0006) — dev deps + `uv run`
+  everywhere + local pre-commit hooks + bounded gate exceptions + hook
+  rewrite ported. Verified: versions resolve, no stale pins (`rg 'uvx ty|ty@0\.0\.'`).
+- [x] **P2 ruff 0.16.3 clean at old scope** — md format exclusion, RUF036
+  fix. Verified: `ruff check .` at flip time.
+- [x] **P3 PLR re-scope** (ADR 0007) — global ignores removed, scoped
+  per-file-ignores with rationale. 203 errors exposed for burndown.
+- [x] **P4 SQLAlchemy 2.1.0b3 override** (ADR 0005) — unit 4037 + integration
+  931 + JS 123 + BATS green on the beta. Full `e2e all` gate still owed (P10).
+- [x] **P5 Wave 1: test-file ty fixes** — 18 files, 0 diagnostics except 6
+  deferred SQLModel sites (now wave-2 scope). Unit lane green post-reboot.
+- [x] **P6 Wave 1: export/navigator/scripts refactors** — complexity + PLR
+  in export pipeline, navigator, incident parsers. Unit+integration green.
+- [~] **P7 Wave 2: db/cli tstring migration + remaining complexity**
+  - [x] w2-acl-workspaces: acl.py + workspaces.py 37→0 diagnostics; 330
+    integration tests green; resolve_annotation_context migrated (single
+    round trip held, ≤5-query test passed; to_jsonb for scalar entities,
+    w.* + model_validate for the bytea-bearing Workspace).
+  - [x] w2-scripts: ingest.py 10→0; analyse_fixture/jsonl_to_md/
+    profile_workspace + PLR singles; 4 new test files; 225 tests green.
+  - [x] w2-annotation: four complexity monsters 28/24/18/20 → 10/0/7/2;
+    respond+tags ty 11→0; long-tail PLR; 24 new unit tests; 262 tests green.
+  - [x] w2-db-rest: 56→0 across 13 files; 416 tests passed (incl. 3 new for
+    previously-uncovered list_students_without_workspaces); closed a latent
+    update_tag(color=None) validation-bypass hole; _UNSET sentinel fixed to
+    enum (object() never narrowed under ty).
+  - [x] w2-cli: 24→0 diagnostics; complexity 35/32/32/27/18/16 all ≤14;
+    tstring migrations with attribute-by-label rows; 26 new tests (20
+    against real Postgres for previously-uncovered loadtest queries); 127
+    tests + 2 live E2E smokes green. setattr monkey-patch gotcha added to
+    convention doc.
+- [~] **P8 Findings review** — ledger items 3, 4 (test-runner: per-lane
+  partition fix + help-bypasses-lock, with new tests), 5 (wait_for overloads,
+  3 casts deleted), 6 (15 dead ignores swept), 9 (both leftover diags fixed
+  properly: TypedDict gained NotRequired _pending_timer; redundant cast
+  removed) all FIXED. Long-tail ty singles (14) fixed. **Tree-wide ty: 0
+  diagnostics.** Items 7 (NoEscape), 8/8b (coordinated migrations) remain
+  open decisions. w3-plr-tail agent sweeping the final ~60 ruff PLR findings.
+- [x] **P9 Final static gates** — ALL GREEN 2026-08-17: ty 0 diagnostics,
+  ruff 0 errors, format clean (689 files), complexipy 0 functions over 15
+  across bare src/+scripts/. Pre-commit complexipy exclude shrunk from 16
+  production files to `^tests/` only. w3-plr-tail swept the final tail
+  (caller-verified `*` fixes where possible, reasoned tracker-linked noqas
+  for ledger-8 deferred signatures).
+- [x] **P10 ADR 0005 suite gate** — `uv run grimoire e2e all`: ALL 8 LANES
+  PASS on 2.1.0b3 (2026-08-17, attempt 2). Attempt 1 exposed a genuine
+  order-dependent structlog-contextvars leak from broadcast.py into
+  TestNullContextFields (pytest-randomly ordering); root-fixed with an
+  autouse clear_contextvars fixture in tests/conftest.py, red→green
+  verified deterministically with -p no:randomly. Not beta-related.
+- [ ] **P11 Docs & housekeeping** — convention doc gotchas (Row attribute
+  access, to_jsonb/bytea), CLAUDE.md hook-section accuracy, update
+  `.notes/project_session-state-2026-08-17-ty-bump.md`, prune docs/_index.
+- [ ] **P12 Commits & stacking** — merge order SETTLED (Brian, 2026-08-17):
+  snapshot branch merges first; this branch rebases on top as a stacked PR.
+  Commit split by concern (toolchain / ADRs+docs / db migration / refactor
+  clusters / tests), match `git log` style, tests with implementation.
+  Post-rebase additions: (a) re-derive tags.py/items_serialise.py edits
+  against their new annotation_core module (serialise_items keyword-only
+  carries over — their side has adopted it); (b) extend the quality pass
+  over their new modules (annotation_core, snapshot, service) so the
+  mechanical pass covers the final architecture; (c) full gate re-run on
+  the stacked result; (d) snapshot session runs one 100-way perf
+  re-attachment leg after the raw-SQL resolve_annotation_context lands.
+  Their session state: .notes/project_session-state-2026-08-17-snapshot-spike.md.
+- [ ] **P13 UAT** — Brian reviews; PR description tells the ADR story.
+  PR-notes flag (from initial-snapshot-delivery session): that branch pins
+  `ty@0.0.24` in .claude/hooks/{python_lint,final_lint}.py; this branch made
+  those hooks versionless (`uv run ty check`, ADR 0006). Whichever merges
+  second resolves the hook files to the versionless form — a version pin
+  reappearing there is a merge mistake.
+
+---
+
+## Findings ledger (P8 — each needs a decision or a fix)
+
+1. **[DONE]** ty Row[Any]/session.exec/select-wrapper/Core-column/sentinel
+   gotchas documented in raw-sql-convention.md § "ty gotchas" (sourced from
+   w2-acl + w2-db-rest reports).
+2. **[DONE in doc; guard open]** `to_jsonb()` bytea corruption documented in
+   the same section. Optional later: an AST/review guard against to_jsonb on
+   bytes-bearing entities.
+3. **[bug, tooling — PRIORITY, hit independently twice]** `grimoire test run`
+   with mixed nicegui + plain paths silently drops the plain paths
+   (`_detect_test_type()` classifies the whole invocation; both w2-acl and
+   w2-db-rest lost a run to it). False-green risk. → Fix in cli/testing.py
+   (small), after w2-cli finishes to avoid collision.
+4. **[bug, tooling]** `grimoire test run --help` acquires the global flock +
+   load gate (70+ min for --help during contention). → Same file, same fix pass.
+5. **[fix-in-branch]** `wait_for[T]` in tests/integration/nicegui_helpers.py
+   doesn't unwrap async condition callables → root-fix, then delete the 3
+   casts in test_tag_management_crdt_sync.py.
+6. **[fix-in-branch]** ~15 dead mypy-style `# type: ignore` comments in
+   test_settings.py — approved sweep.
+7. **[correctness, needs Brian]** NoEscape + format-spec in latex_render
+   silently loses the trust marker (pre-existing, pinned in test docstring).
+   Decide: forbid format-specs on NoEscape, or make NoEscape.__format__
+   preserve the subclass.
+8. **[deferred, coordinated]** Param-object migrations blocked by cross-file
+   call sites / API-guard tests: add_highlight (~149 sites), set_tag (~75),
+   pdf_export pair (~24), grant_share, _dispatch_parser, and the 8
+   annotation functions w2-annotation verified as guard-blocked
+   (resolve_broadcast_label, render_workspace_header,
+   render_document_container, render_organise_tab, serialise_items,
+   refresh_items, AnnotationSidebar.__init__, _save_all_modified_rows,
+   _log_page_load_profile). These carry explicit signature-regression
+   guards; changing them is API design work, not lint burndown. Also (from
+   w2-db-rest): create_tag (~145 sites), update_tag (~20), update_activity
+   (~51), update_course (~31), add_document (~71). → Single coordinated
+   follow-up after this branch, or accept noqa where applied.
+8b. **[deferred]** export_jobs.py's 5 remaining col() sites + users.py's 1 —
+   already ty-clean; migrate to tstring next time those functions are
+   touched (ADR 0004 alignment, no urgency).
+9. **[leftover diags]** tag_management_save.py:117 invalid-key (TypedDict),
+   workspace.py:340 redundant-cast — unowned; fold into P9 sweep.
+10. **[watch]** Drop the sqlalchemy override at 2.1 GA when SQLModel lifts
+    its cap (ADR 0005 consequence).
+11. **[follow-up, post-branch]** Index-candidate enumeration from the
+    migrated queries (ADR 0004 consequence; the old design's Phase 6 idea).
+12. **[found by w2-cli, needs Brian]** `_parallel.py::_run_parallel_e2e` is
+    dead code (defined, never called; grep-verified). The per-file-isolated
+    DB machinery is production-reachable only via the nicegui lane. Decide:
+    delete, or wire the playwright lane back through it.
+13a. **[progress 2026-08-17]** Exact pins DONE (ruff==0.16.3,
+    complexipy==7.0.1). Convention doc DONE: to_jsonb type allowlist with
+    mechanisms (DBA conditions a+d), tzinfo note, ORDER BY rule.
+    Share-button conversion DONE: predicates extracted to SharingUiFlags
+    properties, 11 behavioural tests replace the inline-tautology tables +
+    ast-grep shape guard. Index measurement DONE: 4 PROMOTE (user.is_admin,
+    shared_with_class ×2, search_dirty 30-40×), 4 REJECT on evidence, 2
+    INCONCLUSIVE (export_job unseeded — loadtest generator gap noted);
+    migrations deferred to stack assembly. DBA conditions b+c DONE
+    (w5-hydration-fix): _HydratedRowEntities threading (staff −1 query,
+    peer −2 per page load), to_jsonb field-type guard
+    (falsification-verified), crdt_state byte-equality test, staff-derived
+    permission test (non-default value). NOTE: _resolve_enrollment_permission
+    at complexity exactly 15, no headroom. IN FLIGHT: w5-orderby-migrate
+    (14 sites, 7 files), w5-marking-e2e (instructor journey, Brian-approved).
+    NEW worktree .worktrees/test-codepath-tracing forked from this branch's
+    full uncommitted state, verified green — for the test→codepath tracing
+    audit (scoping with Brian pending).
+13. **[directive, Brian 2026-08-17, refined]** ORDER BY is a raw-SQL signal:
+    any ordered query is a display read — migrate every remaining
+    ORM+order_by site to tstring (activities ×2, weeks student-visibility).
+    Core-column form survives only in unordered unit-of-work predicates
+    (delete-fetch .in_, .returning). Named exception: ordered queue-claim
+    (ORDER BY + FOR UPDATE SKIP LOCKED) may stay ORM if one ever needs to.
+    Update raw-sql-convention.md with this rule. Also convert
+    test_share_button_guard_expression from shape-pin to behavioural test
+    (extract visibility predicate, test flag combinations). Queued behind
+    the running e2e slow.
+14. **[ratified, Brian 2026-08-17]** Judgement items 3 (per-lane test-run
+    dispatch), 4 (--help lock bypass), 5 (tests keep PLR2004/PLR0913
+    per-file-ignores), 6 (informational write hook) accepted. Item 7
+    DIRECTED: exact-pin all three tools (ruff, complexipy join ty at ==);
+    bumps go through the ADR 0003 controlled-upgrade ritual. pyproject edit
+    + relock queued behind the suite (identical resolved versions, so no
+    env drift).
+15. **[PARKED for tonight's test-quality layer, Brian 2026-08-17]** Two
+    CONFIRMED pre-existing placement bugs (verified against HEAD — not
+    migration-introduced): (1) _course_placement ignores
+    course.default_allow_tag_creation (course-placed workspaces never get
+    the course tag policy); (2) get_placement_context's is_template overlay
+    exists only in the activity branch — course-placed/loose template
+    workspaces lose the flag. Fix TDD-style with the Gemini semantic-audit
+    cleanup (semantic_audit_report.md), whose other claims (anonymise
+    tautology oracle, client_registry/factory vacuous mocks, admission dead
+    path) still need verify-against-source before acting.
+16. **[resolved]** JS lane vacuous pass ("vitest not installed" + exit 0) —
+    npm ci restored it; the runner's exit-0-on-missing-vitest behaviour is
+    part of finding 3/4's fix pass.

--- a/docs/implementation-plans/2026-08-17-ty-bump-toolchain/tracker.md
+++ b/docs/implementation-plans/2026-08-17-ty-bump-toolchain/tracker.md
@@ -66,17 +66,21 @@
 - [ ] **P11 Docs & housekeeping** — convention doc gotchas (Row attribute
   access, to_jsonb/bytea), CLAUDE.md hook-section accuracy, update
   `.notes/project_session-state-2026-08-17-ty-bump.md`, prune docs/_index.
-- [ ] **P12 Commits & stacking** — merge order SETTLED (Brian, 2026-08-17):
-  snapshot branch merges first; this branch rebases on top as a stacked PR.
-  Commit split by concern (toolchain / ADRs+docs / db migration / refactor
-  clusters / tests), match `git log` style, tests with implementation.
-  Post-rebase additions: (a) re-derive tags.py/items_serialise.py edits
-  against their new annotation_core module (serialise_items keyword-only
-  carries over — their side has adopted it); (b) extend the quality pass
-  over their new modules (annotation_core, snapshot, service) so the
-  mechanical pass covers the final architecture; (c) full gate re-run on
-  the stacked result; (d) snapshot session runs one 100-way perf
-  re-attachment leg after the raw-SQL resolve_annotation_context lands.
+- [x] **P12 Commits & stacking** — DONE 2026-08-17: seven-commit split
+  landed, then rebased onto origin/perf/initial-snapshot-delivery @
+  f1f7f177 via `--onto` (backup ref ty-bump-pre-stack-backup). (a) tags.py
+  / items_serialise.py resolved to their re-export shims; the typing +
+  keyword-only fixes re-derived into annotation_core.py (their relocated
+  copies still carried the 5 ty errors and the positional signature —
+  now 0 diagnostics, `*` after tag_colours, all call sites verified
+  keyword-safe). (b) Quality pass over their modules: one PLR0917 in
+  test_assessment_cram_load.py fixed keyword-only (30f86001); snapshot
+  modules read via existing db helpers, so ADR 0004-compliant by
+  construction; stacked tree fully static-green. Bonus: Alembic
+  c9d1e7a40b21 adds the four promoted partial indices (817cb8e7),
+  if_not_exists, up+down round-tripped on dev. (c) `test all` green on
+  the stack (4090 unit); `e2e all` result recorded under P13 evidence.
+  (d) 100-way leg: peer waits for the PR ping.
   Their session state: .notes/project_session-state-2026-08-17-snapshot-spike.md.
 - [ ] **P13 UAT** — Brian reviews; PR description tells the ADR story.
   PR-notes flag (from initial-snapshot-delivery session): that branch pins
@@ -184,3 +188,20 @@
 16. **[resolved]** JS lane vacuous pass ("vitest not installed" + exit 0) —
     npm ci restored it; the runner's exit-0-on-missing-vitest behaviour is
     part of finding 3/4's fix pass.
+17. **[PARKED for tonight's test-quality layer, found 2026-08-17 stacked
+    e2e all]** Week-create form value-capture race (pre-existing,
+    courses.py ~1501): `submit()` reads `title.value` server-side instead
+    of using `ui_helpers.on_submit_with_value` — the exact race pattern 2
+    in CLAUDE.md exists to prevent. Under socketio task reordering the
+    click precedes the value update, the "Title is required" guard
+    early-returns, no navigation happens, and any E2E waiting on the
+    redirect times out. Fingerprint: test_instructor_marking failed at
+    add_week in 1 of 4 parallel playwright-lane runs; isolation retry and
+    full lane rerun both green; my commits touch only noqa comments in
+    courses.py. Mechanism is a strong hypothesis (guard-return fits the
+    no-navigation timeout exactly) — confirm by capturing the notify in a
+    repro before fixing. Sibling forms in courses.py (add-activity,
+    course-create) likely share the pattern; sweep them in the same fix.
+    Single-input `on_submit_with_value` suffices for the title guard;
+    week_number keeps its server-side read (numeric default, not
+    guard-relevant).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,18 @@ load-test-data = "promptgrimoire.cli_loadtest:load_test_data"
 # follows the other: that one delays *failing the build* on a known fix, this one
 # delays *adopting* any new release at all. Change one without the other freely.
 exclude-newer = "14 days"
-# Deliberate exception approved 2026-08-16: NiceGUI 3.16.0 fixes an
-# unauthenticated disconnected-client memory leak and color-input XSS on
-# production paths. Bound the exception immediately after that release so it
-# cannot admit a later NiceGUI build accidentally.
-exclude-newer-package = { nicegui = "2026-08-12T15:18:33Z" }
+# Deliberate exceptions, each bounded immediately after the approved release
+# so it cannot admit a later build accidentally.
+# - nicegui (approved 2026-08-16): 3.16.0 fixes an unauthenticated
+#   disconnected-client memory leak and color-input XSS on production paths.
+# - ty / ruff / complexipy (approved 2026-08-17, operator ruling: 3-day gate
+#   acceptable for the lint/type toolchain being refactored around).
+exclude-newer-package = { nicegui = "2026-08-12T15:18:33Z", ty = "2026-08-14T21:35:43Z", ruff = "2026-08-13T15:17:14Z", complexipy = "2026-08-12T22:19:40Z" }
+# SQLModel caps sqlalchemy at <2.1; overridden for tstring()/PEP 750 per
+# ADR 0005 (docs/decisions/0005-sqlalchemy-21-beta-override.md). Exact pin so
+# no later beta is admitted silently. Delete when 2.1 is GA and SQLModel
+# lifts its cap.
+override-dependencies = ["sqlalchemy==2.1.0b3"]
 
 [build-system]
 requires = ["hatchling"]
@@ -109,8 +116,6 @@ select = [
     "RUF",    # Ruff-specific
 ]
 ignore = [
-    "PLR0913",  # Too many arguments
-    "PLR2004",  # Magic value comparison
     "S404",     # subprocess import (CLI tooling uses subprocess intentionally)
     "S603",     # subprocess call without shell check (controlled args in CLI)
     "S607",     # partial executable path (uv, playwright, etc.)
@@ -118,6 +123,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
+    "PLR2004",  # Expected-value literals in assertions; naming them invites tautology tests
+    "PLR0913",  # Test factories/fixtures legitimately take many optional arguments
     "PLC0415",  # Allow imports inside test functions (needed for mocking)
     "S101",     # Assertions are the primary test mechanism
     "S105",     # Hardcoded test tokens/passwords are intentional in test fixtures
@@ -128,6 +135,12 @@ ignore = [
 ]
 "src/promptgrimoire/export/pandoc.py" = [
     "S101",     # Assert after proc.communicate() — returncode guaranteed non-None
+]
+"src/promptgrimoire/export/unicode_latex.py" = [
+    "PLR2004",  # Unicode block boundaries: the hex codepoint literal IS the clearest form
+]
+"src/promptgrimoire/word_count.py" = [
+    "PLR2004",  # Unicode block boundaries, as above
 ]
 "src/promptgrimoire/pages/auth.py" = [
     "S101",     # Type-narrowing asserts after _validate_token guarantees
@@ -259,6 +272,9 @@ known-first-party = ["promptgrimoire"]
 quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
+# Ruff 0.16 formats fenced code blocks in markdown. Our docs hold deliberate
+# fragments (plan excerpts, elided examples) that it rewrites incorrectly.
+exclude = ["*.md"]
 
 [tool.pytest.ini_options]
 # Run tests in this order: unit first (fast, async), integration, then E2E
@@ -297,7 +313,12 @@ filterwarnings = [
 deprecated = "ignore"
 
 [tool.ty.src]
-exclude = ["alembic/"]
+exclude = [
+    "alembic/",
+    # uvx-run standalone script; python-docx is supplied by its uvx invocation
+    # and is deliberately not a project dependency.
+    "scripts/extract_anthropic_console_to_json.py",
+]
 
 [tool.vulture]
 paths = ["src/promptgrimoire"]
@@ -315,6 +336,7 @@ exclude = ["*/migrations/*"]
 [dependency-groups]
 dev = [
     "pre-commit>=4.5.1",
+    "ty==0.0.72",  # exact pin: pre-1.0, diagnostic set changes per release; bump deliberately
     "psycopg[binary]>=3.2",
     "pylatexenc>=2.10",
     "pymupdf>=1.26.7",
@@ -327,7 +349,7 @@ dev = [
     "pytest-subtests>=0.15.0",
     "pytest-xdist[psutil]>=3.8.0",
     "ast-grep-cli>=0.40.5",
-    "ruff>=0.15.5",
+    "ruff==0.16.3",  # exact pin: lint/format behaviour changes per release; bump via ADR 0003 ritual
     "pytest-randomly>=4.0.1",
     "py-spy>=0.4.1",
     "junitparser>=4.0.2",
@@ -335,7 +357,7 @@ dev = [
     "Pillow>=12.3.0",  # Security floor: image parsing and allocation fixes
     "mkdocs-material>=9.7",
     "vulture>=2.14",
-    "complexipy>=5.2.0",
+    "complexipy==7.0.1",  # exact pin: scoring changes per release; bump via ADR 0003 ritual
     "mkdocs-glightbox>=0.5.2",
     "pip-audit>=2.10.0",
     "types-openpyxl>=3.1.5.20250919",

--- a/scripts/analyse_fixture.py
+++ b/scripts/analyse_fixture.py
@@ -24,46 +24,57 @@ from pathlib import Path
 
 FIXTURES_DIR = Path(__file__).parent.parent / "tests" / "fixtures" / "conversations"
 
+# Result caps for the search/context commands -- large fixtures can have
+# thousands of regex hits, so output is truncated for terminal readability.
+_MAX_SEARCH_MATCHES_SHOWN = 20
+_MAX_CONTEXT_OCCURRENCES_SHOWN = 15
 
-def _load_fixture(name_or_path: str) -> tuple[str, str]:
-    """Load a fixture by name or path, handling .html and .html.gz transparently.
 
-    Returns (display_name, html_content).
-    """
-    # Try as direct path first
+def _fixture_stem(path: Path) -> str:
+    """Strip a fixture filename's .html or .html.gz suffix."""
+    return path.name.replace(".html.gz", "").replace(".html", "")
+
+
+def _read_fixture_html(path: Path) -> str:
+    """Read a fixture file's HTML content, decompressing .gz transparently."""
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            return f.read()
+    return path.read_text(encoding="utf-8")
+
+
+def _load_fixture_by_path(name_or_path: str) -> tuple[str, str] | None:
+    """Load a fixture given as a direct filesystem path, if it exists."""
     path = Path(name_or_path)
-    if path.exists():
-        if path.suffix == ".gz":
-            with gzip.open(path, "rt", encoding="utf-8") as f:
-                return path.stem.replace(".html", ""), f.read()
-        return path.stem, path.read_text(encoding="utf-8")
+    if not path.exists():
+        return None
+    return _fixture_stem(path), _read_fixture_html(path)
 
-    # Try as fixture name (without extension)
-    name = name_or_path.lower()
-    for ext in [".html", ".html.gz"]:
+
+def _load_fixture_by_name(name: str) -> tuple[str, str] | None:
+    """Load a fixture by its exact name (without extension) in FIXTURES_DIR."""
+    for ext in (".html", ".html.gz"):
         candidate = FIXTURES_DIR / f"{name}{ext}"
         if candidate.exists():
-            if ext == ".html.gz":
-                with gzip.open(candidate, "rt", encoding="utf-8") as f:
-                    return name, f.read()
-            return name, candidate.read_text(encoding="utf-8")
+            return name, _read_fixture_html(candidate)
+    return None
 
-    # Try matching as substring
-    matches = []
-    for f in sorted(FIXTURES_DIR.iterdir()):
-        if f.name == "clean" or f.is_dir():
-            continue
-        stem = f.name.replace(".html.gz", "").replace(".html", "")
-        if name in stem:
-            matches.append(f)
 
+def _fixtures_matching(name: str) -> list[Path]:
+    """List fixture files in FIXTURES_DIR whose stem contains *name*."""
+    return [
+        f
+        for f in sorted(FIXTURES_DIR.iterdir())
+        if f.name != "clean" and not f.is_dir() and name in _fixture_stem(f)
+    ]
+
+
+def _load_fixture_by_substring(name: str, name_or_path: str) -> tuple[str, str]:
+    """Load a fixture by unique substring match, or exit with a diagnostic."""
+    matches = _fixtures_matching(name)
     if len(matches) == 1:
-        f = matches[0]
-        stem = f.name.replace(".html.gz", "").replace(".html", "")
-        if f.name.endswith(".gz"):
-            with gzip.open(f, "rt", encoding="utf-8") as fh:
-                return stem, fh.read()
-        return stem, f.read_text(encoding="utf-8")
+        match = matches[0]
+        return _fixture_stem(match), _read_fixture_html(match)
     if len(matches) > 1:
         names = [m.name for m in matches]
         print(
@@ -75,6 +86,21 @@ def _load_fixture(name_or_path: str) -> tuple[str, str]:
     print(f"Fixture not found: {name_or_path}", file=sys.stderr)
     print("Available fixtures (use 'list' command):", file=sys.stderr)
     sys.exit(1)
+
+
+def _load_fixture(name_or_path: str) -> tuple[str, str]:
+    """Load a fixture by name or path, handling .html and .html.gz transparently.
+
+    Tries, in order: a direct filesystem path, an exact fixture name match,
+    then a unique substring match against fixture names.
+
+    Returns (display_name, html_content).
+    """
+    return (
+        _load_fixture_by_path(name_or_path)
+        or _load_fixture_by_name(name_or_path.lower())
+        or _load_fixture_by_substring(name_or_path.lower(), name_or_path)
+    )
 
 
 def _strip_style_attrs(html: str) -> str:
@@ -168,7 +194,7 @@ def cmd_search(args: argparse.Namespace) -> None:
     print(f"{len(matches)} matches for /{pattern}/ in {name}:")
     print()
 
-    for i, m in enumerate(matches[:20]):
+    for i, m in enumerate(matches[:_MAX_SEARCH_MATCHES_SHOWN]):
         start = max(0, m.start() - context_chars)
         end = min(len(html), m.end() + context_chars)
         context = html[start:end]
@@ -180,8 +206,8 @@ def cmd_search(args: argparse.Namespace) -> None:
         print(f"    ...{context}...")
         print()
 
-    if len(matches) > 20:
-        print(f"  (showing 20 of {len(matches)} matches)")
+    if len(matches) > _MAX_SEARCH_MATCHES_SHOWN:
+        print(f"  (showing {_MAX_SEARCH_MATCHES_SHOWN} of {len(matches)} matches)")
 
 
 def cmd_context(args: argparse.Namespace) -> None:
@@ -209,7 +235,7 @@ def cmd_context(args: argparse.Namespace) -> None:
     print(f"{len(positions)} occurrences of '{text}' in {name}:")
     print()
 
-    for i, pos in enumerate(positions[:15]):
+    for i, pos in enumerate(positions[:_MAX_CONTEXT_OCCURRENCES_SHOWN]):
         start_ctx = max(0, pos - context_chars)
         end_ctx = min(len(html), pos + len(text) + context_chars)
         context = html[start_ctx:end_ctx]
@@ -226,8 +252,11 @@ def cmd_context(args: argparse.Namespace) -> None:
         print(f"    ...{before}>>>{match}<<<{after}...")
         print()
 
-    if len(positions) > 15:
-        print(f"  (showing 15 of {len(positions)} occurrences)")
+    if len(positions) > _MAX_CONTEXT_OCCURRENCES_SHOWN:
+        print(
+            f"  (showing {_MAX_CONTEXT_OCCURRENCES_SHOWN} of "
+            f"{len(positions)} occurrences)"
+        )
 
 
 def cmd_structure(args: argparse.Namespace) -> None:

--- a/scripts/extract_anthropic_console_to_json.py
+++ b/scripts/extract_anthropic_console_to_json.py
@@ -23,6 +23,9 @@ from typing import Any
 
 from docx import Document  # type: ignore[import-untyped]
 
+# argv[0] is the script path; an input directory is the minimum required arg.
+_MIN_ARGV_WITH_INPUT_DIR = 2
+
 
 def extract_source(docx_path: Path) -> str:
     """Join all paragraphs from a docx into one Python source string."""
@@ -75,7 +78,7 @@ def extract_messages_and_params(source: str) -> dict[str, Any]:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
+    if len(sys.argv) < _MIN_ARGV_WITH_INPUT_DIR:
         sys.exit(f"Usage: {sys.argv[0]} <input_dir>")
 
     input_dir = Path(sys.argv[1])

--- a/scripts/fetch_export_logs.py
+++ b/scripts/fetch_export_logs.py
@@ -35,6 +35,8 @@ from pathlib import Path
 
 SERVICE_NAME = "promptgrimoire.service"
 EXPORT_PREFIX = "promptgrimoire_export_"
+# Workspace UUIDs are truncated to their first 8 hex chars in export dir names.
+WORKSPACE_ID_PREFIX_LEN = 8
 
 
 def find_private_tmp() -> Path | None:
@@ -85,7 +87,11 @@ def format_dir_info(export_dir: Path) -> str:
     # Format: promptgrimoire_export_<ws_id_8>_<random>
     dir_suffix = export_dir.name[len(EXPORT_PREFIX) :]
     parts = dir_suffix.split("_", 1)
-    ws_prefix = parts[0] if len(parts) > 1 and len(parts[0]) == 8 else "unknown"
+    ws_prefix = (
+        parts[0]
+        if len(parts) > 1 and len(parts[0]) == WORKSPACE_ID_PREFIX_LEN
+        else "unknown"
+    )
 
     # Find tex/log files
     tex_files = list(export_dir.glob("*.tex"))

--- a/scripts/grimoire_exemplars.py
+++ b/scripts/grimoire_exemplars.py
@@ -549,7 +549,7 @@ app = typer.Typer(add_completion=False, help=__doc__)
 
 
 @app.command()
-def main(
+def main(  # noqa: PLR0913, PLR0917 -- Typer CLI options, one per flag by design
     top: int = typer.Option(3, help="Top examples to show per assessment."),
     min_highlights: int = typer.Option(
         5, help="Minimum highlights for a workspace to qualify as an example."

--- a/scripts/incident/analysis.py
+++ b/scripts/incident/analysis.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 _CRASH_BOUNCE_THRESHOLD = 300  # seconds
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 3600
 
 LOGIN_EVENT_PATTERN = "Login successful%"
 
@@ -564,18 +567,10 @@ def _query_nosrv_clustering(
     return count_nosrv, nosrv_first_60s
 
 
-def query_epoch_haproxy(
-    conn: sqlite3.Connection,
-    start_utc: str,
-    end_utc: str,
-    duration_seconds: float,
-) -> dict:
-    """Query HAProxy traffic stats within an epoch window.
-
-    Returns status code distribution, request totals, 5xx rates,
-    and latency percentiles (p50/p95/p99).
-    """
-    # Status code distribution
+def _query_status_distribution(
+    conn: sqlite3.Connection, start_utc: str, end_utc: str
+) -> list[dict]:
+    """Query HAProxy status code distribution within a window."""
     status_rows = conn.execute(
         "SELECT status_code, COUNT(*) AS count"
         " FROM haproxy_events"
@@ -584,11 +579,17 @@ def query_epoch_haproxy(
         " ORDER BY status_code",
         (start_utc, end_utc),
     ).fetchall()
-    status_codes = [{"status_code": code, "count": cnt} for code, cnt in status_rows]
+    return [{"status_code": code, "count": cnt} for code, cnt in status_rows]
 
-    # Totals — exclude <NOSRV> (HAProxy 503s during restart, not app errors).
-    # <NOSRV> means HAProxy had no backend available (app restarting).
-    # These are infrastructure transients, not application errors.
+
+def _query_request_totals(
+    conn: sqlite3.Connection, start_utc: str, end_utc: str
+) -> tuple[int, int]:
+    """Query (total_requests, count_5xx), excluding <NOSRV> transients.
+
+    <NOSRV> means HAProxy had no backend available (app restarting) —
+    an infrastructure transient, not an application error.
+    """
     row = conn.execute(
         "SELECT COUNT(*) AS total_requests,"
         " SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END) AS count_5xx"
@@ -597,18 +598,19 @@ def query_epoch_haproxy(
         " AND (server IS NULL OR server != '<NOSRV>')",
         (start_utc, end_utc),
     ).fetchone()
-    total_requests = row[0]
-    count_5xx = row[1] or 0
+    return row[0], row[1] or 0
 
-    count_nosrv, nosrv_first_60s = _query_nosrv_clustering(conn, start_utc, end_utc)
 
-    is_crash = duration_seconds < _CRASH_BOUNCE_THRESHOLD
+_HAPROXY_PERCENTILES = ((0.50, "p50_ms"), (0.95, "p95_ms"), (0.99, "p99_ms"))
 
-    # Percentiles — also exclude <NOSRV> (no meaningful response time)
-    p50_ms: int | None = None
-    p95_ms: int | None = None
-    p99_ms: int | None = None
 
+def _query_latency_percentiles(
+    conn: sqlite3.Connection, start_utc: str, end_utc: str
+) -> tuple[int, int | None, int | None, int | None]:
+    """Query (sample_count, p50_ms, p95_ms, p99_ms), excluding <NOSRV>.
+
+    <NOSRV> rows have no meaningful response time.
+    """
     sample_count_row = conn.execute(
         "SELECT COUNT(*) FROM haproxy_events"
         " WHERE ts_utc >= ? AND ts_utc <= ? AND ta_ms IS NOT NULL"
@@ -617,8 +619,13 @@ def query_epoch_haproxy(
     ).fetchone()
     sample_count = sample_count_row[0]
 
+    percentiles: dict[str, int | None] = {
+        "p50_ms": None,
+        "p95_ms": None,
+        "p99_ms": None,
+    }
     if sample_count > 0:
-        for pct, attr in [(0.50, "p50_ms"), (0.95, "p95_ms"), (0.99, "p99_ms")]:
+        for pct, attr in _HAPROXY_PERCENTILES:
             pct_row = conn.execute(
                 "SELECT ta_ms FROM haproxy_events"
                 " WHERE ts_utc >= ? AND ts_utc <= ? AND ta_ms IS NOT NULL"
@@ -631,21 +638,46 @@ def query_epoch_haproxy(
                 (start_utc, end_utc, pct, start_utc, end_utc),
             ).fetchone()
             if pct_row:
-                if attr == "p50_ms":
-                    p50_ms = pct_row[0]
-                elif attr == "p95_ms":
-                    p95_ms = pct_row[0]
-                else:
-                    p99_ms = pct_row[0]
+                percentiles[attr] = pct_row[0]
+
+    return (
+        sample_count,
+        percentiles["p50_ms"],
+        percentiles["p95_ms"],
+        percentiles["p99_ms"],
+    )
+
+
+def query_epoch_haproxy(
+    conn: sqlite3.Connection,
+    start_utc: str,
+    end_utc: str,
+    duration_seconds: float,
+) -> dict:
+    """Query HAProxy traffic stats within an epoch window.
+
+    Returns status code distribution, request totals, 5xx rates,
+    and latency percentiles (p50/p95/p99).
+    """
+    status_codes = _query_status_distribution(conn, start_utc, end_utc)
+    total_requests, count_5xx = _query_request_totals(conn, start_utc, end_utc)
+    count_nosrv, nosrv_first_60s = _query_nosrv_clustering(conn, start_utc, end_utc)
+    sample_count, p50_ms, p95_ms, p99_ms = _query_latency_percentiles(
+        conn, start_utc, end_utc
+    )
+
+    is_crash = duration_seconds < _CRASH_BOUNCE_THRESHOLD
 
     return {
         "status_codes": status_codes,
         "total_requests": total_requests,
         "count_5xx": count_5xx,
-        "rate_5xx": None if is_crash else count_5xx / (duration_seconds / 3600),
+        "rate_5xx": None
+        if is_crash
+        else count_5xx / (duration_seconds / _SECONDS_PER_HOUR),
         "requests_per_minute": None
         if is_crash
-        else total_requests / (duration_seconds / 60),
+        else total_requests / (duration_seconds / _SECONDS_PER_MINUTE),
         "p50_ms": p50_ms,
         "p95_ms": p95_ms,
         "p99_ms": p99_ms,
@@ -948,14 +980,14 @@ def _fmt_gap_duration(seconds: float | None) -> str:
         return "—"
     if seconds == 0.0:
         return "0s"
-    if seconds < 60:
+    if seconds < _SECONDS_PER_MINUTE:
         return f"{int(seconds)}s"
-    if seconds < 3600:
-        m = int(seconds // 60)
-        s = int(seconds % 60)
+    if seconds < _SECONDS_PER_HOUR:
+        m = int(seconds // _SECONDS_PER_MINUTE)
+        s = int(seconds % _SECONDS_PER_MINUTE)
         return f"{m}m {s}s"
-    h = int(seconds // 3600)
-    m = int((seconds % 3600) // 60)
+    h = int(seconds // _SECONDS_PER_HOUR)
+    m = int((seconds % _SECONDS_PER_HOUR) // _SECONDS_PER_MINUTE)
     return f"{h}h {m}m"
 
 
@@ -1440,12 +1472,16 @@ def _fmt_ratio_delta(n: float) -> str:
     return f"{sign}{pct:.2f}pp"
 
 
+_BYTES_PER_GIB = 1_073_741_824
+_BYTES_PER_MIB = 1_048_576
+
+
 def _fmt_bytes(n: float | int) -> str:
     """Format bytes as human-readable (e.g. 2.7G, 366M)."""
-    if n >= 1_073_741_824:
-        return f"{n / 1_073_741_824:.1f}G"
-    if n >= 1_048_576:
-        return f"{n / 1_048_576:.0f}M"
+    if n >= _BYTES_PER_GIB:
+        return f"{n / _BYTES_PER_GIB:.1f}G"
+    if n >= _BYTES_PER_MIB:
+        return f"{n / _BYTES_PER_MIB:.0f}M"
     return f"{n:.0f}B"
 
 
@@ -1525,20 +1561,36 @@ def _render_section_methodology(lines: list[str]) -> None:
     lines.append("")
 
 
-def render_review_report(
-    sources: list[dict],
-    epochs: list[dict],
-    epoch_analyses: list[dict],
-    summative_users: dict,
-    trends: list[dict],
-    static_counts: dict | None = None,
-) -> str:
+@dataclass
+class ReportData:
+    """Bundles the inputs to :func:`render_review_report`.
+
+    A plain parameter object rather than six positional arguments — every
+    field is always supplied together by the ``review`` CLI orchestration.
+    """
+
+    sources: list[dict]
+    epochs: list[dict]
+    epoch_analyses: list[dict]
+    summative_users: dict
+    trends: list[dict]
+    static_counts: dict | None = None
+
+
+def render_review_report(data: ReportData) -> str:
     """Assemble a markdown operational review report.
 
     Combines source inventory, epoch timeline, per-epoch analysis,
     user activity summary, and trend analysis into a single markdown
     document suitable for review.
     """
+    sources = data.sources
+    epochs = data.epochs
+    epoch_analyses = data.epoch_analyses
+    summative_users = data.summative_users
+    trends = data.trends
+    static_counts = data.static_counts
+
     lines: list[str] = []
     generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
 

--- a/scripts/incident/ingest.py
+++ b/scripts/incident/ingest.py
@@ -9,6 +9,7 @@ import sqlite3
 import sys
 import tarfile
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from scripts.incident.parsers.haproxy import parse_haproxy
@@ -19,25 +20,54 @@ from scripts.incident.parsers.pglog import parse_pglog_auto
 from scripts.incident.provenance import format_to_table, parse_manifest
 from scripts.incident.schema import create_schema
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Declared ahead of the try/except so both branches assign a value of the
+# same type -- ty needs one declared type per module-level name, not one
+# per branch.
+_fetch_beszel: Callable[[str, str, str], list[dict]] | None
 try:
     from scripts.incident.parsers.beszel import (
         fetch_beszel_metrics as _fetch_beszel,
     )
-
-    _HAS_BESZEL = True
 except ImportError:
-    _HAS_BESZEL = False
-    _fetch_beszel = None  # type: ignore[assignment]
+    _fetch_beszel = None
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
-# Maps format string to (parser_func, table_name, column_names).
-# Parser funcs: (data: bytes, window_start: str, window_end: str) -> list[dict]
-# Exception: haproxy parser returns (list[dict], int) — see _dispatch_parser.
-_PARSERS: dict[str, tuple[object, str, list[str]]] = {
+def _adapt_parser(
+    parser: Callable[[bytes, str, str], list[dict]],
+) -> Callable[[bytes, str, str, str], tuple[list[dict], int]]:
+    """Normalise a 3-arg parser to the uniform 4-arg dispatch signature.
+
+    Only the HAProxy parser natively consumes ``timezone`` and reports an
+    unparseable-line count. Every other parser is wrapped to accept (and
+    ignore) the trailing ``timezone`` argument and always report zero
+    unparseable lines, matching prior dispatch behaviour exactly.
+    """
+
+    def _wrapped(
+        data: bytes,
+        window_start_utc: str,
+        window_end_utc: str,
+        timezone: str,  # noqa: ARG001 — signature parity with the HAProxy parser
+    ) -> tuple[list[dict], int]:
+        return parser(data, window_start_utc, window_end_utc), 0
+
+    return _wrapped
+
+
+# Maps format string to (parser_func, table_name, column_names). Every
+# parser_func has the uniform signature
+# (data, window_start_utc, window_end_utc, timezone) -> (events, unparseable_count) --
+# see _adapt_parser for formats whose underlying parser doesn't natively
+# take/return those.
+_PARSERS: dict[
+    str,
+    tuple[Callable[[bytes, str, str, str], tuple[list[dict], int]], str, list[str]],
+] = {
     "journal": (
-        parse_journal,
+        _adapt_parser(parse_journal),
         "journal_events",
         [
             "source_id",
@@ -50,7 +80,7 @@ _PARSERS: dict[str, tuple[object, str, list[str]]] = {
         ],
     ),
     "jsonl": (
-        parse_jsonl,
+        _adapt_parser(parse_jsonl),
         "jsonl_events",
         [
             "source_id",
@@ -85,7 +115,7 @@ _PARSERS: dict[str, tuple[object, str, list[str]]] = {
         ],
     ),
     "pglog": (
-        parse_pglog_auto,
+        _adapt_parser(parse_pglog_auto),
         "pg_events",
         [
             "source_id",
@@ -99,7 +129,7 @@ _PARSERS: dict[str, tuple[object, str, list[str]]] = {
         ],
     ),
     "pgbouncer": (
-        parse_pgbouncer,
+        _adapt_parser(parse_pgbouncer),
         "pgbouncer_events",
         [
             "source_id",
@@ -112,7 +142,7 @@ _PARSERS: dict[str, tuple[object, str, list[str]]] = {
 }
 
 
-def _dispatch_parser(
+def _dispatch_parser(  # noqa: PLR0913, PLR0917 -- caller passes positionally; param-object migration: tracker ledger 8
     conn: sqlite3.Connection,
     fmt: str,
     source_id: int,
@@ -127,18 +157,9 @@ def _dispatch_parser(
         return
 
     parse_fn, table_name, columns = parser_entry
-
-    # HAProxy parser has a different signature: returns (events, count)
-    # and requires a timezone parameter.
-    unparseable_count = 0
-    if fmt == "haproxy":
-        events, unparseable_count = parse_fn(  # type: ignore[operator]
-            file_data, window_start_utc, window_end_utc, timezone
-        )
-    else:
-        events = parse_fn(  # type: ignore[operator]
-            file_data, window_start_utc, window_end_utc
-        )
+    events, unparseable_count = parse_fn(
+        file_data, window_start_utc, window_end_utc, timezone
+    )
 
     if not events:
         return
@@ -162,17 +183,16 @@ def _dispatch_parser(
         print(f"  \u2192 {len(events)} events parsed")
 
 
-def _resolve_data_dir(source: Path) -> tuple[__import__("pathlib").Path, bool]:
+def _resolve_data_dir(source: Path) -> tuple[Path, bool]:
     """Resolve source to a data directory.
 
     Accepts a tarball (.tar.gz) or a directory path.
     Returns (data_dir, is_temp) — caller must clean up if is_temp.
     """
-    P = __import__("pathlib").Path
     if source.is_dir():
-        return P(source), False
+        return Path(source), False
 
-    tmp_dir = P(tempfile.mkdtemp(prefix="incident-ingest-"))
+    tmp_dir = Path(tempfile.mkdtemp(prefix="incident-ingest-"))
     try:
         with tarfile.open(source, "r:gz") as tar:
             tar.extractall(path=tmp_dir, filter="data")
@@ -184,9 +204,9 @@ def _resolve_data_dir(source: Path) -> tuple[__import__("pathlib").Path, bool]:
 
 
 def _copy_db_snapshot(
-    data_dir: __import__("pathlib").Path,
-    db_path: __import__("pathlib").Path,
-) -> __import__("pathlib").Path | None:
+    data_dir: Path,
+    db_path: Path,
+) -> Path | None:
     """Copy db-snapshot.json next to the DB for ``review --counts-json``.
 
     Returns the destination path, or None if no snapshot found.
@@ -224,8 +244,8 @@ def run_ingest(source: Path, db_path: Path) -> None:
 
 
 def _run_ingest_from_dir(
-    data_dir: __import__("pathlib").Path,
-    db_path: __import__("pathlib").Path,
+    data_dir: Path,
+    db_path: Path,
 ) -> None:
     """Core ingest logic operating on an already-extracted directory."""
     manifest_path = data_dir / "manifest.json"
@@ -331,7 +351,7 @@ def _run_ingest_from_dir(
 
 
 def _try_beszel_fetch(
-    db_path: __import__("pathlib").Path,
+    db_path: Path,
     start_utc: str,
     end_utc: str,
     timezone: str,
@@ -341,7 +361,7 @@ def _try_beszel_fetch(
     Requires an SSH tunnel: ``ssh -L 8090:localhost:8090 <monitor>``.
     Silently skips if the port is not open or httpx is unavailable.
     """
-    if not _HAS_BESZEL:
+    if _fetch_beszel is None:
         print("  httpx not available — skipping Beszel fetch")
         return
 

--- a/scripts/incident/parsers/beszel.py
+++ b/scripts/incident/parsers/beszel.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import httpx
 
 _BESZEL_ENV_FILE = Path.home() / ".config" / "beszel" / "env"
+_PAGE_SIZE = 200
 
 
 def _parse_env_file(path: Path) -> dict[str, str]:
@@ -76,7 +77,7 @@ def _authenticate(client: httpx.Client, hub_url: str) -> str:
         f"{hub_url}/api/collections/_superusers/auth-with-password",
         json={"identity": email, "password": password},
     )
-    if resp.status_code != 200:
+    if resp.status_code != httpx.codes.OK:
         print(
             f"Error: Beszel auth failed (HTTP {resp.status_code}). "
             "Check BESZEL_EMAIL/BESZEL_PASSWORD.",
@@ -84,6 +85,67 @@ def _authenticate(client: httpx.Client, hub_url: str) -> str:
         )
         raise SystemExit(1)
     return resp.json()["token"]
+
+
+def _at(seq: list | None, index: int) -> float | None:
+    """Return ``seq[index]`` if present, else ``None``."""
+    return seq[index] if seq and len(seq) > index else None
+
+
+def _stats_from_record(record: dict) -> dict:
+    """Normalise one PocketBase ``system_stats`` record into a flat metrics dict."""
+    stats = record.get("stats", {})
+    la = stats.get("la", [None, None, None])
+    # b = [sent, recv] bandwidth in bytes/s
+    bandwidth = stats.get("b", [None, None])
+    return {
+        "ts_utc": record["created"],
+        "cpu": stats.get("cpu"),
+        "mem_used": stats.get("mu"),
+        "mem_percent": stats.get("mp"),
+        "net_sent": _at(bandwidth, 0),
+        "net_recv": _at(bandwidth, 1),
+        "disk_read": stats.get("dr"),
+        "disk_write": stats.get("dw"),
+        "load_1": _at(la, 0),
+        "load_5": _at(la, 1),
+        "load_15": _at(la, 2),
+    }
+
+
+def _fetch_all_pages(
+    client: httpx.Client,
+    hub_url: str,
+    collection: str,
+    pb_filter: str,
+    headers: dict[str, str],
+) -> list[dict]:
+    """Fetch and normalise every page of records matching ``pb_filter``."""
+    results: list[dict] = []
+    page = 1
+
+    while True:
+        resp = client.get(
+            f"{hub_url}/api/collections/{collection}/records",
+            params={
+                "filter": pb_filter,
+                "page": page,
+                "perPage": _PAGE_SIZE,
+                "sort": "created",
+            },
+            headers=headers,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        results.extend(_stats_from_record(record) for record in body.get("items", []))
+
+        total_pages = body.get("totalPages", 1)
+        if page >= total_pages:
+            break
+        page += 1
+
+    return results
 
 
 def fetch_beszel_metrics(
@@ -119,53 +181,12 @@ def fetch_beszel_metrics(
         On connection, auth, or HTTP errors (exit code 1, clear message).
     """
     pb_filter = f'created >= "{start_utc}" && created <= "{end_utc}"'
-    results: list[dict] = []
-    page = 1
 
     try:
         with httpx.Client() as client:
             token = _authenticate(client, hub_url)
             headers = {"Authorization": f"Bearer {token}"}
-
-            while True:
-                resp = client.get(
-                    f"{hub_url}/api/collections/{collection}/records",
-                    params={
-                        "filter": pb_filter,
-                        "page": page,
-                        "perPage": 200,
-                        "sort": "created",
-                    },
-                    headers=headers,
-                )
-                resp.raise_for_status()
-                body = resp.json()
-
-                for record in body.get("items", []):
-                    stats = record.get("stats", {})
-                    la = stats.get("la", [None, None, None])
-                    # b = [sent, recv] bandwidth in bytes/s
-                    bandwidth = stats.get("b", [None, None])
-                    results.append(
-                        {
-                            "ts_utc": record["created"],
-                            "cpu": stats.get("cpu"),
-                            "mem_used": stats.get("mu"),
-                            "mem_percent": stats.get("mp"),
-                            "net_sent": bandwidth[0] if bandwidth else None,
-                            "net_recv": bandwidth[1] if bandwidth else None,
-                            "disk_read": stats.get("dr"),
-                            "disk_write": stats.get("dw"),
-                            "load_1": la[0] if la else None,
-                            "load_5": la[1] if len(la) > 1 else None,
-                            "load_15": la[2] if len(la) > 2 else None,
-                        }
-                    )
-
-                total_pages = body.get("totalPages", 1)
-                if page >= total_pages:
-                    break
-                page += 1
+            return _fetch_all_pages(client, hub_url, collection, pb_filter, headers)
 
     except httpx.ConnectError:
         print(
@@ -181,5 +202,3 @@ def fetch_beszel_metrics(
             file=sys.stderr,
         )
         raise SystemExit(1) from None
-
-    return results

--- a/scripts/incident/parsers/github.py
+++ b/scripts/incident/parsers/github.py
@@ -16,6 +16,7 @@ import httpx
 from scripts.incident.parsers import normalise_utc
 
 _GITHUB_API = "https://api.github.com"
+_HTTP_NOT_FOUND = 404
 
 _STATUS_MESSAGES: dict[int, str] = {
     401: "Error: GitHub API returned 401 Unauthorized. Check your token.",
@@ -105,7 +106,7 @@ def _handle_http_error(
 ) -> None:
     """Print a user-friendly error message and exit."""
     status = exc.response.status_code
-    if status == 404:
+    if status == _HTTP_NOT_FOUND:
         msg = f"Error: GitHub API returned 404. Repository '{repo}' not found."
     else:
         msg = _STATUS_MESSAGES.get(status, f"Error: GitHub API returned HTTP {status}.")

--- a/scripts/incident/parsers/jsonl.py
+++ b/scripts/incident/parsers/jsonl.py
@@ -42,6 +42,57 @@ _COLUMN_FIELDS = frozenset(
 )
 
 
+def _event_from_record(record: dict, ts_normalised: str) -> dict:
+    """Build the ``jsonl_events`` row dict for one already-validated record."""
+    # extra_json holds all keys NOT in the dedicated column set.
+    extra = {k: v for k, v in record.items() if k not in _COLUMN_FIELDS}
+    return {
+        "ts_utc": ts_normalised,
+        "level": record.get("level"),
+        "event": record.get("event"),
+        "user_id": record.get("user_id"),
+        "workspace_id": record.get("workspace_id"),
+        "request_path": record.get("request_path"),
+        "exc_info": record.get("exc_info"),  # None if absent or JSON null — AC3.5
+        "extra_json": json.dumps(extra) if extra else None,
+    }
+
+
+def _parse_line(
+    line: str,
+    window_start_utc: str,
+    window_end_utc: str,
+) -> tuple[dict | None, bool]:
+    """Parse one JSONL line into ``(event, skipped)``.
+
+    ``event`` is ``None`` when the line produced no row (blank, malformed,
+    missing/unparseable timestamp, or simply outside the window). ``skipped``
+    is ``True`` only for malformed/incomplete lines — blank lines and lines
+    that parsed fine but fell outside the window are not counted as skipped.
+    """
+    if not line.strip():
+        return None, False
+
+    try:
+        record = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed JSONL line")
+        return None, True
+
+    ts_normalised = _extract_timestamp(record)
+    if ts_normalised is None:
+        return None, True
+
+    try:
+        if not in_window(ts_normalised, window_start_utc, window_end_utc):
+            return None, False
+    except ValueError, TypeError:
+        logger.warning("Skipping JSONL line with unparseable timestamp")
+        return None, True
+
+    return _event_from_record(record, ts_normalised), False
+
+
 def parse_jsonl(
     data: bytes,
     window_start_utc: str,
@@ -59,47 +110,10 @@ def parse_jsonl(
     skipped = 0
 
     for line in data.decode("utf-8").split("\n"):
-        if not line.strip():
-            continue
-
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError:
-            skipped += 1
-            logger.warning("Skipping malformed JSONL line")
-            continue
-
-        ts_normalised = _extract_timestamp(record)
-        if ts_normalised is None:
-            skipped += 1
-            continue
-
-        try:
-            if not in_window(ts_normalised, window_start_utc, window_end_utc):
-                continue
-        except ValueError, TypeError:
-            skipped += 1
-            logger.warning("Skipping JSONL line with unparseable timestamp")
-            continue
-
-        # Build extra_json from all keys NOT in the dedicated column set.
-        extra = {k: v for k, v in record.items() if k not in _COLUMN_FIELDS}
-        extra_json = json.dumps(extra) if extra else None
-
-        results.append(
-            {
-                "ts_utc": ts_normalised,
-                "level": record.get("level"),
-                "event": record.get("event"),
-                "user_id": record.get("user_id"),
-                "workspace_id": record.get("workspace_id"),
-                "request_path": record.get("request_path"),
-                "exc_info": record.get(
-                    "exc_info"
-                ),  # None if absent or JSON null — AC3.5
-                "extra_json": extra_json,
-            }
-        )
+        event, was_skipped = _parse_line(line, window_start_utc, window_end_utc)
+        skipped += was_skipped
+        if event is not None:
+            results.append(event)
 
     if skipped:
         logger.warning("Skipped %d malformed/incomplete JSONL lines", skipped)

--- a/scripts/incident/queries.py
+++ b/scripts/incident/queries.py
@@ -132,10 +132,9 @@ def _normalise_bound(ts: str) -> str:
 
 
 def _dict_factory(
-    cursor: object,  # sqlite3.Cursor
+    cursor: sqlite3.Cursor,
     row: tuple,
 ) -> dict:
     """sqlite3 row_factory that returns dicts keyed by column name."""
-    # cursor.description is available on sqlite3.Cursor
-    description = cursor.description  # type: ignore[union-attr]
+    description = cursor.description
     return {col[0]: row[idx] for idx, col in enumerate(description)}

--- a/scripts/incident_db.py
+++ b/scripts/incident_db.py
@@ -125,7 +125,7 @@ def _aedt_to_utc(local_str: str, tz_name: str) -> str:
 
 
 @app.command()
-def timeline(
+def timeline(  # noqa: PLR0913, PLR0917 -- Typer CLI options, one per flag by design
     start: str = typer.Option(..., help="Start time (local, e.g. '2026-03-16 16:05')"),
     end: str = typer.Option(..., help="End time (local, e.g. '2026-03-16 16:14')"),
     level: str | None = typer.Option(None, help="Filter by level/status"),
@@ -263,11 +263,10 @@ def beszel(
     typer.echo(f"Fetched {len(metrics)} metric data points")
 
 
-def _analyse_epochs(
-    conn: sqlite3.Connection,
-    epochs: list[dict],
-) -> list[dict]:
-    """Run per-epoch queries and attach ratio metrics to each epoch dict."""
+def _run_epoch_queries(
+    conn: sqlite3.Connection, start: str, end: str, duration_seconds: float
+) -> dict:
+    """Run every per-epoch analysis query and bundle their results."""
     from scripts.incident.analysis import (
         detect_pool_config,
         query_epoch_errors,
@@ -279,45 +278,62 @@ def _analyse_epochs(
         query_epoch_users,
     )
 
+    return {
+        "errors": query_epoch_errors(conn, start, end, duration_seconds),
+        "haproxy": query_epoch_haproxy(conn, start, end, duration_seconds),
+        "resources": query_epoch_resources(conn, start, end),
+        "pg": query_epoch_pg(conn, start, end),
+        "journal_anomalies": query_epoch_journal_anomalies(conn, start, end),
+        "users": query_epoch_users(conn, start, end),
+        "js_timeouts": query_epoch_js_timeouts(conn, start, end, duration_seconds),
+        "pool_config": detect_pool_config(conn, start, end),
+    }
+
+
+_ERROR_LEVELS = ("error", "critical")
+
+
+def _attach_epoch_ratios(epoch: dict, analysis: dict, total_requests: int) -> None:
+    """Attach error/warning/5xx ratio metrics to ``epoch`` in place.
+
+    Crash-bounce epochs and epochs with zero traffic get ``None`` ratios —
+    dividing by zero requests would be meaningless, not zero.
+    """
+    if epoch["is_crash_bounce"] or total_requests == 0:
+        epoch["error_ratio"] = None
+        epoch["warning_ratio"] = None
+        epoch["5xx_ratio"] = None
+        return
+
+    error_count = sum(
+        e["count"] for e in analysis["errors"] if e["level"] in _ERROR_LEVELS
+    )
+    warning_count = sum(
+        e["count"] for e in analysis["errors"] if e["level"] == "warning"
+    )
+    epoch["error_ratio"] = error_count / total_requests
+    epoch["warning_ratio"] = warning_count / total_requests
+    epoch["5xx_ratio"] = analysis["haproxy"]["count_5xx"] / total_requests
+
+
+def _analyse_epochs(
+    conn: sqlite3.Connection,
+    epochs: list[dict],
+) -> list[dict]:
+    """Run per-epoch queries and attach ratio metrics to each epoch dict."""
     epoch_analyses: list[dict] = []
     for epoch in epochs:
         start = str(epoch["start_utc"])
         end = str(epoch["end_utc"])
         dur_raw = epoch["duration_seconds"]
         dur = dur_raw if isinstance(dur_raw, float) else float(str(dur_raw))
-        pool_config = detect_pool_config(conn, start, end)
-        analysis = {
-            "errors": query_epoch_errors(conn, start, end, dur),
-            "haproxy": query_epoch_haproxy(conn, start, end, dur),
-            "resources": query_epoch_resources(conn, start, end),
-            "pg": query_epoch_pg(conn, start, end),
-            "journal_anomalies": query_epoch_journal_anomalies(conn, start, end),
-            "users": query_epoch_users(conn, start, end),
-            "js_timeouts": query_epoch_js_timeouts(
-                conn,
-                start,
-                end,
-                dur,
-            ),
-            "pool_config": pool_config,
-        }
+
+        analysis = _run_epoch_queries(conn, start, end, dur)
+        pool_config = analysis["pool_config"]
         total_requests = analysis["haproxy"]["total_requests"]
-        if epoch["is_crash_bounce"] or total_requests == 0:
-            epoch["error_ratio"] = None
-            epoch["warning_ratio"] = None
-            epoch["5xx_ratio"] = None
-        else:
-            error_count = sum(
-                e["count"]
-                for e in analysis["errors"]
-                if e["level"] in ("error", "critical")
-            )
-            warning_count = sum(
-                e["count"] for e in analysis["errors"] if e["level"] == "warning"
-            )
-            epoch["error_ratio"] = error_count / total_requests
-            epoch["warning_ratio"] = warning_count / total_requests
-            epoch["5xx_ratio"] = analysis["haproxy"]["count_5xx"] / total_requests
+
+        _attach_epoch_ratios(epoch, analysis, total_requests)
+
         epoch["total_requests"] = total_requests
         epoch["mean_cpu"] = analysis["resources"].get("mean_cpu")
         epoch["active_users"] = analysis["users"]["active_users"]
@@ -346,7 +362,7 @@ def _detect_github_repo() -> str:
 
 
 @app.command()
-def github(
+def github(  # noqa: PLR0913, PLR0917 -- Typer CLI options, one per flag by design
     start: str = typer.Option(..., help="Window start (local time, YYYY-MM-DD HH:MM)"),
     end: str = typer.Option(..., help="Window end (local time, YYYY-MM-DD HH:MM)"),
     repo: str = typer.Option(
@@ -459,6 +475,7 @@ def review(
 ) -> None:
     """Generate operational review report."""
     from scripts.incident.analysis import (
+        ReportData,
         compute_error_landscape,
         compute_trends,
         enrich_epochs_github,
@@ -513,12 +530,14 @@ def review(
             )
 
     report = render_review_report(
-        sources_data,
-        epochs,
-        epoch_analyses,
-        summative,
-        trends_data,
-        static_counts=static_counts,
+        ReportData(
+            sources=sources_data,
+            epochs=epochs,
+            epoch_analyses=epoch_analyses,
+            summative_users=summative,
+            trends=trends_data,
+            static_counts=static_counts,
+        )
     )
 
     if output:

--- a/scripts/jsonl_to_md.py
+++ b/scripts/jsonl_to_md.py
@@ -11,6 +11,13 @@ import json
 import sys
 from pathlib import Path
 
+# Tool-result content longer than this is elided for readability.
+_TOOL_RESULT_TRUNCATE_CHARS = 500
+# argv layouts: script alone is invalid; script+input is stdout;
+# script+input+output writes a file.
+_MIN_ARGV_WITH_INPUT = 2
+_MIN_ARGV_WITH_OUTPUT = 3
+
 
 def _format_tool_use(tool_name: str, tool_input: dict) -> str:
     """Format a tool use block compactly."""
@@ -52,8 +59,8 @@ def _format_block(block: dict) -> str | None:
             )
         case "tool_result":
             content = block.get("content", "")
-            if isinstance(content, str) and len(content) > 500:
-                content = content[:500] + "\n... (truncated)"
+            if isinstance(content, str) and len(content) > _TOOL_RESULT_TRUNCATE_CHARS:
+                content = content[:_TOOL_RESULT_TRUNCATE_CHARS] + "\n... (truncated)"
             if content:
                 return f"```\n{content}\n```"
     return None
@@ -65,54 +72,66 @@ def extract_text_content(content_list: list) -> str:
     return "\n\n".join(p for p in parts if p)
 
 
+def _parse_jsonl_line(raw_line: str) -> dict | None:
+    """Parse one JSONL line into a record dict; None if blank or invalid JSON."""
+    stripped = raw_line.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def _record_to_markdown_section(record: dict) -> str | None:
+    """Render one parsed transcript record as a markdown section.
+
+    Returns None for records that aren't a renderable user/assistant turn
+    (progress records, file-history-snapshot, empty or non-text content).
+    """
+    record_type = record.get("type")
+    if record_type not in ("user", "assistant"):
+        return None
+
+    message = record.get("message", {})
+    role = message.get("role", record_type)
+    content = message.get("content", [])
+
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = extract_text_content(content)
+    else:
+        return None
+
+    if not text.strip():
+        return None
+
+    if role == "user":
+        return f"## User\n\n{text}\n"
+    if role == "assistant":
+        return f"## Assistant\n\n{text}\n"
+    return None
+
+
 def convert_jsonl_to_md(jsonl_path: Path) -> str:
     """Convert JSONL transcript to markdown."""
-    lines = []
-    lines.append(f"# Conversation: {jsonl_path.stem}\n")
+    lines = [f"# Conversation: {jsonl_path.stem}\n"]
 
     with jsonl_path.open() as f:
         for raw_line in f:
-            stripped = raw_line.strip()
-            if not stripped:
+            record = _parse_jsonl_line(raw_line)
+            if record is None:
                 continue
-
-            try:
-                record = json.loads(stripped)
-            except json.JSONDecodeError:
-                continue
-
-            record_type = record.get("type")
-            message = record.get("message", {})
-
-            # Skip non-message records (progress, file-history-snapshot, etc.)
-            if record_type not in ("user", "assistant"):
-                continue
-
-            role = message.get("role", record_type)
-            content = message.get("content", [])
-
-            # Handle string content (simple user messages)
-            if isinstance(content, str):
-                text = content
-            elif isinstance(content, list):
-                text = extract_text_content(content)
-            else:
-                continue
-
-            if not text.strip():
-                continue
-
-            # Format as markdown
-            if role == "user":
-                lines.append(f"## User\n\n{text}\n")
-            elif role == "assistant":
-                lines.append(f"## Assistant\n\n{text}\n")
+            section = _record_to_markdown_section(record)
+            if section is not None:
+                lines.append(section)
 
     return "\n".join(lines)
 
 
 def main():
-    if len(sys.argv) < 2:
+    if len(sys.argv) < _MIN_ARGV_WITH_INPUT:
         print(__doc__, file=sys.stderr)
         sys.exit(1)
 
@@ -123,7 +142,7 @@ def main():
 
     md_content = convert_jsonl_to_md(input_path)
 
-    if len(sys.argv) >= 3:
+    if len(sys.argv) >= _MIN_ARGV_WITH_OUTPUT:
         output_path = Path(sys.argv[2])
         output_path.write_text(md_content)
         print(f"Written to {output_path}", file=sys.stderr)

--- a/scripts/profile_workspace.py
+++ b/scripts/profile_workspace.py
@@ -36,6 +36,7 @@ import json
 import statistics
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,12 @@ from playwright.sync_api import Page, sync_playwright
 from promptgrimoire.docs.helpers import select_chars
 
 app = typer.Typer(help="Profile annotation page load and interaction latency.")
+
+# Fewer than this many text nodes means the document didn't render enough
+# content to meaningfully measure selection/highlight interaction latency.
+_MIN_TEXT_NODES_FOR_INTERACTION = 10
+# statistics.stdev requires at least two data points.
+_MIN_VALUES_FOR_STDEV = 2
 
 # JavaScript to inject before navigation that sets up LCP observation.
 # LCP is reported asynchronously via PerformanceObserver -- we stash
@@ -242,7 +249,7 @@ def _measure_interactions(
     text_nodes_count = page.evaluate(
         "() => window._textNodes ? window._textNodes.length : 0"
     )
-    if text_nodes_count < 10:
+    if text_nodes_count < _MIN_TEXT_NODES_FOR_INTERACTION:
         results["error"] = "not enough text nodes"
         return results
 
@@ -312,7 +319,7 @@ def _compute_stats(
         "mean": round(statistics.mean(values), 1),
         "median": round(statistics.median(values), 1),
     }
-    if len(values) >= 2:
+    if len(values) >= _MIN_VALUES_FOR_STDEV:
         result["stdev"] = round(statistics.stdev(values), 1)
     return result
 
@@ -399,14 +406,20 @@ def _print_summary(summary: dict[str, Any], label: str = "PAGE LOAD") -> None:
     print(f"{'=' * 70}\n")
 
 
+@dataclass(frozen=True, slots=True)
+class _IterationConfig:
+    """Parameters held constant across every profiling iteration of one run."""
+
+    server_url: str
+    workspace_url: str
+    total_iterations: int
+    measure_interactions: bool
+
+
 def _run_single_iteration(
     browser: Any,
-    server_url: str,
-    workspace_url: str,
-    *,
+    config: _IterationConfig,
     iteration: int,
-    total_iterations: int,
-    measure_interactions: bool,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     """Run a single profiling iteration.
 
@@ -416,20 +429,20 @@ def _run_single_iteration(
     page = context.new_page()
 
     print(
-        f"  Iteration {iteration + 1}/{total_iterations}...",
+        f"  Iteration {iteration + 1}/{config.total_iterations}...",
         end="",
         flush=True,
     )
 
-    _authenticate(page, server_url)
-    result = _measure_page_load(page, workspace_url, iteration=iteration)
+    _authenticate(page, config.server_url)
+    result = _measure_page_load(page, config.workspace_url, iteration=iteration)
 
     total = result["timing"]["wallClockTotalMs"]
     ready = "ready" if result["walkerReady"] else "TIMEOUT"
     print(f" {total}ms [{ready}]", end="")
 
     interaction = None
-    if measure_interactions and result["walkerReady"]:
+    if config.measure_interactions and result["walkerReady"]:
         interaction = _measure_interactions(page, iteration=iteration)
         if "highlightMenuMs" in interaction:
             print(f" menu={interaction['highlightMenuMs']}ms", end="")
@@ -458,19 +471,18 @@ def _run_profiling(
     """
     load_results: list[dict[str, Any]] = []
     interaction_results: list[dict[str, Any]] = []
+    config = _IterationConfig(
+        server_url=server_url,
+        workspace_url=workspace_url,
+        total_iterations=iterations,
+        measure_interactions=measure_interactions,
+    )
 
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=not headed)
 
         for i in range(iterations):
-            result, interaction = _run_single_iteration(
-                browser,
-                server_url,
-                workspace_url,
-                iteration=i,
-                total_iterations=iterations,
-                measure_interactions=measure_interactions,
-            )
+            result, interaction = _run_single_iteration(browser, config, i)
             load_results.append(result)
             if interaction is not None:
                 interaction_results.append(interaction)
@@ -510,7 +522,7 @@ def _emit_results(
 
 
 @app.command()
-def profile(
+def profile(  # noqa: PLR0913, PLR0917 -- Typer CLI options, one per flag by design
     url: str = typer.Option(..., help="Server URL (e.g. http://localhost:8080)"),
     workspace_id: str = typer.Option(..., help="UUID of the workspace to profile"),
     iterations: int = typer.Option(5, help="Number of page load iterations"),

--- a/scripts/save_clipboard_fixture.py
+++ b/scripts/save_clipboard_fixture.py
@@ -23,6 +23,9 @@ from pathlib import Path
 
 FIXTURES_DIR = Path(__file__).parent.parent / "tests" / "fixtures" / "conversations"
 
+# argv[0] is the script path; a fixture name is the minimum required arg.
+_MIN_ARGV_WITH_NAME = 2
+
 LOREM_WORDS = [
     "lorem",
     "ipsum",
@@ -146,7 +149,7 @@ def get_clipboard() -> str:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
+    if len(sys.argv) < _MIN_ARGV_WITH_NAME:
         print("Usage: save_clipboard_fixture.py <name> [--lipsum]")
         print("  e.g., save_clipboard_fixture.py claude --lipsum")
         sys.exit(1)

--- a/src/promptgrimoire/__init__.py
+++ b/src/promptgrimoire/__init__.py
@@ -254,7 +254,7 @@ def _install_session_identity_tracing() -> None:
 
         return await _original_dispatch(self, request, _logging_call_next)
 
-    RequestTrackingMiddleware.dispatch = _instrumented_dispatch  # ty: ignore[invalid-assignment]
+    RequestTrackingMiddleware.dispatch = _instrumented_dispatch
     log.info("session_identity_tracing_installed")
 
 

--- a/src/promptgrimoire/annotation_core.py
+++ b/src/promptgrimoire/annotation_core.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from promptgrimoire.crdt.annotation_doc import AnnotationDocument
+    from promptgrimoire.db.models import Tag
 
 _TEXT_PREVIEW_LIMIT = 80
 _DEFAULT_COLOUR = "#999999"
@@ -109,29 +110,26 @@ async def workspace_tags(workspace_id: UUID) -> list[TagInfo]:
     # matches toolbar display order.  Ungrouped tags sort last.
     max_order = float("inf")
 
-    def _sort_key(tag: object) -> tuple[float, int]:
-        # tag is always a Tag SQLModel instance; typed as object to satisfy
-        # sorted()'s homogeneous key-callable signature without a runtime import.
-        grp = group_map.get(tag.group_id) if tag.group_id else None  # type: ignore[attr-defined]  -- see above
-        return (grp.order_index if grp else max_order, tag.order_index)  # type: ignore[attr-defined, return-value]  -- see above
+    def _sort_key(tag: Tag) -> tuple[float, int]:
+        grp = group_map.get(tag.group_id) if tag.group_id else None
+        return (grp.order_index if grp else max_order, tag.order_index)
 
     sorted_tags = sorted(tags, key=_sort_key)
 
-    return [
-        TagInfo(
-            name=tag.name,
-            colour=tag.color,
-            raw_key=str(tag.id),
-            group_name=group_map[tag.group_id].name
-            if tag.group_id in group_map
-            else None,
-            group_colour=group_map[tag.group_id].color
-            if tag.group_id in group_map
-            else None,
-            description=tag.description,
+    result: list[TagInfo] = []
+    for tag in sorted_tags:
+        grp = group_map.get(tag.group_id) if tag.group_id else None
+        result.append(
+            TagInfo(
+                name=tag.name,
+                colour=tag.color,
+                raw_key=str(tag.id),
+                group_name=grp.name if grp else None,
+                group_colour=grp.color if grp else None,
+                description=tag.description,
+            )
         )
-        for tag in sorted_tags
-    ]
+    return result
 
 
 def author_initials(name: str) -> str:
@@ -164,10 +162,11 @@ def group_highlights_by_tag(
     return by_tag
 
 
-def serialise_items(
+def serialise_items(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     highlights: list[dict[str, Any]],
     tag_info_map: dict[str, TagInfo],
     tag_colours: dict[str, str],
+    *,
     user_id: str | None,
     viewer_is_privileged: bool,
     privileged_user_ids: frozenset[str],

--- a/src/promptgrimoire/auth/anonymise.py
+++ b/src/promptgrimoire/auth/anonymise.py
@@ -33,12 +33,13 @@ def _adjective_animal_label(user_id: str) -> str:
     return slug.replace("-", " ").title()
 
 
-def anonymise_author(
+def anonymise_author(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     author: str,
     user_id: str | None,
     viewing_user_id: str | None,
     anonymous_sharing: bool,
     viewer_is_privileged: bool,
+    *,
     author_is_privileged: bool = False,
 ) -> str:
     """Return the display name for an annotation author.

--- a/src/promptgrimoire/cli/admin.py
+++ b/src/promptgrimoire/cli/admin.py
@@ -290,7 +290,7 @@ async def _cmd_ban(
                     json={"user_id": str(user.id)},
                     headers={"Authorization": f"Bearer {secret}"},
                 )
-                if resp.status_code != 200:
+                if resp.status_code != httpx.codes.OK:
                     con.print(
                         f"[green]Banned[/] '{email}'. "
                         f"[yellow]Warning:[/] kick endpoint returned "
@@ -398,7 +398,7 @@ async def _cmd_duplicates(
     con.print("[yellow]Automated deletion is unsafe — review each case manually.[/]")
 
 
-async def _cmd_enroll_bulk(
+async def _cmd_enroll_bulk(  # noqa: PLR0913 -- mirrors Typer CLI options, one per flag by design
     xlsx_file: Path,
     code: str,
     semester: str,

--- a/src/promptgrimoire/cli/e2e/__init__.py
+++ b/src/promptgrimoire/cli/e2e/__init__.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import time
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
@@ -51,6 +52,21 @@ def _apply_e2e_resource_policy() -> None:
 
 _PLAYWRIGHT_TEST_PATH = str(PLAYWRIGHT_LANE.test_paths[0])
 _perf_lock_files: list[TextIO] = []
+_QUIET_LOAD_SAMPLES_REQUIRED = 4
+_PYTEST_NO_TESTS_COLLECTED = 5
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PlaywrightRunOptions:
+    """Runtime knobs for one Playwright pytest invocation against a managed server."""
+
+    use_pyspy: bool = False
+    worker_count: int = 1
+    fail_fast: bool = False
+    browser: str | None = None
+    marker_expr: str = PLAYWRIGHT_DEFAULT_MARKER_EXPR
+    test_timeout: int | None = None
+    log_file: Path | None = None
 
 
 def _playwright_worker_count() -> int:
@@ -82,13 +98,14 @@ def _wait_for_idle_perf_host() -> None:
 
     limit = float(os.environ.get("E2E_PERF_MAX_LOAD", "4"))
     quiet_samples = 0
-    while quiet_samples < 4:
+    while quiet_samples < _QUIET_LOAD_SAMPLES_REQUIRED:
         load_1m = os.getloadavg()[0]
         quiet_samples = quiet_samples + 1 if load_1m <= limit else 0
-        if quiet_samples == 4:
+        if quiet_samples == _QUIET_LOAD_SAMPLES_REQUIRED:
             return
         console.print(
-            f"[yellow]Host load {load_1m:.1f}; need {4 - quiet_samples} more "
+            f"[yellow]Host load {load_1m:.1f}; need "
+            f"{_QUIET_LOAD_SAMPLES_REQUIRED - quiet_samples} more "
             f"quiet sample(s) at ≤{limit:.1f}. Waiting 15s...[/]"
         )
         time.sleep(15)
@@ -162,18 +179,19 @@ def run_playwright_lane(
     if parallel:
         return _run_shared_playwright_e2e(
             user_args,
-            use_pyspy=py_spy,
-            worker_count=_playwright_worker_count(),
-            fail_fast=fail_fast,
-            browser=browser,
+            PlaywrightRunOptions(
+                use_pyspy=py_spy,
+                worker_count=_playwright_worker_count(),
+                fail_fast=fail_fast,
+                browser=browser,
+            ),
         )
 
     return _run_shared_playwright_e2e(
         user_args,
-        use_pyspy=py_spy,
-        worker_count=1,
-        fail_fast=fail_fast,
-        browser=browser,
+        PlaywrightRunOptions(
+            use_pyspy=py_spy, worker_count=1, fail_fast=fail_fast, browser=browser
+        ),
     )
 
 
@@ -350,7 +368,7 @@ def _run_all_lane_steps(user_args: list[str]) -> list[LaneResult]:
         extra_args=user_args,
     )
     # Exit code 5 = no tests collected — legitimate for optional lanes
-    if extra_exit == 5:
+    if extra_exit == _PYTEST_NO_TESTS_COLLECTED:
         extra_exit = 0
     lane_results.append(LaneResult("blns+extra", extra_exit, log_path=extra_log))
 
@@ -372,7 +390,7 @@ def run_all_lanes(user_args: list[str]) -> int:
 
 def _normalise_optional_lane_exit(exit_code: int, user_args: list[str]) -> int:
     """Treat filtered no-test outcomes as non-fatal for umbrella commands."""
-    return 0 if user_args and exit_code == 5 else exit_code
+    return 0 if user_args and exit_code == _PYTEST_NO_TESTS_COLLECTED else exit_code
 
 
 def _run_latexmk_full_suite(user_args: list[str]) -> int:
@@ -416,10 +434,11 @@ def run_slow_lanes(user_args: list[str]) -> int:
         pw_latexmk_exit = _normalise_optional_lane_exit(
             _run_serial_playwright_e2e(
                 user_args,
-                use_pyspy=False,
-                marker_expr=PLAYWRIGHT_SLOW_MARKER_EXPR,
-                test_timeout=120,
-                log_file=pw_latexmk_log,
+                PlaywrightRunOptions(
+                    marker_expr=PLAYWRIGHT_SLOW_MARKER_EXPR,
+                    test_timeout=120,
+                    log_file=pw_latexmk_log,
+                ),
             ),
             user_args,
         )
@@ -459,7 +478,11 @@ def run_slow_lanes(user_args: list[str]) -> int:
         "allow_interspersed_args": False,
     },
 )
-def run(
+# PLR0913/PLR0917 (too many arguments): each parameter is an independent
+# Typer CLI flag with its own --help text; Typer maps one Python parameter
+# per flag, so there is no param-object form to bundle these into without
+# adopting a codebase-wide Typer pattern this project doesn't otherwise use.
+def run(  # noqa: PLR0913, PLR0917
     ctx: typer.Context,
     serial: bool = typer.Option(
         False, "--serial", help="Run in serial mode (single server)"
@@ -516,7 +539,9 @@ def _check_firefox_installed(exit_code: int) -> None:
         "allow_interspersed_args": False,
     },
 )
-def firefox(
+# PLR0913/PLR0917: same Typer CLI flag surface as `run` above -- see the
+# comment on that command's suppression.
+def firefox(  # noqa: PLR0913, PLR0917
     ctx: typer.Context,
     serial: bool = typer.Option(
         False, "--serial", help="Run in serial mode (single server)"
@@ -769,10 +794,11 @@ def latexmk(
     try:
         exit_code = _run_serial_playwright_e2e(
             args,
-            use_pyspy=False,
-            marker_expr=PLAYWRIGHT_SLOW_MARKER_EXPR,
-            test_timeout=120,
-            log_file=Path("test-playwright-latexmk.log"),
+            PlaywrightRunOptions(
+                marker_expr=PLAYWRIGHT_SLOW_MARKER_EXPR,
+                test_timeout=120,
+                log_file=Path("test-playwright-latexmk.log"),
+            ),
         )
     finally:
         if previous_skip_latexmk is None:
@@ -974,14 +1000,7 @@ def _clear_lastfailed_cache() -> None:
 
 def _run_shared_playwright_e2e(
     extra_args: list[str],
-    *,
-    use_pyspy: bool,
-    worker_count: int,
-    fail_fast: bool = False,
-    browser: str | None = None,
-    marker_expr: str = PLAYWRIGHT_DEFAULT_MARKER_EXPR,
-    test_timeout: int | None = None,
-    log_file: Path | None = None,
+    options: PlaywrightRunOptions,
 ) -> int:
     """Run concurrent Playwright clients against one server and database."""
     from promptgrimoire.config import get_settings
@@ -992,7 +1011,7 @@ def _run_shared_playwright_e2e(
     # never failures cached by an earlier lane.
     _clear_lastfailed_cache()
 
-    if use_pyspy:
+    if options.use_pyspy:
         _check_ptrace_scope()
 
     _pre_test_db_cleanup()
@@ -1004,37 +1023,39 @@ def _run_shared_playwright_e2e(
     console.print(f"[green]Server ready at {url}[/]")
 
     os.environ["E2E_BASE_URL"] = url
-    if worker_count > 1:
+    if options.worker_count > 1:
         os.environ["E2E_SHARED_SERVER"] = "1"
 
     pyspy_process: subprocess.Popen[bytes] | None = None
-    if use_pyspy:
+    if options.use_pyspy:
         pyspy_process = _start_pyspy(server_process.pid)
 
     default_args = [
         "-m",
-        marker_expr,
+        options.marker_expr,
         "--ff",
         "-v",
         "--tb=short",
         "--log-cli-level=WARNING",
     ]
-    if worker_count > 1:
-        default_args += ["-n", str(worker_count), "--dist", "loadscope"]
-    if fail_fast:
+    if options.worker_count > 1:
+        default_args += ["-n", str(options.worker_count), "--dist", "loadscope"]
+    if options.fail_fast:
         default_args.append("-x")
-    if test_timeout is not None:
-        default_args += ["--timeout", str(test_timeout)]
-    if browser is not None:
-        default_args += ["--browser", browser]
+    if options.test_timeout is not None:
+        default_args += ["--timeout", str(options.test_timeout)]
+    if options.browser is not None:
+        default_args += ["--browser", options.browser]
     if not _has_test_path(extra_args):
         default_args.insert(0, _PLAYWRIGHT_TEST_PATH)
 
     exit_code = 1
     try:
-        log_path = log_file or Path("test-e2e.log")
+        log_path = options.log_file or Path("test-e2e.log")
         exit_code = _run_pytest(
-            title=(f"Playwright Test Suite ({worker_count} clients) — server {url}"),
+            title=(
+                f"Playwright Test Suite ({options.worker_count} clients) — server {url}"
+            ),
             log_path=log_path,
             default_args=default_args,
             extra_args=extra_args,
@@ -1052,20 +1073,7 @@ def _run_shared_playwright_e2e(
 
 def _run_serial_playwright_e2e(
     extra_args: list[str],
-    *,
-    use_pyspy: bool,
-    browser: str | None = None,
-    marker_expr: str = PLAYWRIGHT_DEFAULT_MARKER_EXPR,
-    test_timeout: int | None = None,
-    log_file: Path | None = None,
+    options: PlaywrightRunOptions,
 ) -> int:
     """Run Playwright tests against one server with one pytest worker."""
-    return _run_shared_playwright_e2e(
-        extra_args,
-        use_pyspy=use_pyspy,
-        worker_count=1,
-        browser=browser,
-        marker_expr=marker_expr,
-        test_timeout=test_timeout,
-        log_file=log_file,
-    )
+    return _run_shared_playwright_e2e(extra_args, replace(options, worker_count=1))

--- a/src/promptgrimoire/cli/e2e/_artifacts.py
+++ b/src/promptgrimoire/cli/e2e/_artifacts.py
@@ -61,7 +61,7 @@ def write_worker_metadata(
     return worker_json
 
 
-def write_summary_metadata(
+def write_summary_metadata(  # noqa: PLR0913 -- E2E-harness metadata writer, kw-only args; param-object migration: tracker ledger 8
     run_dir: Path,
     lane_name: str,
     results: list[WorkerResult],

--- a/src/promptgrimoire/cli/e2e/_parallel.py
+++ b/src/promptgrimoire/cli/e2e/_parallel.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 import shutil
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,38 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 _POSTGRES_IDENTIFIER_MAX_BYTES = 63
+
+
+@dataclass(frozen=True, slots=True)
+class LaneRunContext:
+    """Constants shared by every worker dispatched within one lane run."""
+
+    lane: LaneSpec
+    worker: Callable[..., Awaitable[WorkerResult]]
+    user_args: list[str]
+    browser: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerFleet:
+    """Per-file collections threaded through parallel lane orchestration.
+
+    ``files[i]`` pairs positionally with ``ports[i]`` and ``worker_dbs[i]``;
+    ``worker_dirs`` is keyed by file path.
+    """
+
+    files: list[Path]
+    ports: list[int]
+    worker_dbs: list[tuple[str, str]]
+    worker_dirs: dict[Path, Path]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceDatabase:
+    """The template database a lane run clones per-worker databases from."""
+
+    url: str
+    name: str
 
 
 def _drop_database_with_debug(db_url: str, *, context: str) -> None:
@@ -93,7 +126,15 @@ def _all_results_passed(results: list[WorkerResult]) -> bool:
     return len(results) > 0 and all(result.exit_code in (0, 5) for result in results)
 
 
-async def _run_worker_for_lane(
+# PLR0913 (too many arguments): every keyword here is part of the
+# `run_worker_for_lane` callback contract that `_retry.py::
+# retry_failed_files_in_isolation` invokes by this exact keyword shape
+# (see test_retry_forwards_browser_to_run_worker_for_lane in
+# tests/unit/test_cli_e2e_runner.py) -- `_retry.py` is owned by a different
+# workstream in this cleanup, so its calling convention is not renegotiable
+# here. Bundling these into a param object would have to happen on both
+# sides at once.
+async def _run_worker_for_lane(  # noqa: PLR0913
     lane: LaneSpec,
     worker: Callable[..., Awaitable[WorkerResult]],
     *,
@@ -121,51 +162,45 @@ async def _run_worker_for_lane(
 
 
 async def _run_all_workers(
-    lane: LaneSpec,
-    worker: Callable[..., Awaitable[WorkerResult]],
-    files: list[Path],
-    ports: list[int],
-    worker_dbs: list[tuple[str, str]],
-    worker_dirs: dict[Path, Path],
-    user_args: list[str],
+    ctx: LaneRunContext,
+    fleet: WorkerFleet,
     *,
     worker_count: int,
-    browser: str | None = None,
 ) -> list[WorkerResult]:
     """Run all lane workers with bounded concurrency and per-file progress."""
-    total = len(files)
+    total = len(fleet.files)
     results: list[WorkerResult] = []
     semaphore = asyncio.Semaphore(worker_count)
 
     async def _tracked_worker(i: int) -> WorkerResult:
         async with semaphore:
             return await _run_worker_for_lane(
-                lane,
-                worker,
-                test_file=files[i],
-                db_url=worker_dbs[i][0],
-                worker_dir=worker_dirs[files[i]],
-                user_args=user_args,
-                port=ports[i] if lane.needs_server else None,
-                browser=browser,
+                ctx.lane,
+                ctx.worker,
+                test_file=fleet.files[i],
+                db_url=fleet.worker_dbs[i][0],
+                worker_dir=fleet.worker_dirs[fleet.files[i]],
+                user_args=ctx.user_args,
+                port=fleet.ports[i] if ctx.lane.needs_server else None,
+                browser=ctx.browser,
             )
 
     tasks: list[asyncio.Task[WorkerResult]] = [
         asyncio.create_task(_tracked_worker(i), name=f"e2e-{f.stem}")
-        for i, f in enumerate(files)
+        for i, f in enumerate(fleet.files)
     ]
 
     for done_count, future in enumerate(asyncio.as_completed(tasks), 1):
         try:
             result = await future
         except Exception as exc:
-            fpath = _resolve_failed_task_file(tasks, exc, files)
+            fpath = _resolve_failed_task_file(tasks, exc, fleet.files)
             console.print(f"[red]Worker {fpath.name} raised: {exc}[/]")
             result = WorkerResult(
                 file=fpath,
                 exit_code=1,
                 duration_s=0.0,
-                artifact_dir=worker_dirs[fpath],
+                artifact_dir=fleet.worker_dirs[fpath],
             )
 
         results.append(result)
@@ -206,16 +241,10 @@ async def _cancel_and_drain_tasks(
 
 
 async def _run_fail_fast_workers(
-    lane: LaneSpec,
-    worker: Callable[..., Awaitable[WorkerResult]],
-    files: list[Path],
-    ports: list[int],
-    worker_dbs: list[tuple[str, str]],
-    worker_dirs: dict[Path, Path],
-    user_args: list[str],
+    ctx: LaneRunContext,
+    fleet: WorkerFleet,
     *,
     worker_count: int,
-    browser: str | None = None,
 ) -> list[WorkerResult]:
     """Run E2E workers with fail-fast: cancel remaining on first failure."""
     semaphore = asyncio.Semaphore(worker_count)
@@ -223,22 +252,22 @@ async def _run_fail_fast_workers(
     async def _tracked_worker(i: int) -> WorkerResult:
         async with semaphore:
             return await _run_worker_for_lane(
-                lane,
-                worker,
-                test_file=files[i],
-                db_url=worker_dbs[i][0],
-                worker_dir=worker_dirs[files[i]],
-                user_args=user_args,
-                port=ports[i] if lane.needs_server else None,
-                browser=browser,
+                ctx.lane,
+                ctx.worker,
+                test_file=fleet.files[i],
+                db_url=fleet.worker_dbs[i][0],
+                worker_dir=fleet.worker_dirs[fleet.files[i]],
+                user_args=ctx.user_args,
+                port=fleet.ports[i] if ctx.lane.needs_server else None,
+                browser=ctx.browser,
             )
 
     tasks: list[asyncio.Task[WorkerResult]] = [
         asyncio.create_task(_tracked_worker(i), name=f"e2e-{f.stem}")
-        for i, f in enumerate(files)
+        for i, f in enumerate(fleet.files)
     ]
 
-    total = len(files)
+    total = len(fleet.files)
     results: list[WorkerResult] = []
     completed_files: set[Path] = set()
     done_count = 0
@@ -249,13 +278,13 @@ async def _run_fail_fast_workers(
         except asyncio.CancelledError:
             continue
         except Exception as exc:
-            fpath = _resolve_failed_task_file(tasks, exc, files)
+            fpath = _resolve_failed_task_file(tasks, exc, fleet.files)
             console.print(f"[red]Worker {fpath.name} raised: {exc}[/]")
             result = WorkerResult(
                 file=fpath,
                 exit_code=1,
                 duration_s=0.0,
-                artifact_dir=worker_dirs[fpath],
+                artifact_dir=fleet.worker_dirs[fpath],
             )
 
         results.append(result)
@@ -265,7 +294,7 @@ async def _run_fail_fast_workers(
 
         if result.exit_code not in (0, 5):
             cancelled = await _cancel_and_drain_tasks(
-                tasks, completed_files, files, worker_dirs
+                tasks, completed_files, fleet.files, fleet.worker_dirs
             )
             results.extend(cancelled)
             break
@@ -299,8 +328,7 @@ def _advertise_failed_workers(
 def _cleanup_parallel_results(
     all_passed: bool,
     had_flaky: bool,
-    worker_dbs: list[tuple[str, str]],
-    files: list[Path],
+    fleet: WorkerFleet,
     run_dir: Path,
     results: list[WorkerResult],
 ) -> None:
@@ -310,7 +338,8 @@ def _cleanup_parallel_results(
     the rest.  On flaky-pass, preserves the artifact directory but
     drops all databases.
     """
-    file_db_map = dict(zip(files, worker_dbs, strict=False))
+    worker_dbs = fleet.worker_dbs
+    file_db_map = dict(zip(fleet.files, worker_dbs, strict=False))
 
     if all_passed and not had_flaky:
         _drop_all_worker_dbs(worker_dbs, context="parallel result cleanup")
@@ -353,15 +382,10 @@ def _print_retry_summary(
 
 
 async def _retry_parallel_failures(
-    lane: LaneSpec,
-    worker: Callable[..., Awaitable[WorkerResult]],
+    ctx: LaneRunContext,
     failed_results: list[WorkerResult],
-    template_db_url: str,
-    source_db_name: str,
+    source_db: SourceDatabase,
     run_dir: Path,
-    user_args: list[str],
-    *,
-    browser: str | None = None,
 ) -> tuple[list[Path], list[Path]]:
     """Re-run failed E2E files with fresh servers and databases.
 
@@ -376,25 +400,25 @@ async def _retry_parallel_failures(
 
     retry_ports = (
         _allocate_ports(len(failed_results))
-        if lane.needs_server
+        if ctx.lane.needs_server
         else [0] * len(failed_results)
     )
     retry_dbs = _create_worker_databases(
-        template_db_url, source_db_name, len(failed_results), suffix="retry"
+        source_db.url, source_db.name, len(failed_results), suffix="retry"
     )
     failed_files = [result.file for result in failed_results]
 
     try:
         genuine_failures, flaky_files = await retry_failed_files_in_isolation(
-            lane,
-            worker,
+            ctx.lane,
+            ctx.worker,
             failed_files=failed_files,
             result_root=run_dir,
-            user_args=user_args,
+            user_args=ctx.user_args,
             retry_dbs=retry_dbs,
             retry_ports=retry_ports,
             run_worker_for_lane=_run_worker_for_lane,
-            browser=browser,
+            browser=ctx.browser,
         )
         _print_retry_summary(genuine_failures, flaky_files)
         return genuine_failures, flaky_files
@@ -442,16 +466,11 @@ def _create_worker_databases(
 
 
 async def _finalise_parallel_results(
-    lane: LaneSpec,
-    worker: Callable[..., Awaitable[WorkerResult]],
+    ctx: LaneRunContext,
     results: list[WorkerResult],
     wall_start: float,
-    test_db_url: str,
-    source_db_name: str,
+    source_db: SourceDatabase,
     run_dir: Path,
-    user_args: list[str],
-    *,
-    browser: str | None = None,
 ) -> tuple[bool, bool]:
     """Summarise, retry failures, merge JUnit XML.
 
@@ -469,14 +488,7 @@ async def _finalise_parallel_results(
         ]
         if failed_results:
             genuine_failures, flaky_files = await _retry_parallel_failures(
-                lane,
-                worker,
-                failed_results,
-                test_db_url,
-                source_db_name,
-                run_dir,
-                user_args,
-                browser=browser,
+                ctx, failed_results, source_db, run_dir
             )
             # Retries are diagnostic only; preserve the initial failing result.
 
@@ -486,7 +498,7 @@ async def _finalise_parallel_results(
         logger.debug("Failed to merge JUnit XML in %s", run_dir, exc_info=True)
     write_summary_metadata(
         run_dir,
-        lane.name,
+        ctx.lane.name,
         results,
         wall_clock_s=wall_clock,
         flaky_files=flaky_files,
@@ -501,7 +513,15 @@ def _default_worker_count(file_count: int) -> int:
     return max(1, min(file_count, 4, max(1, (os.cpu_count() or 4) // 2)))
 
 
-async def run_lane_files(
+# PLR0913 (6 > 5): this is the public entry point for both the parallel
+# Playwright lane and the NiceGUI lane, called from e2e/__init__.py and
+# tested only via a full monkeypatch replacement (test_cli_e2e_runner.py::
+# test_run_nicegui_e2e_routes_command_to_nicegui_lane) rather than through
+# its real body. Bundling worker_count/fail_fast/browser into a param
+# object would touch this load-bearing signature and its mocked test for a
+# one-argument reduction; left as-is per the harness caution in this
+# cleanup's brief (conservative mechanical extraction only, flag the rest).
+async def run_lane_files(  # noqa: PLR0913
     lane: LaneSpec,
     worker: Callable[..., Awaitable[WorkerResult]],
     *,
@@ -550,6 +570,12 @@ async def run_lane_files(
     console.print(f"  artifacts: {run_dir}")
     console.print(f"  workers:   {bounded_worker_count}  files: {len(files)}")
 
+    ctx = LaneRunContext(lane=lane, worker=worker, user_args=user_args, browser=browser)
+    fleet = WorkerFleet(
+        files=files, ports=ports, worker_dbs=worker_dbs, worker_dirs=worker_dirs
+    )
+    source_db = SourceDatabase(url=test_db_url, name=source_db_name)
+
     wall_start = time.monotonic()
     results: list[WorkerResult] = []
     all_passed = False
@@ -558,46 +584,20 @@ async def run_lane_files(
     try:
         if fail_fast:
             results = await _run_fail_fast_workers(
-                lane,
-                worker,
-                files,
-                ports,
-                worker_dbs,
-                worker_dirs,
-                user_args,
-                worker_count=bounded_worker_count,
-                browser=browser,
+                ctx, fleet, worker_count=bounded_worker_count
             )
         else:
             results = await _run_all_workers(
-                lane,
-                worker,
-                files,
-                ports,
-                worker_dbs,
-                worker_dirs,
-                user_args,
-                worker_count=bounded_worker_count,
-                browser=browser,
+                ctx, fleet, worker_count=bounded_worker_count
             )
 
         all_passed, had_flaky = await _finalise_parallel_results(
-            lane,
-            worker,
-            results,
-            wall_start,
-            test_db_url,
-            source_db_name,
-            run_dir,
-            user_args,
-            browser=browser,
+            ctx, results, wall_start, source_db, run_dir
         )
         return 0 if all_passed else 1
 
     finally:
-        _cleanup_parallel_results(
-            all_passed, had_flaky, worker_dbs, files, run_dir, results
-        )
+        _cleanup_parallel_results(all_passed, had_flaky, fleet, run_dir, results)
 
 
 async def _run_parallel_e2e(

--- a/src/promptgrimoire/cli/e2e/_retry.py
+++ b/src/promptgrimoire/cli/e2e/_retry.py
@@ -93,7 +93,7 @@ def _run_retry_node(node_id: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _record_retry_result(
+def _record_retry_result(  # noqa: PLR0913 -- all-kw-only classification helper; param-object migration: tracker ledger 8
     *,
     index: int,
     total: int,
@@ -180,7 +180,7 @@ def _retry_e2e_tests_in_isolation(
     return 1
 
 
-async def retry_failed_files_in_isolation(
+async def retry_failed_files_in_isolation(  # noqa: PLR0913 -- cross-file callback contract pinned by test_retry_forwards_browser_to_run_worker_for_lane; param-object migration: tracker ledger 8
     lane: LaneSpec,
     worker: Callable[..., Awaitable[WorkerResult]],
     *,

--- a/src/promptgrimoire/cli/e2e/_server_script.py
+++ b/src/promptgrimoire/cli/e2e/_server_script.py
@@ -40,6 +40,64 @@ import threading
 
 _watchdog_logger = structlog.get_logger("e2e.watchdog")
 _watchdog_loop_ref: asyncio.AbstractEventLoop | None = None
+_WATCHDOG_SLOW_THRESHOLD_S = 0.5
+
+
+def _ping_event_loop(
+    loop: asyncio.AbstractEventLoop, *, timeout: float
+) -> tuple[bool, float]:
+    """Schedule a no-op callback on *loop* and time the round trip.
+
+    Returns (responded, elapsed_seconds). May raise RuntimeError if the
+    loop is already closed.
+    """
+    import time
+
+    event = threading.Event()
+    t0 = time.monotonic()
+
+    def _ping():
+        event.set()
+
+    loop.call_soon_threadsafe(_ping)
+    responded = event.wait(timeout=timeout)
+    return responded, time.monotonic() - t0
+
+
+def _dump_watchdog_stacks(dump_path: str) -> None:
+    """Best-effort dump of every thread's stack to *dump_path*."""
+    import sys as _sys
+    import traceback as _tb
+
+    try:
+        import datetime as _dt
+
+        fd = os.open(dump_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+
+        def _w(s):
+            os.write(fd, s.encode())
+
+        _w(f"\n=== BLOCKED at {_dt.datetime.now()} ===\n")
+        frames = _sys._current_frames()
+        _w(f"Threads: {len(frames)}\n")
+        for tid, frame in frames.items():
+            tname = "unknown"
+            for t in threading.enumerate():
+                if t.ident == tid:
+                    tname = t.name
+                    break
+            _w(f"--- {tname} (tid={tid}) ---\n")
+            for entry in _tb.extract_stack(frame):
+                _w(f"  {entry.filename}:{entry.lineno} in {entry.name}: {entry.line}\n")
+        _w("=== END ===\n")
+        os.close(fd)
+    except Exception as exc:
+        try:
+            efd = os.open(dump_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            os.write(efd, f"DUMP FAILED: {exc}\n".encode())
+            os.close(efd)
+        except Exception:
+            pass
 
 
 def _watchdog_loop():
@@ -53,26 +111,13 @@ def _watchdog_loop():
         if loop is None:
             continue
 
-        # Schedule a callback on the event loop and measure how long it takes
-        event = threading.Event()
-        t0 = time.monotonic()
-
-        def _ping():
-            event.set()
-
         try:
-            loop.call_soon_threadsafe(_ping)
+            responded, elapsed = _ping_event_loop(loop, timeout=5.0)
         except RuntimeError:
             _watchdog_logger.warning("WATCHDOG: event loop closed")
             break
 
-        responded = event.wait(timeout=5.0)
-        elapsed = time.monotonic() - t0
-
         if not responded:
-            import sys as _sys
-            import traceback as _tb
-
             _watchdog_logger.warning(
                 "WATCHDOG: event loop DID NOT RESPOND in 5.0s"
                 " — BLOCKED. Dumping stacks to file."
@@ -80,52 +125,8 @@ def _watchdog_loop():
             # Canary: does code after the log message run?
             with open("/tmp/wd-canary.txt", "w") as _f:
                 _f.write("reached")
-            dump_path = "/tmp/watchdog-stacks.log"
-            try:
-                import datetime as _dt
-
-                fd = os.open(
-                    dump_path,
-                    os.O_WRONLY | os.O_CREAT | os.O_APPEND,
-                    0o644,
-                )
-
-                def _w(s):
-                    os.write(fd, s.encode())
-
-                _w(f"\n=== BLOCKED at {_dt.datetime.now()} ===\n")
-                frames = _sys._current_frames()
-                _w(f"Threads: {len(frames)}\n")
-                for tid, frame in frames.items():
-                    tname = "unknown"
-                    for t in threading.enumerate():
-                        if t.ident == tid:
-                            tname = t.name
-                            break
-                    _w(f"--- {tname} (tid={tid}) ---\n")
-                    for entry in _tb.extract_stack(frame):
-                        _w(
-                            f"  {entry.filename}:{entry.lineno}"
-                            f" in {entry.name}:"
-                            f" {entry.line}\n"
-                        )
-                _w("=== END ===\n")
-                os.close(fd)
-            except Exception as exc:
-                try:
-                    efd = os.open(
-                        dump_path,
-                        os.O_WRONLY | os.O_CREAT | os.O_APPEND,
-                        0o644,
-                    )
-                    os.write(
-                        efd,
-                        f"DUMP FAILED: {exc}\n".encode(),
-                    )
-                    os.close(efd)
-                except Exception:
-                    pass
-        elif elapsed > 0.5:
+            _dump_watchdog_stacks("/tmp/watchdog-stacks.log")
+        elif elapsed > _WATCHDOG_SLOW_THRESHOLD_S:
             _watchdog_logger.warning(
                 "WATCHDOG: event loop slow — responded in %.3fs", elapsed
             )
@@ -147,14 +148,25 @@ _wd_thread.start()
 # Set E2E_SKIP_LATEXMK=0 for full PDF compilation (test-e2e-slow).
 if os.environ.get("E2E_SKIP_LATEXMK", "1") == "1":
 
-    async def _compile_latex_noop(tex_path, output_dir=None):
+    async def _compile_latex_noop(
+        tex_path: Path, output_dir: Path | None = None
+    ) -> Path:
         return tex_path
 
     import promptgrimoire.export.pdf as _pdf_mod
     import promptgrimoire.export.pdf_export as _pdf_export_mod
 
-    _pdf_mod.compile_latex = _compile_latex_noop  # type: ignore[assignment]  # intentional monkey-patch
-    _pdf_export_mod.compile_latex = _compile_latex_noop  # type: ignore[assignment]  # intentional monkey-patch
+    # setattr() rather than attribute assignment: ty pins a module-level
+    # `async def`'s inferred attribute type to that specific function
+    # definition, so a same-signature replacement is rejected even though
+    # it is runtime-identical to `_pdf_mod.compile_latex = _compile_latex_noop`.
+    # setattr() isn't attribute-type-checked, so it expresses the same
+    # intentional monkey-patch without a false-positive diagnostic. B010
+    # (ruff's setattr-with-constant-name lint) would "fix" this straight
+    # back to the assignment form ruff and ty disagree on -- suppressed here,
+    # not on a type diagnostic.
+    setattr(_pdf_mod, "compile_latex", _compile_latex_noop)  # noqa: B010
+    setattr(_pdf_export_mod, "compile_latex", _compile_latex_noop)  # noqa: B010
 # --- End monkey-patch ---
 
 from nicegui import app, ui
@@ -168,6 +180,8 @@ if os.environ.get("E2E_INSTRUMENT_OUTBOX") == "1":
     from nicegui.outbox import Outbox as _Outbox
 
     from promptgrimoire.diagnostics import record_load_metric as _record_load_metric
+
+    _LARGE_SEND_THRESHOLD_BYTES = 100_000
 
     _original_enqueue_update = _Outbox.enqueue_update
     _original_emit = _Outbox._emit
@@ -206,7 +220,7 @@ if os.environ.get("E2E_INSTRUMENT_OUTBOX") == "1":
         finally:
             elapsed_ms = round((_time.monotonic() - started) * 1000, 1)
             _record_load_metric("engineio_websocket_send_ms", elapsed_ms)
-            if size >= 100_000:
+            if size >= _LARGE_SEND_THRESHOLD_BYTES:
                 _record_load_metric("engineio_large_send_ms", elapsed_ms)
                 _record_load_metric("engineio_large_send_bytes", size)
 
@@ -436,6 +450,9 @@ async def _diagnostics():
     }
 
 
+_QUALNAME_TAIL_SEGMENTS = 2
+
+
 def _task_summary(tasks):
     # Summarise asyncio tasks by coroutine/callback name.
     from collections import Counter
@@ -449,8 +466,12 @@ def _task_summary(tasks):
             name = t.get_name()
         # Keep last two segments for disambiguation (e.g. Event.wait vs
         # websocket_wait) instead of just the final name.
-        parts = name.rsplit(".", 2)
-        name = ".".join(parts[-2:]) if len(parts) >= 2 else name
+        parts = name.rsplit(".", _QUALNAME_TAIL_SEGMENTS)
+        name = (
+            ".".join(parts[-_QUALNAME_TAIL_SEGMENTS:])
+            if len(parts) >= _QUALNAME_TAIL_SEGMENTS
+            else name
+        )
         names.append(name)
     return dict(Counter(names).most_common(10))
 
@@ -464,9 +485,74 @@ def _task_summary(tasks):
 #   clients_only  — force-delete NiceGUI clients + their SIDs only
 #   eio_only      — disconnect orphan engine.io sessions only
 #   events_only   — cancel orphan Event.wait tasks only
+
+
+async def _cleanup_stale_clients() -> tuple[int, int]:
+    """Force-delete stale NiceGUI clients and their socket.io SIDs.
+
+    Returns (deleted, sids_closed).
+    """
+    from nicegui import Client, core
+
+    deleted = 0
+    sids_closed = 0
+    stale_ids = list(Client.instances.keys())
+    for cid in stale_ids:
+        c = Client.instances.get(cid)
+        if c is not None:
+            for sid in list(c._socket_to_document_id.keys()):
+                try:
+                    await core.sio.disconnect(sid)
+                    sids_closed += 1
+                except Exception:
+                    pass
+            c.delete()
+            deleted += 1
+            await asyncio.sleep(0)
+    return deleted, sids_closed
+
+
+async def _cleanup_orphan_eio_sessions() -> int:
+    """Disconnect orphan engine.io sessions (WebSocket receive tasks from
+    connections whose NiceGUI client was already deleted via the normal
+    disconnect→delete_content→delete path).
+
+    Returns eio_closed.
+    """
+    from nicegui import core
+
+    eio_closed = 0
+    for eio_sid in list(core.sio.eio.sockets.keys()):
+        try:
+            await core.sio.eio.disconnect(eio_sid)
+            eio_closed += 1
+        except Exception:
+            pass
+    return eio_closed
+
+
+def _cleanup_orphan_event_waits() -> int:
+    """Cancel orphan Event.wait tasks leaked by NiceGUI's page handler.
+
+    See handle_handshake() which CLEARS _waiting_for_connection (not sets
+    it), leaving the wait() task orphaned. Returns orphan_wait.
+    """
+    from nicegui import background_tasks as _bt
+
+    orphan_wait = 0
+    for t in list(_bt.running_tasks):
+        if not t.done():
+            coro = t.get_coro()
+            qn = getattr(coro, "__qualname__", "") if coro else ""
+            if qn == "Event.wait":
+                t.cancel()
+                orphan_wait += 1
+    return orphan_wait
+
+
 @app.post("/api/test/cleanup")
 async def _cleanup(mode: str = "all"):
-    from nicegui import Client, core
+    from nicegui import Client
 
     _cleanup_logger = structlog.get_logger("e2e.cleanup")
     before = len(Client.instances)
@@ -477,46 +563,14 @@ async def _cleanup(mode: str = "all"):
     eio_closed = 0
     orphan_wait = 0
 
-    # Action 1: Force-delete NiceGUI clients and their socket.io SIDs
     if mode in ("all", "clients_only"):
-        stale_ids = list(Client.instances.keys())
-        for cid in stale_ids:
-            c = Client.instances.get(cid)
-            if c is not None:
-                for sid in list(c._socket_to_document_id.keys()):
-                    try:
-                        await core.sio.disconnect(sid)
-                        sids_closed += 1
-                    except Exception:
-                        pass
-                c.delete()
-                deleted += 1
-                await asyncio.sleep(0)
+        deleted, sids_closed = await _cleanup_stale_clients()
 
-    # Action 2: Disconnect orphan engine.io sessions (WebSocket receive
-    # tasks from connections whose NiceGUI client was already deleted
-    # via the normal disconnect→delete_content→delete path).
     if mode in ("all", "eio_only"):
-        for eio_sid in list(core.sio.eio.sockets.keys()):
-            try:
-                await core.sio.eio.disconnect(eio_sid)
-                eio_closed += 1
-            except Exception:
-                pass
+        eio_closed = await _cleanup_orphan_eio_sessions()
 
-    # Action 3: Cancel orphan Event.wait tasks leaked by NiceGUI's page
-    # handler. See handle_handshake() which CLEARS _waiting_for_connection
-    # (not sets it), leaving the wait() task orphaned.
     if mode in ("all", "events_only"):
-        from nicegui import background_tasks as _bt
-
-        for t in list(_bt.running_tasks):
-            if not t.done():
-                coro = t.get_coro()
-                qn = getattr(coro, "__qualname__", "") if coro else ""
-                if qn == "Event.wait":
-                    t.cancel()
-                    orphan_wait += 1
+        orphan_wait = _cleanup_orphan_event_waits()
 
     await asyncio.sleep(0)  # let cancellations propagate
     elapsed_total = _time.monotonic() - t_total

--- a/src/promptgrimoire/cli/e2e/_workers.py
+++ b/src/promptgrimoire/cli/e2e/_workers.py
@@ -181,7 +181,7 @@ def _build_worker_result(
     return result
 
 
-async def run_playwright_file(
+async def run_playwright_file(  # noqa: PLR0913 -- per-worker E2E entrypoint invoked by the fleet; param-object migration: tracker ledger 8
     test_file: Path,
     port: int,
     db_url: str,

--- a/src/promptgrimoire/cli/export.py
+++ b/src/promptgrimoire/cli/export.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 import tempfile
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
@@ -18,19 +19,9 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
-from sqlmodel import select
+from sqlalchemy import tstring
 
 from promptgrimoire.db.engine import get_session
-from promptgrimoire.db.models import (
-    ACLEntry,
-    Activity,
-    Course,
-    CourseEnrollment,
-    User,
-    Week,
-    Workspace,
-    WorkspaceDocument,
-)
 from promptgrimoire.db.tags import list_tags_for_workspace
 from promptgrimoire.db.workspace_documents import list_documents
 from promptgrimoire.db.workspaces import get_workspace, get_workspace_export_metadata
@@ -263,6 +254,116 @@ def _extract_error_summary(exc: LaTeXCompilationError) -> str:
     return error_summary
 
 
+def _enrich_document_highlights(
+    doc,
+    highlights: list[dict],
+    tag_name_map: dict[str, str],
+) -> list[dict]:
+    """Filter to one document's highlights and enrich each with its tag name."""
+    doc_highlights = [h for h in highlights if h.get("document_id") == str(doc.id)]
+    valid = [hl for hl in doc_highlights if str(hl.get("tag", "")) in tag_name_map]
+    return [
+        {**hl, "tag_name": tag_name_map.get(str(hl.get("tag", "")))} for hl in valid
+    ]
+
+
+def _build_export_document_payload(
+    doc,
+    enriched_highlights: list[dict],
+    fallback_index: int,
+) -> dict:
+    """Build one document's export payload dict."""
+    doc_para_map = doc.paragraph_map
+    legal_para_map: dict[int, int | None] | None = (
+        {int(k): v for k, v in doc_para_map.items()} if doc_para_map else None
+    )
+    return {
+        "title": doc.title or f"Source {fallback_index}",
+        "html_content": doc.content or "",
+        "highlights": enriched_highlights,
+        "word_to_legal_para": legal_para_map,
+    }
+
+
+def _build_export_documents(
+    content_docs: list,
+    highlights: list[dict],
+    tag_name_map: dict[str, str],
+) -> list[dict]:
+    """Assemble per-document export payloads, enriching highlights with tag names."""
+    documents: list[dict] = []
+    for i, doc in enumerate(content_docs, 1):
+        enriched = _enrich_document_highlights(doc, highlights, tag_name_map)
+        documents.append(_build_export_document_payload(doc, enriched, i))
+    return documents
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceExportJob:
+    """A fully-prepared, ready-to-compile single-workspace export."""
+
+    workspace_id: UUID
+    safe_stem: str
+    tag_colours: dict[str, str]
+    notes_latex: str
+    documents: list[dict]
+
+
+async def _compile_workspace_pdf(
+    job: WorkspaceExportJob,
+    output_dir: Path,
+    *,
+    with_log: bool,
+    with_tex: bool,
+) -> tuple[str, str | None]:
+    """Compile one workspace's PDF, copy artifacts, and classify any error.
+
+    Returns (filename_stem, error_or_none).
+    """
+    ws_export_dir = Path(
+        tempfile.mkdtemp(
+            prefix=f"promptgrimoire_export_{str(job.workspace_id)[:8]}_",
+        )
+    )
+
+    try:
+        pdf_path = await export_annotation_pdf(
+            html_content="",
+            highlights=[],
+            tag_colours=job.tag_colours,
+            output_dir=ws_export_dir,
+            filename=job.safe_stem,
+            workspace_id=str(job.workspace_id),
+            notes_latex=job.notes_latex,
+            documents=job.documents,
+        )
+        shutil.copy2(pdf_path, output_dir / pdf_path.name)
+        _copy_artifacts(
+            ws_export_dir,
+            output_dir,
+            job.safe_stem,
+            with_log=with_log,
+            with_tex=with_tex,
+        )
+        return job.safe_stem, None
+
+    except LaTeXCompilationError as exc:
+        _copy_artifacts(
+            ws_export_dir,
+            output_dir,
+            job.safe_stem,
+            with_log=with_log,
+            with_tex=with_tex,
+        )
+        return job.safe_stem, _extract_error_summary(exc)
+
+    except Exception as exc:
+        return job.safe_stem, f"{type(exc).__name__}: {exc}"
+
+    finally:
+        shutil.rmtree(ws_export_dir, ignore_errors=True)
+
+
 async def _export_single_workspace(
     workspace_id: UUID,
     output_dir: Path,
@@ -296,25 +397,7 @@ async def _export_single_workspace(
         highlights = _extract_crdt_highlights(crdt_doc, tags)
 
     tag_name_map = {str(t.id): t.name for t in tags}
-    documents: list[dict] = []
-    for doc in content_docs:
-        doc_highlights = [h for h in highlights if h.get("document_id") == str(doc.id)]
-        valid = [hl for hl in doc_highlights if str(hl.get("tag", "")) in tag_name_map]
-        enriched = [
-            {**hl, "tag_name": tag_name_map.get(str(hl.get("tag", "")))} for hl in valid
-        ]
-        doc_para_map = doc.paragraph_map
-        legal_para_map: dict[int, int | None] | None = (
-            {int(k): v for k, v in doc_para_map.items()} if doc_para_map else None
-        )
-        documents.append(
-            {
-                "title": doc.title or f"Source {len(documents) + 1}",
-                "html_content": doc.content or "",
-                "highlights": enriched,
-                "word_to_legal_para": legal_para_map,
-            }
-        )
+    documents = _build_export_documents(content_docs, highlights, tag_name_map)
 
     has_highlights = any(d["highlights"] for d in documents)
     if not has_highlights:
@@ -324,40 +407,16 @@ async def _export_single_workspace(
     response_md = _extract_response_markdown(crdt_doc) if crdt_doc else ""
     notes_latex = await markdown_to_latex_notes(response_md) if response_md else ""
 
-    ws_export_dir = Path(
-        tempfile.mkdtemp(
-            prefix=f"promptgrimoire_export_{str(workspace_id)[:8]}_",
-        )
+    job = WorkspaceExportJob(
+        workspace_id=workspace_id,
+        safe_stem=safe_stem,
+        tag_colours=tag_colours,
+        notes_latex=notes_latex,
+        documents=documents,
     )
-
-    try:
-        pdf_path = await export_annotation_pdf(
-            html_content="",
-            highlights=[],
-            tag_colours=tag_colours,
-            output_dir=ws_export_dir,
-            filename=safe_stem,
-            workspace_id=str(workspace_id),
-            notes_latex=notes_latex,
-            documents=documents,
-        )
-        shutil.copy2(pdf_path, output_dir / pdf_path.name)
-        _copy_artifacts(
-            ws_export_dir, output_dir, safe_stem, with_log=with_log, with_tex=with_tex
-        )
-        return safe_stem, None
-
-    except LaTeXCompilationError as exc:
-        _copy_artifacts(
-            ws_export_dir, output_dir, safe_stem, with_log=with_log, with_tex=with_tex
-        )
-        return safe_stem, _extract_error_summary(exc)
-
-    except Exception as exc:
-        return safe_stem, f"{type(exc).__name__}: {exc}"
-
-    finally:
-        shutil.rmtree(ws_export_dir, ignore_errors=True)
+    return await _compile_workspace_pdf(
+        job, output_dir, with_log=with_log, with_tex=with_tex
+    )
 
 
 async def _export_single_workspace_tex_only(
@@ -429,37 +488,67 @@ async def _export_single_workspace_tex_only(
 
 
 async def _resolve_scope_workspace_ids(scope: str) -> list[UUID]:
-    """Resolve a --scope value to a list of exportable workspace IDs."""
-    async with get_session() as session:
-        stmt = (
-            select(Workspace.id)
-            .join(
-                WorkspaceDocument,
-                WorkspaceDocument.workspace_id == Workspace.id,  # type: ignore[arg-type]
-            )
-            .where(
-                Workspace.crdt_state.is_not(None),  # type: ignore[union-attr]
-                WorkspaceDocument.content.is_not(None),  # type: ignore[union-attr]
-                WorkspaceDocument.content != "",
-            )
-        )
+    """Resolve a --scope value to a list of exportable workspace IDs.
 
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- SQLModel
+    column expressions in .join()/.where()/.in_() do not type-check under
+    ty (astral-sh/ty#3421). The "exportable" predicate (crdt_state set, a
+    document with non-empty content) is repeated per branch rather than
+    shared, since t-string SQL fragments aren't composable the way
+    SQLAlchemy expression objects were.
+    """
+    async with get_session() as session:
         if scope == "server":
-            pass
+            rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT DISTINCT w.id
+                    FROM workspace w
+                    JOIN workspace_document wd ON wd.workspace_id = w.id
+                    WHERE w.crdt_state IS NOT NULL
+                      AND wd.content IS NOT NULL
+                      AND wd.content != ''
+                    """
+                )
+            )
         elif scope.startswith("unit:"):
             course_id = UUID(scope.removeprefix("unit:"))
-            activity_ids_stmt = (
-                select(Activity.id)
-                .join(Week, Week.id == Activity.week_id)  # type: ignore[arg-type]
-                .where(Week.course_id == course_id)
-            )
-            stmt = stmt.where(
-                (Workspace.course_id == course_id)
-                | Workspace.activity_id.in_(activity_ids_stmt),  # type: ignore[union-attr]
+            rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT DISTINCT w.id
+                    FROM workspace w
+                    JOIN workspace_document wd ON wd.workspace_id = w.id
+                    WHERE w.crdt_state IS NOT NULL
+                      AND wd.content IS NOT NULL
+                      AND wd.content != ''
+                      AND (
+                        w.course_id = {course_id}
+                        OR w.activity_id IN (
+                            SELECT a.id
+                            FROM activity a
+                            JOIN week wk ON wk.id = a.week_id
+                            WHERE wk.course_id = {course_id}
+                        )
+                      )
+                    """
+                )
             )
         elif scope.startswith("activity:"):
             activity_id = UUID(scope.removeprefix("activity:"))
-            stmt = stmt.where(Workspace.activity_id == activity_id)
+            rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT DISTINCT w.id
+                    FROM workspace w
+                    JOIN workspace_document wd ON wd.workspace_id = w.id
+                    WHERE w.crdt_state IS NOT NULL
+                      AND wd.content IS NOT NULL
+                      AND wd.content != ''
+                      AND w.activity_id = {activity_id}
+                    """
+                )
+            )
         else:
             console.print(
                 f"[red]Error:[/] Invalid scope '{scope}'. "
@@ -467,9 +556,7 @@ async def _resolve_scope_workspace_ids(scope: str) -> list[UUID]:
             )
             sys.exit(1)
 
-        stmt = stmt.distinct()
-        result = await session.exec(stmt)
-        return list(result.all())
+        return [row[0] for row in rows.all()]
 
 
 # ---------------------------------------------------------------------------
@@ -553,39 +640,50 @@ async def _resolve_workspace_unit_mapping(
     Uses ACL owner entries for the owner, and course_enrollment for
     unit membership. Multi-enrolled users appear under every unit.
     Users with no enrollment get ["_unenrolled"].
+
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- SQLModel
+    column expressions in .join()/.where()/.in_() do not type-check under
+    ty (astral-sh/ty#3421).
     """
     mapping: dict[UUID, tuple[str, list[str]]] = {}
     async with get_session() as session:
         # workspace -> owner email
-        owner_rows = await session.exec(
-            select(
-                ACLEntry.workspace_id,
-                User.email,
-                User.id,
-            )
-            .join(User, User.id == ACLEntry.user_id)  # type: ignore[arg-type]
-            .where(
-                ACLEntry.workspace_id.in_(workspace_ids),  # type: ignore[union-attr]
-                ACLEntry.permission == "owner",
+        # Row indexing beyond [0] doesn't type-check for raw execute()
+        # results (ty infers `Row[Any]` as length-1); attribute access by
+        # column label does, so every column here is explicitly aliased.
+        owner_rows = await session.execute(
+            tstring(
+                t"""
+                SELECT a.workspace_id AS workspace_id,
+                       u.email AS email,
+                       u.id AS user_id
+                FROM acl_entry a
+                JOIN "user" u ON u.id = a.user_id
+                WHERE a.workspace_id = ANY({workspace_ids})
+                  AND a.permission = 'owner'
+                """
             )
         )
         ws_owner: dict[UUID, tuple[str, UUID]] = {}
-        for ws_id, email, user_id in owner_rows:
-            ws_owner[ws_id] = (email, user_id)
+        for row in owner_rows:
+            ws_owner[row.workspace_id] = (row.email, row.user_id)
 
         # user -> enrolled unit names
-        user_ids = {uid for _, uid in ws_owner.values()}
+        user_ids = list({uid for _, uid in ws_owner.values()})
+        user_units: dict[UUID, list[str]] = {}
         if user_ids:
-            enroll_rows = await session.exec(
-                select(CourseEnrollment.user_id, Course.name)
-                .join(Course, Course.id == CourseEnrollment.course_id)  # type: ignore[arg-type]
-                .where(CourseEnrollment.user_id.in_(user_ids))  # type: ignore[union-attr]
+            enroll_rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT ce.user_id AS user_id, c.name AS unit_name
+                    FROM course_enrollment ce
+                    JOIN course c ON c.id = ce.course_id
+                    WHERE ce.user_id = ANY({user_ids})
+                    """
+                )
             )
-            user_units: dict[UUID, list[str]] = {}
-            for uid, unit_name in enroll_rows:
-                user_units.setdefault(uid, []).append(unit_name)
-        else:
-            user_units = {}
+            for row in enroll_rows:
+                user_units.setdefault(row.user_id, []).append(row.unit_name)
 
         for ws_id in workspace_ids:
             if ws_id in ws_owner:
@@ -603,6 +701,47 @@ def _sanitise_dirname(name: str) -> str:
     return re.sub(r'[<>:"/\\|?*]', "_", name).strip(". ")
 
 
+def _resolve_reorganise_target(
+    result: tuple[str, str, str | None],
+    short_to_full: dict[str, UUID],
+    ws_mapping: dict[UUID, tuple[str, list[str]]],
+    output_dir: Path,
+) -> tuple[str, list[str], list[Path]] | None:
+    """Resolve one export result to (owner_email, units, matching_files).
+
+    Returns None if the result should be skipped (failed, unmapped, or
+    no matching files on disk).
+    """
+    short_id, stem, error = result
+    if error is not None:
+        return None
+    ws_id = short_to_full.get(short_id)
+    if ws_id is None or ws_id not in ws_mapping:
+        return None
+
+    email, units = ws_mapping[ws_id]
+    files = list(output_dir.glob(f"{stem}.*"))
+    if not files:
+        return None
+
+    return email, units, files
+
+
+def _copy_files_to_unit_dirs(
+    files: list[Path],
+    units: list[str],
+    output_dir: Path,
+    safe_email: str,
+) -> None:
+    """Copy exported files into output_dir/<unit>/<email>/ for every unit."""
+    for unit_name in units:
+        safe_unit = _sanitise_dirname(unit_name)
+        dest_dir = output_dir / safe_unit / safe_email
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for f in files:
+            shutil.copy2(f, dest_dir / f.name)
+
+
 def _reorganise_by_unit(
     output_dir: Path,
     results: list[tuple[str, str, str | None]],
@@ -614,27 +753,16 @@ def _reorganise_by_unit(
     short_to_full: dict[str, UUID] = {str(ws_id)[:8]: ws_id for ws_id in workspace_ids}
 
     moved = 0
-    for short_id, stem, error in results:
-        if error is not None:
+    for result in results:
+        target = _resolve_reorganise_target(
+            result, short_to_full, ws_mapping, output_dir
+        )
+        if target is None:
             continue
-        ws_id = short_to_full.get(short_id)
-        if ws_id is None or ws_id not in ws_mapping:
-            continue
+        email, units, files = target
 
-        email, units = ws_mapping[ws_id]
         safe_email = _sanitise_dirname(email)
-
-        # Find all files matching this stem
-        files = list(output_dir.glob(f"{stem}.*"))
-        if not files:
-            continue
-
-        for unit_name in units:
-            safe_unit = _sanitise_dirname(unit_name)
-            dest_dir = output_dir / safe_unit / safe_email
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            for f in files:
-                shutil.copy2(f, dest_dir / f.name)
+        _copy_files_to_unit_dirs(files, units, output_dir, safe_email)
 
         # Remove the flat copies
         for f in files:
@@ -658,16 +786,22 @@ async def _resolve_ids(ids_or_scope: list[UUID] | str) -> list[UUID] | None:
     return workspace_ids
 
 
+@dataclass(frozen=True, slots=True)
+class BatchExportOptions:
+    """Flags controlling one batch export run."""
+
+    with_log: bool = False
+    with_tex: bool = False
+    dry_run: bool = False
+    tex_only: bool = False
+    only_errors: bool = False
+    by_unit: bool = False
+
+
 async def _run_batch_export(
     workspace_ids_or_scope: list[UUID] | str,
     output_dir: Path,
-    *,
-    with_log: bool,
-    with_tex: bool,
-    dry_run: bool,
-    tex_only: bool,
-    only_errors: bool,
-    by_unit: bool = False,
+    options: BatchExportOptions,
 ) -> None:
     """Export multiple workspaces sequentially.
 
@@ -680,7 +814,7 @@ async def _run_batch_export(
         return
     workspace_ids = resolved
 
-    if dry_run:
+    if options.dry_run:
         _print_dry_run(workspace_ids)
         return
 
@@ -690,8 +824,8 @@ async def _run_batch_export(
     output_dir.mkdir(parents=True)
 
     # --only-errors implies --with-log --with-tex for failures
-    effective_with_log = with_log or only_errors
-    effective_with_tex = with_tex or only_errors
+    effective_with_log = options.with_log or options.only_errors
+    effective_with_tex = options.with_tex or options.only_errors
 
     results: list[tuple[str, str, str | None]] = []
     for i, ws_id in enumerate(workspace_ids, 1):
@@ -700,7 +834,7 @@ async def _run_batch_export(
             f"[dim][{i}/{len(workspace_ids)}][/] Exporting {short_id}...",
             end=" ",
         )
-        if tex_only:
+        if options.tex_only:
             stem, error = await _export_single_workspace_tex_only(ws_id, output_dir)
         else:
             stem, error = await _export_single_workspace(
@@ -717,18 +851,18 @@ async def _run_batch_export(
             console.print("[green]OK[/]")
         results.append((short_id, stem, error))
 
-    if only_errors:
+    if options.only_errors:
         _purge_successes(output_dir, results)
 
-    if by_unit:
+    if options.by_unit:
         console.print("\n[bold]Resolving unit/user mapping...[/]")
         ws_mapping = await _resolve_workspace_unit_mapping(workspace_ids)
         _reorganise_by_unit(output_dir, results, ws_mapping, workspace_ids)
 
     _print_results_table(
         results,
-        only_errors=only_errors,
-        tex_only=tex_only,
+        only_errors=options.only_errors,
+        tex_only=options.tex_only,
         output_dir=output_dir,
     )
 
@@ -771,7 +905,11 @@ def _validate_workspace_args(
                 raise typer.Exit(1) from None
         return parsed
 
-    return scope  # type: ignore[return-value]  -- guarded by early exits above
+    # workspace_ids is falsy here. The first guard proved
+    # `workspace_ids or scope`, so scope must be set -- ty can't trace that
+    # cross-branch boolean invariant, hence the explicit assert.
+    assert scope is not None  # noqa: S101 - guarded by early exits above
+    return scope
 
 
 def _build_artifacts_label(
@@ -793,8 +931,13 @@ def _build_artifacts_label(
     return mode
 
 
+# PLR0913/PLR0917 (too many arguments): each parameter is an independent
+# Typer CLI flag with its own --help text; Typer maps one Python parameter
+# per flag, so there is no param-object form to bundle these into without
+# adopting a codebase-wide Typer pattern this project doesn't otherwise use
+# (see the matching noqa on `run`/`firefox` in cli/e2e/__init__.py).
 @export_app.command("run")
-def run(
+def run(  # noqa: PLR0913, PLR0917
     workspace_ids: Annotated[
         list[str] | None,
         typer.Argument(help="Workspace UUIDs to export"),
@@ -880,11 +1023,13 @@ def run(
         _run_batch_export(
             ids_or_scope,
             output,
-            with_log=with_log,
-            with_tex=with_tex,
-            dry_run=dry_run,
-            tex_only=tex_only,
-            only_errors=only_errors,
-            by_unit=by_unit,
+            BatchExportOptions(
+                with_log=with_log,
+                with_tex=with_tex,
+                dry_run=dry_run,
+                tex_only=tex_only,
+                only_errors=only_errors,
+                by_unit=by_unit,
+            ),
         )
     )

--- a/src/promptgrimoire/cli/migrate.py
+++ b/src/promptgrimoire/cli/migrate.py
@@ -161,21 +161,29 @@ async def _backfill_tags(
     """Scan workspaces with tags and backfill CRDT state from DB."""
     from uuid import UUID
 
-    from sqlmodel import select
+    from sqlalchemy import tstring
 
     from promptgrimoire.db.engine import get_session, init_db
-    from promptgrimoire.db.models import Tag, Workspace
+    from promptgrimoire.db.models import Workspace
 
     await init_db()
 
     async with get_session() as session:
-        query = select(Workspace.id).where(
-            Workspace.id.in_(select(Tag.workspace_id).distinct())  # type: ignore[union-attr]  -- Column has .in_()
+        # Query-shaped read migrated to raw SQL per ADR 0004/0005 --
+        # Workspace.id.in_(select(Tag.workspace_id)) does not type-check
+        # under ty (astral-sh/ty#3421).
+        target_id = UUID(single_workspace_id) if single_workspace_id else None
+        rows = await session.execute(
+            tstring(
+                t"""
+                SELECT DISTINCT w.id
+                FROM workspace w
+                WHERE w.id IN (SELECT DISTINCT workspace_id FROM tag)
+                  AND ({target_id}::uuid IS NULL OR w.id = {target_id})
+                """
+            )
         )
-        if single_workspace_id:
-            query = query.where(Workspace.id == UUID(single_workspace_id))
-        result = await session.exec(query)
-        workspace_ids = list(result.all())
+        workspace_ids = [row[0] for row in rows.all()]
 
     if not workspace_ids:
         console.print("[yellow]No workspaces with tags found.[/]")

--- a/src/promptgrimoire/cli/testing.py
+++ b/src/promptgrimoire/cli/testing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -82,6 +83,10 @@ test_app = typer.Typer(
 @test_app.callback()
 def _apply_test_resource_policy() -> None:
     """Apply the inherited resource policy before any test subcommand."""
+    # Help output must never queue on the cross-worktree test lock or the
+    # host-load gate (observed: `test run --help` blocked 70+ minutes).
+    if any(flag in sys.argv for flag in ("--help", "-h")):
+        return
     _configure_test_run_resources()
 
 
@@ -190,6 +195,14 @@ def _handle_running_phase(
 # ---------------------------------------------------------------------------
 
 
+# Pytest prints its second `====` separator when results end and the
+# post-results summary section begins.
+_SUMMARY_SEPARATOR_COUNT = 2
+
+# A structurally valid PDF (header + one page + xref) can't be smaller.
+_MIN_VALID_PDF_BYTES = 1000
+
+
 def _stream_plain(
     process: subprocess.Popen[str],
     log_file: IO[str],
@@ -210,7 +223,7 @@ def _stream_plain(
 
         if not in_summary and _SEPARATOR_RE.match(stripped):
             separator_count += 1
-            if separator_count >= 2:
+            if separator_count >= _SUMMARY_SEPARATOR_COUNT:
                 in_summary = True
 
         if in_summary:
@@ -224,39 +237,42 @@ def _stream_plain(
     return process.returncode
 
 
+@dataclass
+class _ProgressState:
+    """Streaming-phase state threaded through the pytest progress parser."""
+
+    phase: str = "collecting"
+    count: int | None = None
+    done: int = 0
+
+
 def _dispatch_progress_line(
     stripped: str,
     raw_line: str,
-    phase: str,
-    count: int | None,
-    done: int,
+    state: _ProgressState,
     progress: Progress,
     task_id: TaskID,
-) -> tuple[str, int | None, int]:
-    """Dispatch a single line through the phase state machine.
-
-    Returns:
-        (new_phase, new_count, new_done) tuple.
-    """
-    if phase == "summary":
+) -> _ProgressState:
+    """Dispatch a single line through the phase state machine."""
+    if state.phase == "summary":
         print(raw_line, end="")
-        return phase, count, done
+        return state
 
-    if phase == "collecting":
-        count, start_running = _handle_collecting_phase(stripped, count)
+    if state.phase == "collecting":
+        count, start_running = _handle_collecting_phase(stripped, state.count)
         if start_running:
             _activate_running_phase(count, progress, task_id)
-            return "running", count, done
-        return "collecting", count, done
+            return _ProgressState("running", count, state.done)
+        return _ProgressState("collecting", count, state.done)
 
     done, enter_summary = _handle_running_phase(
-        stripped, progress, task_id, count, done
+        stripped, progress, task_id, state.count, state.done
     )
     if enter_summary:
         progress.stop()
         print(raw_line, end="")
-        return "summary", count, done
-    return "running", count, done
+        return _ProgressState("summary", state.count, done)
+    return _ProgressState("running", state.count, done)
 
 
 def _stream_with_progress(
@@ -264,9 +280,7 @@ def _stream_with_progress(
     log_file: IO[str],
 ) -> int:
     """Stream pytest output with a Rich progress bar -- for interactive TTY use."""
-    phase = "collecting"
-    count: int | None = None
-    done = 0
+    state = _ProgressState()
 
     progress = Progress(
         SpinnerColumn(),
@@ -283,11 +297,11 @@ def _stream_with_progress(
         for raw_line in process.stdout or []:
             log_file.write(raw_line)
             log_file.flush()
-            phase, count, done = _dispatch_progress_line(
-                raw_line.rstrip(), raw_line, phase, count, done, progress, task_id
+            state = _dispatch_progress_line(
+                raw_line.rstrip(), raw_line, state, progress, task_id
             )
     finally:
-        if phase != "summary":
+        if state.phase != "summary":
             progress.stop()
 
     process.wait()
@@ -474,23 +488,30 @@ _NICEGUI_UI_FILES: frozenset[str] = frozenset(
 )
 
 
-def _detect_test_type(args: list[str]) -> str:
-    """Classify test paths as 'e2e', 'nicegui', or 'unit'.
+def _partition_test_args(args: list[str]) -> tuple[dict[str, list[str]], list[str]]:
+    """Split *args* into per-lane path lists plus shared flags.
 
-    Scans *args* for anything that looks like a test path (not a flag).
-    Returns the detected type, defaulting to 'unit' when no paths match
-    a special category.
+    Every path is classified individually ('e2e', 'nicegui', or 'unit') so a
+    mixed invocation runs every lane it names. The old first-match-wins
+    classification routed the whole invocation down one lane, and that lane's
+    runner silently dropped the foreign paths — a false-green.
     """
+    lanes: dict[str, list[str]] = {"e2e": [], "nicegui": [], "unit": []}
+    flags: list[str] = []
     for arg in args:
-        if arg.startswith("-"):
+        # Values consumed by flags (`-k foo`, `-m blns`) must stay with the
+        # flags in original order; only path-shaped args are lane paths.
+        if arg.startswith("-") or not ("/" in arg or ".py" in arg):
+            flags.append(arg)
             continue
         normalised = arg.split("::")[0]
         if "tests/e2e" in normalised or normalised.startswith("tests/e2e"):
-            return "e2e"
-        filename = Path(normalised).name
-        if filename in _NICEGUI_UI_FILES:
-            return "nicegui"
-    return "unit"
+            lanes["e2e"].append(arg)
+        elif Path(normalised).name in _NICEGUI_UI_FILES:
+            lanes["nicegui"].append(arg)
+        else:
+            lanes["unit"].append(arg)
+    return lanes, flags
 
 
 @test_app.command(
@@ -516,36 +537,42 @@ def run_tests(
     from promptgrimoire.cli._shared import _prepend_filter
 
     args = _prepend_filter(ctx.args, filter_expr)
-    test_type = _detect_test_type(args)
+    lanes, flags = _partition_test_args(args)
 
-    if test_type == "e2e":
+    exit_code = 0
+    if lanes["e2e"]:
         from promptgrimoire.cli.e2e import run_playwright_noretry_lane
 
-        sys.exit(run_playwright_noretry_lane(args))
+        exit_code = run_playwright_noretry_lane(lanes["e2e"] + flags) or exit_code
 
-    if test_type == "nicegui":
+    if lanes["nicegui"]:
         from promptgrimoire.cli.e2e import run_nicegui_lane
 
-        sys.exit(run_nicegui_lane(args))
+        exit_code = run_nicegui_lane(lanes["nicegui"] + flags) or exit_code
 
     # Unit / integration — serial, no retries, fail-fast for targeted runs.
     # Exclude nicegui_ui and e2e markers so directory-level runs
     # (e.g. tests/integration/) don't collect NiceGUI tests that
     # need the user_simulation harness.
-    sys.exit(
-        _run_pytest(
-            title="Targeted Tests (no retries, fail-fast)",
-            log_path=Path("test-run.log"),
-            default_args=[
-                "-x",
-                "-v",
-                "--tb=short",
-                "-m",
-                _NON_UI_MARKER_EXPRESSION,
-            ],
-            extra_args=args,
+    # A bare `grimoire test run` (paths in no lane) still lands here so the
+    # marker-scoped default collection is preserved.
+    if lanes["unit"] or not (lanes["e2e"] or lanes["nicegui"]):
+        exit_code = (
+            _run_pytest(
+                title="Targeted Tests (no retries, fail-fast)",
+                log_path=Path("test-run.log"),
+                default_args=[
+                    "-x",
+                    "-v",
+                    "--tb=short",
+                    "-m",
+                    _NON_UI_MARKER_EXPRESSION,
+                ],
+                extra_args=lanes["unit"] + flags,
+            )
+            or exit_code
         )
-    )
+    sys.exit(exit_code)
 
 
 def _depper_base_ref() -> str:
@@ -834,7 +861,7 @@ def smoke_export() -> None:
 
     size = pdf_path.stat().st_size
 
-    if size < 1000:
+    if size < _MIN_VALID_PDF_BYTES:
         print(f"FAIL: PDF too small ({size} bytes): {pdf_path}")
         sys.exit(1)
 

--- a/src/promptgrimoire/cli_loadtest.py
+++ b/src/promptgrimoire/cli_loadtest.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 import asyncio
 import random
 import sys
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urlencode
 
 from rich.console import Console
+from sqlalchemy import tstring
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
@@ -32,10 +34,8 @@ from promptgrimoire.db.courses import (
 )
 from promptgrimoire.db.engine import get_session, init_db
 from promptgrimoire.db.models import (
-    ACLEntry,
     Activity,
     Course,
-    CourseEnrollment,
     Tag,
     TagGroup,
     User,
@@ -218,6 +218,8 @@ LOOSE_WORKSPACE_TITLES: list[str] = [
 # CRDT builder helper
 # ---------------------------------------------------------------------------
 
+_MIN_HIGHLIGHT_CONTENT_LENGTH = 20
+
 
 def build_crdt_state(
     document_id: str,
@@ -251,9 +253,11 @@ def build_crdt_state(
     highlight_ids: list[str] = []
 
     for _ in range(num_highlights):
-        if content_length < 20:
+        if content_length < _MIN_HIGHLIGHT_CONTENT_LENGTH:
             break
-        start = random.randint(0, max(0, content_length - 20))
+        start = random.randint(
+            0, max(0, content_length - _MIN_HIGHLIGHT_CONTENT_LENGTH)
+        )
         end = min(start + random.randint(10, 50), content_length)
         tag = random.choice(tag_ids) if tag_ids else ""
         text = f"highlighted text by {student_name}"
@@ -302,7 +306,19 @@ def roll_1d6_minus_2() -> int:
 # Course / user / enrollment data definitions
 # ---------------------------------------------------------------------------
 
-COURSE_DEFS: list[dict[str, object]] = [
+
+class CourseDef(TypedDict):
+    """One load-test course definition."""
+
+    code: str
+    name: str
+    semester: str
+    student_count: int
+    default_allow_sharing: bool
+    default_anonymous_sharing: bool
+
+
+COURSE_DEFS: list[CourseDef] = [
     {
         "code": "LT-LAWS1100",
         "name": "Introduction to Torts (Load Test)",
@@ -556,13 +572,18 @@ async def _ensure_activities_for_course(
     # Check existing activities.
     # Key on (week_id, title) so the same title in two different weeks is not
     # incorrectly treated as already-existing.
+    # Query-shaped read migrated to raw SQL per ADR 0004/0005 -- Column.in_()
+    # does not type-check under ty (astral-sh/ty#3421).
     async with get_session() as session:
-        existing_acts = await session.exec(
-            select(Activity).where(
-                Activity.week_id.in_([w.id for w in week_map.values()])  # type: ignore[union-attr]  # SQLAlchemy column expression
+        week_ids = [w.id for w in week_map.values()]
+        existing_rows = await session.execute(
+            tstring(
+                t"""
+                SELECT week_id, title FROM activity WHERE week_id = ANY({week_ids})
+                """
             )
         )
-        existing_act_keys = {(a.week_id, a.title) for a in existing_acts.all()}
+        existing_act_keys = {(row.week_id, row.title) for row in existing_rows}
 
     for week_num, act_title in activity_defs:
         week = week_map.get(week_num)
@@ -640,18 +661,25 @@ async def _check_workspace_exists(activity_id: UUID, user_id: UUID) -> bool:
 
     Looks for a workspace with the given activity_id that has an owner
     ACL entry for the given user.
+
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- .join()
+    does not type-check under ty (astral-sh/ty#3421).
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Workspace.id)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-            .where(
-                Workspace.activity_id == activity_id,
-                ACLEntry.user_id == user_id,
-                ACLEntry.permission == "owner",
+        rows = await session.execute(
+            tstring(
+                t"""
+                SELECT w.id
+                FROM workspace w
+                JOIN acl_entry a ON a.workspace_id = w.id
+                WHERE w.activity_id = {activity_id}
+                  AND a.user_id = {user_id}
+                  AND a.permission = 'owner'
+                LIMIT 1
+                """
             )
         )
-        return result.first() is not None
+        return rows.first() is not None
 
 
 async def _get_template_documents(
@@ -685,6 +713,10 @@ async def _seed_tags_and_crdt_state(
         await save_workspace_crdt_state(workspace_id, crdt_bytes)
 
 
+_SHARED_WITH_CLASS_PROBABILITY = 0.2
+_DOCUMENT_VARIATION_PROBABILITY = 0.3
+
+
 async def _create_student_activity_workspace(
     activity: Activity,
     user: User,
@@ -700,7 +732,7 @@ async def _create_student_activity_workspace(
 
     # Place in activity and set title
     await place_workspace_in_activity(ws_id, activity.id)
-    shared_with_class = random.random() < 0.2  # ~20% chance
+    shared_with_class = random.random() < _SHARED_WITH_CLASS_PROBABILITY  # ~20% chance
     async with get_session() as session:
         ws = await session.get(Workspace, ws_id)
         if ws:
@@ -720,7 +752,7 @@ async def _create_student_activity_workspace(
     for tmpl_doc in template_docs:
         # Swap one paragraph from the pool for variation
         content = tmpl_doc.content
-        if random.random() < 0.3:  # 30% chance of variation
+        if random.random() < _DOCUMENT_VARIATION_PROBABILITY:  # 30% chance
             extra_para = random.choice(DOCUMENT_PARAGRAPHS)
             content = content + "\n" + extra_para
 
@@ -820,6 +852,9 @@ async def _resolve_course_id_for_code(
     a load-test run).
 
     Returns None if the course has no activities or the hierarchy is broken.
+
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- .join()
+    does not type-check under ty (astral-sh/ty#3421).
     """
     if course_code in _course_id_cache:
         return _course_id_cache[course_code]
@@ -829,14 +864,20 @@ async def _resolve_course_id_for_code(
         _course_id_cache[course_code] = None
         return None
 
-    activity_for_course = acts[0][0]
+    activity_id = acts[0][0].id
     async with get_session() as session:
-        result = await session.exec(
-            select(Week.course_id)
-            .join(Activity, Activity.week_id == Week.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-            .where(Activity.id == activity_for_course.id)
+        rows = await session.execute(
+            tstring(
+                t"""
+                SELECT wk.course_id
+                FROM week wk
+                JOIN activity a ON a.week_id = wk.id
+                WHERE a.id = {activity_id}
+                """
+            )
         )
-        course_id = result.first()
+        row = rows.first()
+        course_id = row.course_id if row is not None else None
 
     _course_id_cache[course_code] = course_id
     return course_id
@@ -874,6 +915,78 @@ async def _create_loose_workspaces_for_student(
     return ws_count, doc_count
 
 
+async def _build_template_doc_cache(
+    course_activities: dict[str, list[tuple[Activity, UUID]]],
+) -> dict[UUID, list[WorkspaceDocument]]:
+    """Pre-fetch template documents for every activity, keyed by template id.
+
+    Avoids repeated queries for the same template workspace across students.
+    """
+    template_doc_cache: dict[UUID, list[WorkspaceDocument]] = {}
+    for acts in course_activities.values():
+        for _activity, tmpl_id in acts:
+            if tmpl_id not in template_doc_cache:
+                template_doc_cache[tmpl_id] = await _get_template_documents(tmpl_id)
+    return template_doc_cache
+
+
+_ACTIVITY_WORKSPACE_CREATION_PROBABILITY = 0.7
+
+
+async def _create_activity_workspaces_for_student(
+    user: User,
+    enrolled_codes: list[str],
+    course_activities: dict[str, list[tuple[Activity, UUID]]],
+    template_doc_cache: dict[UUID, list[WorkspaceDocument]],
+) -> tuple[int, int, int]:
+    """Create activity workspaces for one student across their enrolled courses.
+
+    Rolls a 70% chance per activity and skips activities the student
+    already has a workspace for.
+
+    Returns:
+        (activity_workspace_count, document_count, shared_with_class_count)
+    """
+    ws_count = 0
+    doc_count = 0
+    shared_count = 0
+
+    for code in enrolled_codes:
+        activities = course_activities.get(code, [])
+        for activity, tmpl_id in activities:
+            if random.random() > _ACTIVITY_WORKSPACE_CREATION_PROBABILITY:
+                continue
+
+            if await _check_workspace_exists(activity.id, user.id):
+                continue
+
+            _ws_id, docs, is_shared = await _create_student_activity_workspace(
+                activity=activity,
+                user=user,
+                template_docs=template_doc_cache[tmpl_id],
+            )
+            ws_count += 1
+            doc_count += docs
+            if is_shared:
+                shared_count += 1
+
+    return ws_count, doc_count, shared_count
+
+
+def _report_seeding_progress(
+    idx: int,
+    total_students: int,
+    activity_ws_count: int,
+    loose_ws_count: int,
+) -> None:
+    """Print a progress line every 100 students, and on the final student."""
+    if (idx + 1) % 100 == 0 or idx + 1 == total_students:
+        console.print(
+            f"  [green]Progress:[/] {idx + 1}/{total_students} students "
+            f"({activity_ws_count} activity ws, {loose_ws_count} loose ws)"
+        )
+
+
 async def _seed_student_workspaces(
     all_students: dict[str, User],
     student_courses: dict[str, list[str]],
@@ -892,12 +1005,7 @@ async def _seed_student_workspaces(
     total_doc_count = 0
     shared_count = 0
 
-    # Pre-fetch template documents for each activity to avoid repeated queries
-    template_doc_cache: dict[UUID, list[WorkspaceDocument]] = {}
-    for acts in course_activities.values():
-        for _activity, tmpl_id in acts:
-            if tmpl_id not in template_doc_cache:
-                template_doc_cache[tmpl_id] = await _get_template_documents(tmpl_id)
+    template_doc_cache = await _build_template_doc_cache(course_activities)
 
     student_list = list(all_students.items())
     total_students = len(student_list)
@@ -905,41 +1013,20 @@ async def _seed_student_workspaces(
     for idx, (email, user) in enumerate(student_list):
         enrolled_codes = student_courses.get(email, [])
 
-        # Activity workspaces
-        for code in enrolled_codes:
-            activities = course_activities.get(code, [])
-            for activity, tmpl_id in activities:
-                # 70% chance of creating a workspace
-                if random.random() > 0.7:
-                    continue
+        act_ws, act_docs, act_shared = await _create_activity_workspaces_for_student(
+            user, enrolled_codes, course_activities, template_doc_cache
+        )
+        activity_ws_count += act_ws
+        total_doc_count += act_docs
+        shared_count += act_shared
 
-                # Idempotency check
-                if await _check_workspace_exists(activity.id, user.id):
-                    continue
-
-                _ws_id, doc_count, is_shared = await _create_student_activity_workspace(
-                    activity=activity,
-                    user=user,
-                    template_docs=template_doc_cache[tmpl_id],
-                )
-                activity_ws_count += 1
-                total_doc_count += doc_count
-                if is_shared:
-                    shared_count += 1
-
-        # Loose workspaces
         loose, docs = await _create_loose_workspaces_for_student(
             user, enrolled_codes, course_activities
         )
         loose_ws_count += loose
         total_doc_count += docs
 
-        # Progress reporting every 100 students
-        if (idx + 1) % 100 == 0 or idx + 1 == total_students:
-            console.print(
-                f"  [green]Progress:[/] {idx + 1}/{total_students} students "
-                f"({activity_ws_count} activity ws, {loose_ws_count} loose ws)"
-            )
+        _report_seeding_progress(idx, total_students, activity_ws_count, loose_ws_count)
 
     console.print(
         f"  [green]Activity workspaces:[/] {activity_ws_count}\n"
@@ -954,6 +1041,85 @@ async def _seed_student_workspaces(
 # ---------------------------------------------------------------------------
 # ACL shares (Task 4)
 # ---------------------------------------------------------------------------
+
+
+def _build_course_students_map(
+    all_students: dict[str, User],
+    student_courses: dict[str, list[str]],
+    courses: dict[str, Course],
+) -> dict[UUID, list[User]]:
+    """Map course_id -> enrolled student Users."""
+    course_students: dict[UUID, list[User]] = {}
+    for email, codes in student_courses.items():
+        user = all_students[email]
+        for code in codes:
+            if code in courses:
+                cid = courses[code].id
+                course_students.setdefault(cid, []).append(user)
+    return course_students
+
+
+async def _fetch_candidate_workspaces(
+    courses: dict[str, Course],
+) -> list[tuple[UUID, UUID, UUID]]:
+    """Find non-template activity workspaces with an owner, across every course.
+
+    Returns (workspace_id, owner_user_id, course_id) tuples.
+
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- .join() does
+    not type-check under ty (astral-sh/ty#3421).
+    """
+    candidate_workspaces: list[tuple[UUID, UUID, UUID]] = []
+    for course in courses.values():
+        course_id = course.id
+        async with get_session() as session:
+            rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.id AS workspace_id,
+                           acl.user_id AS owner_id,
+                           wk.course_id AS course_id
+                    FROM workspace w
+                    JOIN activity act ON act.id = w.activity_id
+                    JOIN week wk ON wk.id = act.week_id
+                    JOIN acl_entry acl ON acl.workspace_id = w.id
+                    WHERE wk.course_id = {course_id}
+                      AND acl.permission = 'owner'
+                      AND w.id != act.template_workspace_id
+                    """
+                )
+            )
+            for row in rows:
+                candidate_workspaces.append(
+                    (row.workspace_id, row.owner_id, row.course_id)
+                )
+    return candidate_workspaces
+
+
+async def _grant_shares_for_workspace(
+    ws_id: UUID,
+    owner_id: UUID,
+    course_id: UUID,
+    course_students: dict[UUID, list[User]],
+) -> int:
+    """Grant editor/viewer access to 1-2 other students in the same course.
+
+    Returns the number of shares granted for this workspace.
+    """
+    students_in_course = course_students.get(course_id, [])
+    eligible = [s for s in students_in_course if s.id != owner_id]
+    if not eligible:
+        return 0
+
+    num_shares = random.randint(1, min(2, len(eligible)))
+    recipients = random.sample(eligible, num_shares)
+
+    granted = 0
+    for recipient in recipients:
+        perm = random.choice(["editor", "viewer"])
+        await grant_permission(ws_id, recipient.id, perm)
+        granted += 1
+    return granted
 
 
 async def _seed_acl_shares(
@@ -971,38 +1137,8 @@ async def _seed_acl_shares(
     """
     console.print("\n[bold cyan]Phase 6: ACL Shares[/]")
 
-    share_count = 0
-
-    # Build course_id -> list of student Users mapping
-    course_students: dict[UUID, list[User]] = {}
-    for email, codes in student_courses.items():
-        user = all_students[email]
-        for code in codes:
-            if code in courses:
-                cid = courses[code].id
-                course_students.setdefault(cid, []).append(user)
-
-    # Collect activity-linked student workspaces (not templates, not loose)
-    candidate_workspaces: list[
-        tuple[UUID, UUID, UUID]
-    ] = []  # (workspace_id, owner_user_id, course_id)
-
-    for _course_code, course in courses.items():
-        async with get_session() as session:
-            # Find non-template activity workspaces in this course
-            result = await session.exec(
-                select(Workspace.id, ACLEntry.user_id, Week.course_id)
-                .join(Activity, Workspace.activity_id == Activity.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-                .join(Week, Activity.week_id == Week.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-                .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-                .where(
-                    Week.course_id == course.id,
-                    ACLEntry.permission == "owner",
-                    Workspace.id != Activity.template_workspace_id,
-                )
-            )
-            for ws_id, owner_id, cid in result.all():
-                candidate_workspaces.append((ws_id, owner_id, cid))
+    course_students = _build_course_students_map(all_students, student_courses, courses)
+    candidate_workspaces = await _fetch_candidate_workspaces(courses)
 
     if not candidate_workspaces:
         console.print("  [yellow]No candidate workspaces for sharing[/]")
@@ -1012,21 +1148,11 @@ async def _seed_acl_shares(
     sample_size = min(50, len(candidate_workspaces))
     selected = random.sample(candidate_workspaces, sample_size)
 
+    share_count = 0
     for ws_id, owner_id, course_id in selected:
-        students_in_course = course_students.get(course_id, [])
-        # Filter out the owner
-        eligible = [s for s in students_in_course if s.id != owner_id]
-        if not eligible:
-            continue
-
-        # Grant to 1-2 other students
-        num_shares = random.randint(1, min(2, len(eligible)))
-        recipients = random.sample(eligible, num_shares)
-
-        for recipient in recipients:
-            perm = random.choice(["editor", "viewer"])
-            await grant_permission(ws_id, recipient.id, perm)
-            share_count += 1
+        share_count += await _grant_shares_for_workspace(
+            ws_id, owner_id, course_id, course_students
+        )
 
     console.print(f"  [green]ACL shares created:[/] {share_count}")
     return share_count
@@ -1037,16 +1163,27 @@ async def _seed_acl_shares(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True, slots=True)
+class LoadTestCounts:
+    """Aggregate counters produced by the student-workspace seeding phases."""
+
+    activity_ws_count: int
+    loose_ws_count: int
+    total_doc_count: int
+    share_count: int
+    shared_with_class_count: int
+
+
 async def _print_summary(
     courses: dict[str, Course],
     course_activities: dict[str, list[tuple[Activity, UUID]]],
-    activity_ws_count: int,
-    loose_ws_count: int,
-    total_doc_count: int,
-    share_count: int,
-    shared_with_class_count: int,
+    counts: LoadTestCounts,
 ) -> None:
-    """Print final load-test data summary with counts from the database."""
+    """Print final load-test data summary with counts from the database.
+
+    Query-shaped reads migrated to raw SQL per ADR 0004/0005 -- .like()/
+    .in_() do not type-check under ty (astral-sh/ty#3421).
+    """
     console.print("\n[bold green]Load test data summary:[/]")
 
     # Count from database for accuracy
@@ -1054,19 +1191,20 @@ async def _print_summary(
         # All load-test users share @test.local domain (students: loadtest-*,
         # instructors: lt-instructor-*, admin: lt-admin). Seed data uses
         # @uni.edu and @example.com, so this won't over-count.
-        user_result = await session.exec(
-            select(User.id).where(User.email.like("%@test.local"))  # type: ignore[union-attr]  # SQLAlchemy column expression
+        user_rows = await session.execute(
+            tstring(t"""SELECT id FROM "user" WHERE email LIKE '%@test.local'""")
         )
-        db_user_count = len(user_result.all())
+        db_user_count = len(user_rows.all())
 
-        enrollment_result = await session.exec(
-            select(CourseEnrollment.id).where(
-                CourseEnrollment.course_id.in_(  # type: ignore[union-attr]  # SQLAlchemy column expression
-                    [c.id for c in courses.values()]
-                )
+        course_ids = [c.id for c in courses.values()]
+        enrollment_rows = await session.execute(
+            tstring(
+                t"""
+                SELECT id FROM course_enrollment WHERE course_id = ANY({course_ids})
+                """
             )
         )
-        db_enrollment_count = len(enrollment_result.all())
+        db_enrollment_count = len(enrollment_rows.all())
 
     total_activities = sum(len(acts) for acts in course_activities.values())
 
@@ -1074,11 +1212,13 @@ async def _print_summary(
     console.print(f"  Courses: {len(courses)}")
     console.print(f"  Enrollments: {db_enrollment_count}")
     console.print(f"  Activities: {total_activities}")
-    console.print(f"  Workspaces (activity): {activity_ws_count}")
-    console.print(f"  Workspaces (loose): {loose_ws_count}")
-    console.print(f"  Documents: {total_doc_count}")
-    console.print(f"  ACL shares: {share_count}")
-    console.print(f"  Workspaces with shared_with_class: {shared_with_class_count}")
+    console.print(f"  Workspaces (activity): {counts.activity_ws_count}")
+    console.print(f"  Workspaces (loose): {counts.loose_ws_count}")
+    console.print(f"  Documents: {counts.total_doc_count}")
+    console.print(f"  ACL shares: {counts.share_count}")
+    console.print(
+        f"  Workspaces with shared_with_class: {counts.shared_with_class_count}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1182,8 +1322,8 @@ async def _seed_students(
     total_student_count = 0
 
     for cdef in COURSE_DEFS:
-        code = str(cdef["code"])
-        count = int(cdef["student_count"])  # type: ignore[arg-type]  # dict value is typed as object; int() is safe here
+        code = cdef["code"]
+        count = cdef["student_count"]
         s_range = _student_range_for_course(code, count)
 
         enrolled_count = 0
@@ -1283,19 +1423,28 @@ async def _validate_ensure_student_workspace(
 
     Returns:
         The workspace UUID (existing or newly created).
+
+    Query-shaped read migrated to raw SQL per ADR 0004/0005 -- .join() does
+    not type-check under ty (astral-sh/ty#3421).
     """
     if await _check_workspace_exists(activity.id, student.id):
+        activity_id = activity.id
+        student_id = student.id
         async with get_session() as session:
-            result = await session.exec(
-                select(Workspace.id)
-                .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  # SQLAlchemy join expression, not a plain column
-                .where(
-                    Workspace.activity_id == activity.id,
-                    ACLEntry.user_id == student.id,
-                    ACLEntry.permission == "owner",
+            rows = await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.id
+                    FROM workspace w
+                    JOIN acl_entry a ON a.workspace_id = w.id
+                    WHERE w.activity_id = {activity_id}
+                      AND a.user_id = {student_id}
+                      AND a.permission = 'owner'
+                    """
                 )
             )
-            ws_id = result.first()
+            row = rows.first()
+            ws_id = row[0] if row is not None else None
         console.print(f"  [yellow]Exists:[/] Student workspace (id={ws_id})")
         return ws_id
 
@@ -1402,11 +1551,13 @@ async def _async_load_test_data() -> None:
     await _print_summary(
         courses=courses,
         course_activities=course_activities,
-        activity_ws_count=activity_ws_count,
-        loose_ws_count=loose_ws_count,
-        total_doc_count=total_doc_count,
-        share_count=share_count,
-        shared_with_class_count=shared_with_class_count,
+        counts=LoadTestCounts(
+            activity_ws_count=activity_ws_count,
+            loose_ws_count=loose_ws_count,
+            total_doc_count=total_doc_count,
+            share_count=share_count,
+            shared_with_class_count=shared_with_class_count,
+        ),
     )
 
 

--- a/src/promptgrimoire/config.py
+++ b/src/promptgrimoire/config.py
@@ -254,6 +254,12 @@ def get_current_branch() -> str | None:
     return _current_branch()
 
 
+# Cap on the sanitised branch-name suffix appended to the database name;
+# PostgreSQL identifiers max out at 63 bytes, so this leaves room for the
+# base database name alongside the suffix.
+_MAX_BRANCH_SUFFIX_LENGTH = 40
+
+
 def _branch_db_suffix(branch: str | None) -> str:
     """Derive a database name suffix from the branch name.
 
@@ -270,9 +276,10 @@ def _branch_db_suffix(branch: str | None) -> str:
     if not sanitised:
         return ""
 
-    if len(sanitised) > 40:
+    if len(sanitised) > _MAX_BRANCH_SUFFIX_LENGTH:
         h = hashlib.sha256(branch.encode()).hexdigest()[:8]
-        sanitised = f"{sanitised[:31]}_{h}"
+        truncate_at = _MAX_BRANCH_SUFFIX_LENGTH - len(h) - 1
+        sanitised = f"{sanitised[:truncate_at]}_{h}"
 
     return sanitised
 

--- a/src/promptgrimoire/crdt/annotation_doc.py
+++ b/src/promptgrimoire/crdt/annotation_doc.py
@@ -7,6 +7,7 @@ and comment threads across multiple connected clients.
 
 from __future__ import annotations
 
+import dataclasses
 from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -221,13 +222,14 @@ class AnnotationDocument:
 
     # --- Highlight operations ---
 
-    def add_highlight(
+    def add_highlight(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
         self,
         start_char: int,
         end_char: int,
         tag: str,
         text: str,
         author: str,
+        *,
         para_ref: str = "",
         origin_client_id: str | None = None,
         document_id: str | None = None,
@@ -486,7 +488,7 @@ class AnnotationDocument:
 
     # --- Tag CRUD operations ---
 
-    def set_tag(
+    def set_tag(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
         self,
         tag_id: str | UUID,
         name: str,
@@ -834,18 +836,29 @@ def _hydrate_crdt_from_db(
     )
 
 
+@dataclasses.dataclass
+class _TagReconciliationState:
+    """DB-side and CRDT-side tag/tag-group snapshots being reconciled."""
+
+    db_tags: list[Any]
+    db_groups: list[Any]
+    crdt_tags: dict[str, Any]
+    crdt_groups: dict[str, Any]
+
+
 def _reconcile_crdt_with_db(
     doc: AnnotationDocument,
-    db_tags: list[Any],
-    db_groups: list[Any],
-    crdt_tags: dict[str, Any],
-    crdt_groups: dict[str, Any],
+    state: _TagReconciliationState,
     workspace_id: UUID,
 ) -> bool:
     """Add missing DB entries to CRDT and remove orphans (AC1.6).
 
     Returns True if any changes were made.
     """
+    db_tags = state.db_tags
+    db_groups = state.db_groups
+    crdt_tags = state.crdt_tags
+    crdt_groups = state.crdt_groups
     db_tag_ids = {str(t.id) for t in db_tags}
     db_group_ids = {str(g.id) for g in db_groups}
     changed = False
@@ -944,7 +957,9 @@ async def _ensure_crdt_tag_consistency(
         changed = True
     else:
         changed = _reconcile_crdt_with_db(
-            doc, db_tags, db_groups, crdt_tags, crdt_groups, workspace_id
+            doc,
+            _TagReconciliationState(db_tags, db_groups, crdt_tags, crdt_groups),
+            workspace_id,
         )
 
     if changed:

--- a/src/promptgrimoire/db/acl.py
+++ b/src/promptgrimoire/db/acl.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
+from sqlalchemy import tstring
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import select
 
@@ -20,7 +21,6 @@ from promptgrimoire.db.models import (
     Activity,
     Course,
     CourseEnrollment,
-    Permission,
     User,
     Week,
     Workspace,
@@ -135,16 +135,24 @@ async def list_accessible_workspaces(
         (Workspace, permission_name) tuples, ordered by workspace.created_at.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Workspace, ACLEntry.permission)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement
-            .where(
-                ACLEntry.user_id == user_id,
-                ACLEntry.workspace_id != None,  # noqa: E711
+        rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.*, a.permission AS permission
+                    FROM workspace w
+                    JOIN acl_entry a ON a.workspace_id = w.id
+                    WHERE a.user_id = {user_id}
+                      AND a.workspace_id IS NOT NULL
+                    ORDER BY w.created_at
+                    """
+                )
             )
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  # TODO(2026-Q2): Revisit when SQLModel updates type stubs
-        )
-        return list(result.all())
+        ).all()
+        return [
+            (Workspace.model_validate(row, from_attributes=True), row.permission)
+            for row in rows
+        ]
 
 
 async def list_course_workspaces(
@@ -166,31 +174,57 @@ async def list_course_workspaces(
     """
     async with get_session() as session:
         # Collect template workspace IDs to exclude
-        template_result = await session.exec(
-            select(Activity.template_workspace_id)
-            .join(Week, Activity.week_id == Week.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement
-            .where(Week.course_id == course_id)
+        template_rows = (
+            (
+                await session.execute(
+                    tstring(
+                        t"""
+                    SELECT a.template_workspace_id
+                    FROM activity a
+                    JOIN week wk ON wk.id = a.week_id
+                    WHERE wk.course_id = {course_id}
+                    """
+                    )
+                )
+            )
+            .scalars()
+            .all()
         )
-        template_ids = set(template_result.all())
+        template_ids = set(template_rows)
 
         # Activity-placed workspaces: via Activity -> Week -> Course
-        activity_result = await session.exec(
-            select(Workspace)
-            .join(Activity, Workspace.activity_id == Activity.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement
-            .join(Week, Activity.week_id == Week.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement
-            .where(Week.course_id == course_id)
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  -- SQLModel order_by stubs
-        )
-        activity_workspaces = list(activity_result.all())
+        activity_rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.* FROM workspace w
+                    JOIN activity a ON w.activity_id = a.id
+                    JOIN week wk ON a.week_id = wk.id
+                    WHERE wk.course_id = {course_id}
+                    ORDER BY w.created_at
+                    """
+                )
+            )
+        ).all()
+        activity_workspaces = [
+            Workspace.model_validate(row, from_attributes=True) for row in activity_rows
+        ]
 
         # Loose workspaces: directly placed in course
-        loose_result = await session.exec(
-            select(Workspace)
-            .where(Workspace.course_id == course_id)
-            .where(Workspace.activity_id == None)  # noqa: E711
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  -- SQLModel order_by stubs
-        )
-        loose_workspaces = list(loose_result.all())
+        loose_rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.* FROM workspace w
+                    WHERE w.course_id = {course_id} AND w.activity_id IS NULL
+                    ORDER BY w.created_at
+                    """
+                )
+            )
+        ).all()
+        loose_workspaces = [
+            Workspace.model_validate(row, from_attributes=True) for row in loose_rows
+        ]
 
         # Combine and exclude templates
         all_workspaces = activity_workspaces + loose_workspaces
@@ -217,18 +251,30 @@ async def list_activity_workspaces(
             return []
         template_id = activity.template_workspace_id
 
-        result = await session.exec(
-            select(Workspace, ACLEntry.permission, ACLEntry.user_id)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement
-            .where(
-                Workspace.activity_id == activity_id,
-                ACLEntry.permission == "owner",
-                ACLEntry.workspace_id != None,  # noqa: E711
+        rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.*, a.permission AS permission, a.user_id AS acl_user_id
+                    FROM workspace w
+                    JOIN acl_entry a ON a.workspace_id = w.id
+                    WHERE w.activity_id = {activity_id}
+                      AND a.permission = 'owner'
+                      AND a.workspace_id IS NOT NULL
+                    ORDER BY w.created_at
+                    """
+                )
             )
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  -- SQLModel order_by stubs
-        )
-        rows = list(result.all())
-        return [(ws, perm, uid) for ws, perm, uid in rows if ws.id != template_id]
+        ).all()
+        return [
+            (
+                Workspace.model_validate(row, from_attributes=True),
+                row.permission,
+                row.acl_user_id,
+            )
+            for row in rows
+            if row.id != template_id
+        ]
 
 
 async def _resolve_workspace_course(
@@ -329,12 +375,13 @@ async def _resolve_permission_with_session(
 
     # Step 3: Highest wins
     if explicit and derived_permission:
-        level_result = await session.exec(
-            select(Permission.name, Permission.level).where(
-                Permission.name.in_([explicit.permission, derived_permission])  # type: ignore[union-attr]  -- Column has in_
+        names = [explicit.permission, derived_permission]
+        level_rows = (
+            await session.execute(
+                tstring(t"SELECT name, level FROM permission WHERE name = ANY({names})")
             )
-        )
-        levels = dict(level_result.all())
+        ).all()
+        levels = {row.name: row.level for row in level_rows}
         e_level = levels[explicit.permission]
         d_level = levels[derived_permission]
         return explicit.permission if e_level >= d_level else derived_permission
@@ -369,7 +416,7 @@ async def resolve_permission(workspace_id: UUID, user_id: UUID) -> str | None:
         return await _resolve_permission_with_session(session, workspace_id, user_id)
 
 
-async def grant_share(
+async def grant_share(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     workspace_id: UUID,
     grantor_id: UUID,
     recipient_id: UUID,
@@ -525,14 +572,15 @@ async def list_importable_workspaces(
     #
     # Mirrors the navigator CTE visibility logic but returns only
     # workspaces that have at least one tag, with tag names aggregated.
-    sql = sa.text("""
+    stmt = tstring(
+        t"""
         WITH visible AS (
             -- Path 1: ACL-granted workspaces
             SELECT DISTINCT w.id AS workspace_id,
                    acl.permission AS permission
             FROM workspace w
             JOIN acl_entry acl ON acl.workspace_id = w.id
-                AND acl.user_id = :user_id
+                AND acl.user_id = {user_id}
 
             UNION ALL
 
@@ -542,8 +590,8 @@ async def list_importable_workspaces(
             FROM activity a
             JOIN week wk ON wk.id = a.week_id
             WHERE a.template_workspace_id IS NOT NULL
-                AND wk.course_id = ANY(:enrolled_course_ids)
-                AND :is_privileged = true
+                AND wk.course_id = ANY({course_ids})
+                AND {is_privileged} = true
 
             UNION ALL
 
@@ -559,10 +607,10 @@ async def list_importable_workspaces(
             JOIN week wk ON wk.id = a.week_id
             JOIN course c ON c.id = wk.course_id
             WHERE tmpl_check.id IS NULL
-                AND c.id = ANY(:enrolled_course_ids)
-                AND owner_acl.user_id != :user_id
+                AND c.id = ANY({course_ids})
+                AND owner_acl.user_id != {user_id}
                 AND (
-                    :is_privileged = true
+                    {is_privileged} = true
                     OR (
                         w.shared_with_class = true
                         AND COALESCE(a.allow_sharing, c.default_allow_sharing)
@@ -580,10 +628,10 @@ async def list_importable_workspaces(
                 AND owner_acl.permission = 'owner'
             JOIN course c ON c.id = w.course_id
             WHERE w.activity_id IS NULL
-                AND c.id = ANY(:enrolled_course_ids)
-                AND owner_acl.user_id != :user_id
+                AND c.id = ANY({course_ids})
+                AND owner_acl.user_id != {user_id}
                 AND (
-                    :is_privileged = true
+                    {is_privileged} = true
                     OR (
                         w.shared_with_class = true
                         AND c.default_allow_sharing = true
@@ -600,8 +648,8 @@ async def list_importable_workspaces(
                        ELSE 3
                    END) AS perm_rank
             FROM visible
-            WHERE (CAST(:exclude_id AS uuid) IS NULL
-                   OR workspace_id != :exclude_id)
+            WHERE (CAST({exclude_workspace_id} AS uuid) IS NULL
+                   OR workspace_id != {exclude_workspace_id})
             GROUP BY workspace_id
         )
         -- Final: join with tags and course info
@@ -624,19 +672,11 @@ async def list_importable_workspaces(
             array_length(array_agg(t.name), 1) DESC,  -- more tags first
             COALESCE(c1.name, c2.name, ''),
             COALESCE(w.title, '')
-    """)
+        """
+    )
 
     async with get_session() as session:
-        raw = await session.execute(
-            sql,
-            {
-                "user_id": user_id,
-                "enrolled_course_ids": course_ids,
-                "is_privileged": is_privileged,
-                "exclude_id": exclude_workspace_id,
-            },
-        )
-        rows = raw.fetchall()
+        rows = (await session.execute(stmt)).all()
 
     if not rows:
         return []
@@ -644,21 +684,29 @@ async def list_importable_workspaces(
     # Hydrate Workspace objects and build result tuples
     ws_ids = [row[0] for row in rows]
     async with get_session() as session:
-        ws_result = await session.exec(
-            select(Workspace).where(Workspace.id.in_(ws_ids))  # type: ignore[union-attr]
-        )
-        ws_by_id: dict[UUID, Workspace] = {ws.id: ws for ws in ws_result.all()}
+        ws_rows = (
+            await session.execute(
+                tstring(t"SELECT * FROM workspace WHERE id = ANY({ws_ids})")
+            )
+        ).all()
+        ws_by_id: dict[UUID, Workspace] = {
+            ws.id: ws
+            for ws in (
+                Workspace.model_validate(row, from_attributes=True) for row in ws_rows
+            )
+        }
 
     result: list[tuple[Workspace, str | None, list[str]]] = []
     seen_tag_sets: set[tuple[str, ...]] = set()
-    for ws_id, course_name, tag_names, _is_template, _perm_rank in rows:
-        ws = ws_by_id.get(ws_id)
+    for row in rows:
+        ws = ws_by_id.get(row.id)
         if ws is None:
             continue
+        tag_names = row.tag_names
         key = tuple(sorted(n.lower() for n in tag_names))
         if key not in seen_tag_sets:
             seen_tag_sets.add(key)
-            result.append((ws, course_name, tag_names))
+            result.append((ws, row.course_name, tag_names))
     return result
 
 
@@ -693,14 +741,22 @@ async def get_privileged_user_ids_for_workspace(
         staff_ids: set[str] = set()
 
         if course_id is not None:
-            staff_roles = await get_staff_roles(session=session)
-            result = await session.exec(
-                select(CourseEnrollment.user_id).where(
-                    CourseEnrollment.course_id == course_id,
-                    CourseEnrollment.role.in_(staff_roles),  # type: ignore[union-attr]  -- Column has in_
+            staff_roles = list(await get_staff_roles(session=session))
+            staff_rows = (
+                (
+                    await session.execute(
+                        tstring(
+                            t"""
+                        SELECT user_id FROM course_enrollment
+                        WHERE course_id = {course_id} AND role = ANY({staff_roles})
+                        """
+                        )
+                    )
                 )
+                .scalars()
+                .all()
             )
-            staff_ids = {str(uid) for uid in result.all()}
+            staff_ids = {str(uid) for uid in staff_rows}
 
         # Also include org-level admins
         admin_result = await session.exec(
@@ -745,33 +801,23 @@ async def list_peer_workspaces(
         # Team-target ACL rows satisfy num_nonnulls(workspace_id, team_id) = 1
         # with workspace_id NULL, so this NOT IN subquery must exclude NULLs
         # explicitly to avoid NULL poisoning workspace-only peer discovery.
-        owned_subq = (
-            select(ACLEntry.workspace_id)
-            .where(
-                ACLEntry.user_id == exclude_user_id,
-                ACLEntry.permission == "owner",
-                ACLEntry.workspace_id != None,  # noqa: E711
-            )
-            .scalar_subquery()
-        )
-
-        # Main query
-        stmt = (
-            select(Workspace)
-            .where(
-                Workspace.activity_id == activity_id,
-                Workspace.shared_with_class == True,  # noqa: E712
-            )
-            .where(Workspace.id.not_in(owned_subq))  # type: ignore[union-attr]  -- Column has not_in
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  -- SQLModel order_by stubs
-        )
-
-        # Exclude template workspace
+        query = t"""
+            SELECT w.* FROM workspace w
+            WHERE w.activity_id = {activity_id}
+              AND w.shared_with_class = true
+              AND w.id NOT IN (
+                  SELECT workspace_id FROM acl_entry
+                  WHERE user_id = {exclude_user_id}
+                    AND permission = 'owner'
+                    AND workspace_id IS NOT NULL
+              )
+        """
         if template_id is not None:
-            stmt = stmt.where(Workspace.id != template_id)
+            query = query + t" AND w.id != {template_id}"
+        query = query + t" ORDER BY w.created_at"
 
-        result = await session.exec(stmt)
-        return list(result.all())
+        rows = (await session.execute(tstring(query))).all()
+        return [Workspace.model_validate(row, from_attributes=True) for row in rows]
 
 
 async def list_peer_workspaces_with_owners(
@@ -795,31 +841,31 @@ async def list_peer_workspaces_with_owners(
         # Team-target ACL rows satisfy num_nonnulls(workspace_id, team_id) = 1
         # with workspace_id NULL, so this NOT IN subquery must exclude NULLs
         # explicitly to keep workspace-owner filtering NULL-safe.
-        owned_subq = (
-            select(ACLEntry.workspace_id)
-            .where(
-                ACLEntry.user_id == exclude_user_id,
-                ACLEntry.permission == "owner",
-                ACLEntry.workspace_id != None,  # noqa: E711
-            )
-            .scalar_subquery()
-        )
-
-        stmt = (
-            select(Workspace, User.display_name, ACLEntry.user_id)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- SQLAlchemy join stubs
-            .join(User, User.id == ACLEntry.user_id)  # type: ignore[arg-type]  -- SQLAlchemy join stubs
-            .where(
-                Workspace.activity_id == activity_id,
-                Workspace.shared_with_class == True,  # noqa: E712
-                ACLEntry.permission == "owner",
-            )
-            .where(Workspace.id.not_in(owned_subq))  # type: ignore[union-attr]
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]
-        )
-
+        query = t"""
+            SELECT w.*, u.display_name AS owner_display_name,
+                   a.user_id AS owner_user_id
+            FROM workspace w
+            JOIN acl_entry a ON a.workspace_id = w.id AND a.permission = 'owner'
+            JOIN "user" u ON u.id = a.user_id
+            WHERE w.activity_id = {activity_id}
+              AND w.shared_with_class = true
+              AND w.id NOT IN (
+                  SELECT workspace_id FROM acl_entry
+                  WHERE user_id = {exclude_user_id}
+                    AND permission = 'owner'
+                    AND workspace_id IS NOT NULL
+              )
+        """
         if template_id is not None:
-            stmt = stmt.where(Workspace.id != template_id)
+            query = query + t" AND w.id != {template_id}"
+        query = query + t" ORDER BY w.created_at"
 
-        rows = await session.exec(stmt)
-        return [(row[0], row[1], row[2]) for row in rows.all()]
+        rows = (await session.execute(tstring(query))).all()
+        return [
+            (
+                Workspace.model_validate(row, from_attributes=True),
+                row.owner_display_name,
+                row.owner_user_id,
+            )
+            for row in rows
+        ]

--- a/src/promptgrimoire/db/activities.py
+++ b/src/promptgrimoire/db/activities.py
@@ -9,15 +9,16 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlmodel import select
+from sqlalchemy import tstring
 
 from promptgrimoire.db.engine import get_session
 from promptgrimoire.db.exceptions import DeletionBlockedError
-from promptgrimoire.db.models import Activity, Week, Workspace
+from promptgrimoire.db.models import Activity, Workspace
 from promptgrimoire.db.weeks import purge_activity
 from promptgrimoire.db.workspaces import has_student_workspaces
 
 if TYPE_CHECKING:
+    from types import EllipsisType
     from uuid import UUID
 
 
@@ -122,17 +123,18 @@ def _apply_sentinel_fields(model: Activity, **fields: object) -> None:
             setattr(model, attr, value)
 
 
-async def update_activity(
+async def update_activity(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     activity_id: UUID,
+    *,
     title: str | None = None,
-    description: str | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (clear description)
-    copy_protection: bool | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (reset to inherit)
-    allow_sharing: bool | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (reset to inherit)
-    anonymous_sharing: bool | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (reset to inherit)
-    allow_tag_creation: bool | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (reset to inherit)
-    word_minimum: int | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (clear minimum)
-    word_limit: int | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (clear limit)
-    word_limit_enforcement: bool | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None (reset to inherit)
+    description: str | EllipsisType | None = ...,
+    copy_protection: bool | EllipsisType | None = ...,
+    allow_sharing: bool | EllipsisType | None = ...,
+    anonymous_sharing: bool | EllipsisType | None = ...,
+    allow_tag_creation: bool | EllipsisType | None = ...,
+    word_minimum: int | EllipsisType | None = ...,
+    word_limit: int | EllipsisType | None = ...,
+    word_limit_enforcement: bool | EllipsisType | None = ...,
 ) -> Activity | None:
     """Update activity details.
 
@@ -217,12 +219,20 @@ async def delete_activity(
 async def list_activities_for_week(week_id: UUID) -> list[Activity]:
     """List all activities for a week, ordered by created_at."""
     async with get_session() as session:
-        result = await session.exec(
-            select(Activity)
-            .where(Activity.week_id == week_id)
-            .order_by(Activity.created_at)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, week_id, type, template_workspace_id, title,
+                       description, copy_protection, allow_sharing,
+                       anonymous_sharing, allow_tag_creation, word_minimum,
+                       word_limit, word_limit_enforcement, created_at, updated_at
+                FROM activity
+                WHERE week_id = {week_id}
+                ORDER BY created_at
+                """
+            )
         )
-        return list(result.all())
+        return [Activity(**row._mapping) for row in result.all()]
 
 
 async def list_activities_for_course(course_id: UUID) -> list[Activity]:
@@ -231,10 +241,19 @@ async def list_activities_for_course(course_id: UUID) -> list[Activity]:
     Returns activities across all weeks, ordered by week number then created_at.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Activity)
-            .join(Week, Activity.week_id == Week.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement, not bool
-            .where(Week.course_id == course_id)
-            .order_by(Week.week_number, Activity.created_at)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT a.id, a.week_id, a.type, a.template_workspace_id, a.title,
+                       a.description, a.copy_protection, a.allow_sharing,
+                       a.anonymous_sharing, a.allow_tag_creation, a.word_minimum,
+                       a.word_limit, a.word_limit_enforcement, a.created_at,
+                       a.updated_at
+                FROM activity a
+                JOIN week w ON w.id = a.week_id
+                WHERE w.course_id = {course_id}
+                ORDER BY w.week_number, a.created_at
+                """
+            )
         )
-        return list(result.all())
+        return [Activity(**row._mapping) for row in result.all()]

--- a/src/promptgrimoire/db/courses.py
+++ b/src/promptgrimoire/db/courses.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import text
+from sqlalchemy import text, tstring
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
@@ -17,7 +17,6 @@ from promptgrimoire.db.models import (
     Activity,
     Course,
     CourseEnrollment,
-    User,
     Week,
     Workspace,
 )
@@ -25,6 +24,7 @@ from promptgrimoire.db.weeks import purge_activity
 from promptgrimoire.db.workspaces import has_student_workspaces
 
 if TYPE_CHECKING:
+    from types import EllipsisType
     from uuid import UUID
 
     from sqlmodel.ext.asyncio.session import AsyncSession
@@ -98,14 +98,15 @@ async def list_courses(
         return list(result.all())
 
 
-async def update_course(
+async def update_course(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     course_id: UUID,
+    *,
     name: str | None = None,
-    default_copy_protection: bool = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    default_allow_sharing: bool = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    default_anonymous_sharing: bool = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    default_allow_tag_creation: bool = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    default_word_limit_enforcement: bool = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
+    default_copy_protection: bool | EllipsisType = ...,
+    default_allow_sharing: bool | EllipsisType = ...,
+    default_anonymous_sharing: bool | EllipsisType = ...,
+    default_allow_tag_creation: bool | EllipsisType = ...,
+    default_word_limit_enforcement: bool | EllipsisType = ...,
 ) -> Course | None:
     """Update a course's mutable fields.
 
@@ -190,10 +191,12 @@ async def _fetch_course_children(
     if not week_ids:
         return weeks, []
 
+    # ty cannot type ``Activity.week_id.in_(...)`` (Model.field descriptor,
+    # astral-sh/ty#3421); go through .metadata.tables[...] for a plain Core
+    # Column instead, still returning session-attached Activity instances.
+    activity_table = Activity.metadata.tables[Activity.__tablename__]
     activity_rows = await session.exec(
-        select(Activity).where(
-            Activity.week_id.in_(week_ids)  # type: ignore[union-attr]  -- Column has .in_()
-        )
+        select(Activity).where(activity_table.c.week_id.in_(week_ids))
     )
     return weeks, list(activity_rows.all())
 
@@ -250,10 +253,13 @@ async def delete_course(
             await purge_activity(session, act)
 
         # Delete loose workspaces (course-placed, no activity)
+        # ty cannot type ``Workspace.activity_id.is_(...)`` (Model.field
+        # descriptor, astral-sh/ty#3421); use the plain Core Column instead.
+        workspace_table = Workspace.metadata.tables[Workspace.__tablename__]
         loose_rows = await session.exec(
             select(Workspace).where(
                 Workspace.course_id == course_id,
-                Workspace.activity_id.is_(None),  # type: ignore[union-attr]  -- Column has .is_()
+                workspace_table.c.activity_id.is_(None),
             )
         )
         for ws in loose_rows.all():
@@ -362,12 +368,17 @@ async def list_user_enrollments(user_id: UUID) -> list[CourseEnrollment]:
         List of CourseEnrollment objects.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(CourseEnrollment)
-            .where(CourseEnrollment.user_id == user_id)
-            .order_by("created_at")
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, course_id, user_id, role, created_at
+                FROM course_enrollment
+                WHERE user_id = {user_id}
+                ORDER BY created_at
+                """
+            )
         )
-        return list(result.all())
+        return [CourseEnrollment(**row._mapping) for row in result.all()]
 
 
 async def list_course_enrollments(course_id: UUID) -> list[CourseEnrollment]:
@@ -380,12 +391,17 @@ async def list_course_enrollments(course_id: UUID) -> list[CourseEnrollment]:
         List of CourseEnrollment objects.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(CourseEnrollment)
-            .where(CourseEnrollment.course_id == course_id)
-            .order_by("role", "user_id")
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, course_id, user_id, role, created_at
+                FROM course_enrollment
+                WHERE course_id = {course_id}
+                ORDER BY role, user_id
+                """
+            )
         )
-        return list(result.all())
+        return [CourseEnrollment(**row._mapping) for row in result.all()]
 
 
 async def list_enrollment_rows(course_id: UUID) -> list[dict[str, Any]]:
@@ -401,22 +417,28 @@ async def list_enrollment_rows(course_id: UUID) -> list[dict[str, Any]]:
         List of dicts ready for ui.table rows parameter.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(CourseEnrollment, User)
-            .join(User, User.id == CourseEnrollment.user_id)  # type: ignore[arg-type]  -- SQLModel Column expression valid at runtime; ty infers InstrumentedAttribute mismatch
-            .where(CourseEnrollment.course_id == course_id)
-            .order_by(CourseEnrollment.role, User.display_name)
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT ce.role, ce.created_at, ce.user_id,
+                       u.email, u.display_name, u.student_id
+                FROM course_enrollment ce
+                JOIN "user" u ON u.id = ce.user_id
+                WHERE ce.course_id = {course_id}
+                ORDER BY ce.role, u.display_name
+                """
+            )
         )
         return [
             {
-                "email": user.email,
-                "display_name": user.display_name,
-                "student_id": user.student_id or "",
-                "role": enrollment.role,
-                "created_at": enrollment.created_at.isoformat(),
-                "user_id": str(enrollment.user_id),
+                "email": row.email,
+                "display_name": row.display_name,
+                "student_id": row.student_id or "",
+                "role": row.role,
+                "created_at": row.created_at.isoformat(),
+                "user_id": str(row.user_id),
             }
-            for enrollment, user in result.all()
+            for row in result.all()
         ]
 
 
@@ -515,4 +537,8 @@ async def list_students_without_workspaces(
             text(_ZERO_WORKSPACE_SQL),
             {"course_id": course_id},
         )
-        return [(row[0], row[1]) for row in result.all()]
+        # Attribute access by label, not row[0]/row[1] -- SQLModel's
+        # AsyncSession.execute() stub declares Result[Any], which ty resolves
+        # as a length-1 Row TypeVarTuple; positional indexing past 0 is
+        # flagged as out-of-bounds even though the query selects two columns.
+        return [(row.display_name, row.email) for row in result.all()]

--- a/src/promptgrimoire/db/engine.py
+++ b/src/promptgrimoire/db/engine.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 _pool_logger = structlog.get_logger(f"{__name__}.pool")
 
+# Session-acquire time above which a warning (rather than debug) log fires,
+# signalling pool contention.
+_SLOW_SESSION_ACQUIRE_MS = 5
+
 
 def _pool_status(pool: object) -> str:
     """Format current pool status for logging."""
@@ -337,7 +341,7 @@ async def get_session() -> AsyncIterator[AsyncSession]:
     _t0 = _time.monotonic()
     async with session_factory() as session:
         _acquire_ms = round((_time.monotonic() - _t0) * 1000)
-        if _acquire_ms > 5:
+        if _acquire_ms > _SLOW_SESSION_ACQUIRE_MS:
             _pool_logger.warning(
                 "session_acquire_slow",
                 acquire_ms=_acquire_ms,

--- a/src/promptgrimoire/db/enrolment.py
+++ b/src/promptgrimoire/db/enrolment.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import structlog
-from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import select
 
 from promptgrimoire.db.courses import _enroll_user_with_session
 from promptgrimoire.db.engine import get_session
@@ -138,11 +138,7 @@ async def _apply_student_id_overwrites(
 ) -> int:
     """Force-overwrite conflicting student_ids. Returns count."""
     for email, _old, new_id in conflicts:
-        result = await session.execute(
-            select(User).where(
-                User.email == email.lower(),  # type: ignore[arg-type]  -- SQLAlchemy column expression
-            )
-        )
+        result = await session.execute(select(User).where(User.email == email.lower()))
         user = result.scalar_one()
         user.student_id = new_id
         session.add(user)
@@ -197,15 +193,18 @@ async def _create_groups_and_memberships(
             stmt = stmt.on_conflict_do_nothing(
                 constraint="uq_student_group_course_name",
             )
-            result = await session.execute(stmt)
-            if result.rowcount == 1:  # type: ignore[union-attr]  -- CursorResult has rowcount
+            # session.exec(), not .execute() -- the deprecated .execute()
+            # stub declares Result[Any] with no .rowcount; .exec() resolves
+            # an Insert/UpdateBase statement to CursorResult[Any], which has it.
+            result = await session.exec(stmt)
+            if result.rowcount == 1:
                 groups_created += 1
 
             # Query back to get the actual group row
             group_result = await session.execute(
                 select(StudentGroup).where(
-                    StudentGroup.course_id == course_id,  # type: ignore[arg-type]  -- SQLAlchemy column expression
-                    StudentGroup.name == group_name,  # type: ignore[arg-type]  -- SQLAlchemy column expression
+                    StudentGroup.course_id == course_id,
+                    StudentGroup.name == group_name,
                 )
             )
             group = group_result.scalar_one()
@@ -219,8 +218,8 @@ async def _create_groups_and_memberships(
             mem_stmt = mem_stmt.on_conflict_do_nothing(
                 constraint="uq_student_group_membership_group_user",
             )
-            mem_result = await session.execute(mem_stmt)
-            if mem_result.rowcount == 1:  # type: ignore[union-attr]  -- CursorResult has rowcount
+            mem_result = await session.exec(mem_stmt)
+            if mem_result.rowcount == 1:
                 memberships_created += 1
 
     return groups_created, memberships_created

--- a/src/promptgrimoire/db/export_jobs.py
+++ b/src/promptgrimoire/db/export_jobs.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 import structlog
+from sqlalchemy import tstring
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 
@@ -41,16 +42,21 @@ async def create_export_job(
     is the real guard; the application check provides a friendly error.
     """
     async with get_session() as session:
-        # Application-level check (friendly error, not race-proof)
-        existing = (
-            await session.exec(
-                select(ExportJob).where(
-                    ExportJob.user_id == user_id,
-                    ExportJob.status.in_(["queued", "running"]),  # type: ignore[union-attr]  -- Column has .in_()
-                )
+        # Application-level check (friendly error, not race-proof). Raw SQL,
+        # not ORM select().where(Model.field.in_(...)) -- only existence is
+        # needed, and ty cannot type a bare .in_() call on a Model column
+        # descriptor (astral-sh/ty#3421).
+        active_statuses = ["queued", "running"]
+        existing = await session.execute(
+            tstring(
+                t"""
+                SELECT 1 FROM export_job
+                WHERE user_id = {user_id} AND status = ANY({active_statuses})
+                LIMIT 1
+                """
             )
-        ).first()
-        if existing:
+        )
+        if existing.first() is not None:
             raise BusinessLogicError("A PDF export is already in progress")
 
         job = ExportJob(

--- a/src/promptgrimoire/db/navigator.py
+++ b/src/promptgrimoire/db/navigator.py
@@ -550,6 +550,11 @@ def _build_prefix_query(raw: str) -> str:
     return " & ".join(safe)
 
 
+# Below this length, an FTS prefix search is too broad to be useful and is
+# skipped rather than sent to the database.
+_MIN_SEARCH_QUERY_LENGTH = 3
+
+
 async def search_navigator(
     query: str,
     *,
@@ -565,7 +570,7 @@ async def search_navigator(
     Returns NavigatorRows with snippet and rank, ordered by relevance.
     """
     stripped = query.strip()
-    if len(stripped) < 3:
+    if len(stripped) < _MIN_SEARCH_QUERY_LENGTH:
         return []
 
     prefix_query = _build_prefix_query(stripped)

--- a/src/promptgrimoire/db/roles.py
+++ b/src/promptgrimoire/db/roles.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy import tstring
 from sqlmodel import select
 
 from promptgrimoire.db.engine import get_session
@@ -46,15 +47,14 @@ async def get_all_roles(*, session: AsyncSession | None = None) -> tuple[str, ..
     """
     global _all_roles_cache  # noqa: PLW0603
     if _all_roles_cache is None:
+        query = tstring(t"SELECT name FROM course_role ORDER BY level")
         if session is None:
             async with get_session() as db_session:
-                result = await db_session.exec(
-                    select(CourseRoleRef.name).order_by("level")
-                )
-                _all_roles_cache = tuple(result.all())
+                result = await db_session.execute(query)
+                _all_roles_cache = tuple(row.name for row in result.all())
         else:
-            result = await session.exec(select(CourseRoleRef.name).order_by("level"))
-            _all_roles_cache = tuple(result.all())
+            result = await session.execute(query)
+            _all_roles_cache = tuple(row.name for row in result.all())
     return _all_roles_cache
 
 

--- a/src/promptgrimoire/db/tags.py
+++ b/src/promptgrimoire/db/tags.py
@@ -10,11 +10,12 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import text, tstring
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import func, select
@@ -33,6 +34,7 @@ from promptgrimoire.db.models import Tag, TagGroup
 logger = structlog.get_logger()
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from types import EllipsisType
     from uuid import UUID
 
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -174,7 +176,18 @@ async def get_tag_group(group_id: UUID) -> TagGroup | None:
         return await session.get(TagGroup, group_id)
 
 
-_UNSET = object()
+class _Unset(Enum):
+    """Sentinel enum member distinguishing "not provided" from explicit ``None``.
+
+    A plain ``object()`` singleton cannot be narrowed by ty's ``is``/``is not``
+    analysis (it stays typed as ``object`` after the check), so a single-member
+    enum is used instead -- ty narrows enum-literal identity checks correctly.
+    """
+
+    TOKEN = auto()
+
+
+_UNSET = _Unset.TOKEN
 
 
 async def _flush_or_detect_duplicate(
@@ -203,13 +216,13 @@ async def update_tag_group(
     group_id: UUID,
     name: str | None = None,
     order_index: int | None = None,
-    # ``color`` uses the ``_UNSET`` object sentinel (not ``...``) because the
+    # ``color`` uses the ``_UNSET`` enum sentinel (not ``...``) because the
     # parameter lives in the public function signature where ``Ellipsis`` as a
     # default looks unusual to callers.  The ``_UNSET`` name makes the intent
     # ("omitted") explicit.  ``update_tag`` uses ``...`` (Ellipsis) for the
     # same purpose in an internal helper -- both patterns are valid, but we keep
     # them separate here for readability.
-    color: str | None | object = _UNSET,
+    color: str | _Unset | None = _UNSET,
     *,
     crdt_doc: AnnotationDocument | None = None,
 ) -> TagGroup | None:
@@ -223,7 +236,7 @@ async def update_tag_group(
         DuplicateNameError: If *name* conflicts with an existing group name.
     """
     if color is not _UNSET and color is not None:
-        _validate_hex_color(str(color))
+        _validate_hex_color(color)
 
     async with get_session() as session:
         group = await session.get(TagGroup, group_id)
@@ -235,7 +248,7 @@ async def update_tag_group(
         if order_index is not None:
             group.order_index = order_index
         if color is not _UNSET:
-            group.color = color  # type: ignore[assignment]  -- sentinel pattern
+            group.color = color
 
         session.add(group)
         duplicate = await _flush_or_detect_duplicate(
@@ -298,18 +311,23 @@ async def delete_tag_group(
 async def list_tag_groups_for_workspace(workspace_id: UUID) -> list[TagGroup]:
     """List all TagGroups for a workspace, ordered by order_index."""
     async with get_session() as session:
-        result = await session.exec(
-            select(TagGroup)
-            .where(TagGroup.workspace_id == workspace_id)
-            .order_by(TagGroup.order_index)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, workspace_id, name, color, order_index, created_at
+                FROM tag_group
+                WHERE workspace_id = {workspace_id}
+                ORDER BY order_index
+                """
+            )
         )
-        return list(result.all())
+        return [TagGroup(**row._mapping) for row in result.all()]
 
 
 # ── Tag CRUD ─────────────────────────────────────────────────────────
 
 
-async def create_tag(
+async def create_tag(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     workspace_id: UUID,
     name: str,
     color: str,
@@ -411,15 +429,21 @@ async def get_tag(tag_id: UUID) -> Tag | None:
         return await session.get(Tag, tag_id)
 
 
-def _enforce_tag_lock(
-    tag: Tag,
-    *,
-    bypass_lock: bool,
-    name: object,
-    color: object,
-    description: object,
-    group_id: object,
-) -> None:
+@dataclass(frozen=True, slots=True)
+class _TagFieldUpdate:
+    """Sentinel-typed partial-update fields shared by lock-checking and apply.
+
+    Bundles ``update_tag``'s four Ellipsis-sentinel fields so the two
+    single-call-site helpers below take one param instead of four.
+    """
+
+    name: str | EllipsisType
+    color: str | EllipsisType
+    description: str | EllipsisType | None
+    group_id: UUID | EllipsisType | None
+
+
+def _enforce_tag_lock(tag: Tag, fields: _TagFieldUpdate, *, bypass_lock: bool) -> None:
     """Raise TagLockedError if a locked tag has non-lock field changes.
 
     Skipped when ``bypass_lock`` is True (instructor operations).
@@ -427,7 +451,8 @@ def _enforce_tag_lock(
     if not tag.locked or bypass_lock:
         return
     has_non_lock_changes = any(
-        v is not ... for v in [name, color, description, group_id]
+        v is not ...
+        for v in (fields.name, fields.color, fields.description, fields.group_id)
     )
     if has_non_lock_changes:
         msg = "Tag is locked"
@@ -435,23 +460,17 @@ def _enforce_tag_lock(
 
 
 def _apply_tag_field_updates(
-    tag: Tag,
-    *,
-    name: object,
-    color: object,
-    description: object,
-    group_id: object,
-    locked: bool | None,
+    tag: Tag, fields: _TagFieldUpdate, *, locked: bool | None
 ) -> None:
     """Apply Ellipsis-sentinel partial updates to a Tag model."""
-    if name is not ...:
-        tag.name = name  # type: ignore[assignment]  -- Ellipsis sentinel already checked
-    if color is not ...:
-        tag.color = color  # type: ignore[assignment]  -- Ellipsis sentinel already checked
-    if description is not ...:
-        tag.description = description  # type: ignore[assignment]  -- Ellipsis sentinel already checked
-    if group_id is not ...:
-        tag.group_id = group_id  # type: ignore[assignment]  -- Ellipsis sentinel already checked
+    if fields.name is not ...:
+        tag.name = fields.name
+    if fields.color is not ...:
+        tag.color = fields.color
+    if fields.description is not ...:
+        tag.description = fields.description
+    if fields.group_id is not ...:
+        tag.group_id = fields.group_id
     if locked is not None:
         tag.locked = locked
 
@@ -472,13 +491,13 @@ def _sync_tag_to_crdt(tag: Tag, crdt_doc: AnnotationDocument) -> None:
         )
 
 
-async def update_tag(
+async def update_tag(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     tag_id: UUID,
     *,
-    name: str | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel distinguishes "not provided" from explicit None
-    color: str | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    description: str | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
-    group_id: UUID | None = ...,  # type: ignore[assignment]  -- Ellipsis sentinel
+    name: str | EllipsisType = ...,
+    color: str | EllipsisType = ...,
+    description: str | EllipsisType | None = ...,
+    group_id: UUID | EllipsisType | None = ...,
     locked: bool | None = None,
     bypass_lock: bool = False,
     crdt_doc: AnnotationDocument | None = None,
@@ -490,32 +509,26 @@ async def update_tag(
     may be changed (to allow instructor lock toggle); all other field
     changes raise ``TagLockedError``.
 
+    ``name`` and ``color`` cannot be cleared to ``None`` -- both are
+    NOT NULL columns on ``Tag`` -- so their sentinel type omits ``None``
+    (unlike ``description``/``group_id``, which are nullable).
+
     Pass ``bypass_lock=True`` to allow instructors to edit locked tags.
     """
-    if color is not ... and color is not None:
+    if color is not ...:
         _validate_hex_color(color)
+
+    fields = _TagFieldUpdate(
+        name=name, color=color, description=description, group_id=group_id
+    )
 
     async with get_session() as session:
         tag = await session.get(Tag, tag_id)
         if not tag:
             return None
 
-        _enforce_tag_lock(
-            tag,
-            bypass_lock=bypass_lock,
-            name=name,
-            color=color,
-            description=description,
-            group_id=group_id,
-        )
-        _apply_tag_field_updates(
-            tag,
-            name=name,
-            color=color,
-            description=description,
-            group_id=group_id,
-            locked=locked,
-        )
+        _enforce_tag_lock(tag, fields, bypass_lock=bypass_lock)
+        _apply_tag_field_updates(tag, fields, locked=locked)
 
         session.add(tag)
         duplicate_name = await _flush_or_detect_duplicate(
@@ -610,12 +623,18 @@ async def delete_tag(
 async def list_tags_for_workspace(workspace_id: UUID) -> list[Tag]:
     """List all Tags for a workspace, ordered by order_index."""
     async with get_session() as session:
-        result = await session.exec(
-            select(Tag)
-            .where(Tag.workspace_id == workspace_id)
-            .order_by(Tag.order_index)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, workspace_id, group_id, name, description, color,
+                       locked, order_index, created_at
+                FROM tag
+                WHERE workspace_id = {workspace_id}
+                ORDER BY order_index
+                """
+            )
         )
-        return list(result.all())
+        return [Tag(**row._mapping) for row in result.all()]
 
 
 # ── Reorder ──────────────────────────────────────────────────────────
@@ -764,93 +783,114 @@ class ImportResult:
     skipped_groups: int = 0
 
 
+@dataclass(slots=True)
+class _ImportContext:
+    """Mutable state threaded through one import_tags_from_workspace() run.
+
+    Bundles the session, target workspace, and the two in-place-mutated
+    accumulators so ``_import_groups``/``_import_tags`` take three params
+    instead of six.
+    """
+
+    session: AsyncSession
+    target_workspace_id: UUID
+    group_id_map: dict[UUID, UUID]
+    result_obj: ImportResult
+
+
 async def _import_groups(
-    session: AsyncSession,
+    ctx: _ImportContext,
     source_groups: list[TagGroup],
-    target_workspace_id: UUID,
     base_order: int,
-    result_obj: ImportResult,
-    group_id_map: dict[UUID, UUID],
 ) -> None:
     """Insert source groups into target via ON CONFLICT DO NOTHING.
 
-    Populates *result_obj* and *group_id_map* in place.
+    Populates *ctx.result_obj* and *ctx.group_id_map* in place.
     """
+    # ty cannot type ``TagGroup.__table__`` (SQLModel metaclass access, #3421);
+    # go through .metadata.tables[...] to get a plain Core Table/Column instead.
+    tag_group_table = TagGroup.metadata.tables[TagGroup.__tablename__]
     for idx, src_group in enumerate(source_groups):
         new_id = uuid4()
         stmt = (
             pg_insert(TagGroup)
             .values(
                 id=new_id,
-                workspace_id=target_workspace_id,
+                workspace_id=ctx.target_workspace_id,
                 name=src_group.name,
                 color=src_group.color or "#808080",
                 order_index=base_order + idx,
                 created_at=datetime.now(UTC),
             )
             .on_conflict_do_nothing(constraint="uq_tag_group_workspace_name")
-            .returning(TagGroup.__table__.c.id)  # type: ignore[union-attr]  -- SQLModel __table__
+            .returning(tag_group_table.c.id)
         )
-        insert_result = await session.execute(stmt)
+        insert_result = await ctx.session.execute(stmt)
         created_id = insert_result.scalar_one_or_none()
 
         if created_id is not None:
-            created_group = await session.get(TagGroup, created_id)
+            created_group = await ctx.session.get(TagGroup, created_id)
             assert created_group is not None  # noqa: S101  -- RETURNING guarantees non-None after insert
-            result_obj.created_groups.append(created_group)
-            group_id_map[src_group.id] = created_id
+            ctx.result_obj.created_groups.append(created_group)
+            ctx.group_id_map[src_group.id] = created_id
         else:
-            result_obj.skipped_groups += 1
-            existing = await session.execute(
-                select(TagGroup).where(
-                    TagGroup.workspace_id == target_workspace_id,
-                    TagGroup.name == src_group.name,
+            ctx.result_obj.skipped_groups += 1
+            target_workspace_id = ctx.target_workspace_id
+            src_group_name = src_group.name
+            existing_id = await ctx.session.execute(
+                tstring(
+                    t"""
+                    SELECT id FROM tag_group
+                    WHERE workspace_id = {target_workspace_id}
+                      AND name = {src_group_name}
+                    """
                 )
             )
-            existing_group = existing.scalar_one()
-            group_id_map[src_group.id] = existing_group.id
+            ctx.group_id_map[src_group.id] = existing_id.scalar_one()
 
 
 async def _import_tags(
-    session: AsyncSession,
+    ctx: _ImportContext,
     source_tags: list[Tag],
-    target_workspace_id: UUID,
     base_order: int,
-    group_id_map: dict[UUID, UUID],
-    result_obj: ImportResult,
 ) -> None:
     """Insert source tags into target via ON CONFLICT DO NOTHING.
 
-    Populates *result_obj* in place.
+    Populates *ctx.result_obj* in place.
     """
+    # ty cannot type ``Tag.__table__`` (SQLModel metaclass access, #3421);
+    # go through .metadata.tables[...] to get a plain Core Table/Column instead.
+    tag_table = Tag.metadata.tables[Tag.__tablename__]
     for src_tag in source_tags:
-        new_group_id = group_id_map.get(src_tag.group_id) if src_tag.group_id else None
+        new_group_id = (
+            ctx.group_id_map.get(src_tag.group_id) if src_tag.group_id else None
+        )
         new_id = uuid4()
         stmt = (
             pg_insert(Tag)
             .values(
                 id=new_id,
-                workspace_id=target_workspace_id,
+                workspace_id=ctx.target_workspace_id,
                 name=src_tag.name,
                 color=src_tag.color,
                 group_id=new_group_id,
                 description=src_tag.description,
                 locked=False,
-                order_index=base_order + len(result_obj.created_tags),
+                order_index=base_order + len(ctx.result_obj.created_tags),
                 created_at=datetime.now(UTC),
             )
             .on_conflict_do_nothing(constraint="uq_tag_workspace_name")
-            .returning(Tag.__table__.c.id)  # type: ignore[union-attr]  -- SQLModel __table__
+            .returning(tag_table.c.id)
         )
-        insert_result = await session.execute(stmt)
+        insert_result = await ctx.session.execute(stmt)
         created_id = insert_result.scalar_one_or_none()
 
         if created_id is not None:
-            created_tag = await session.get(Tag, created_id)
+            created_tag = await ctx.session.get(Tag, created_id)
             assert created_tag is not None  # noqa: S101  -- RETURNING guarantees non-None after insert
-            result_obj.created_tags.append(created_tag)
+            ctx.result_obj.created_tags.append(created_tag)
         else:
-            result_obj.skipped_tags += 1
+            ctx.result_obj.skipped_tags += 1
 
 
 def _import_crdt_dual_write(
@@ -933,23 +973,22 @@ async def import_tags_from_workspace(
         if row is None:
             msg = f"Workspace {target_workspace_id} not found"
             raise ValueError(msg)
+        # Attribute access by label, not row[0]/row[1] -- SQLModel's
+        # AsyncSession.execute() stub declares Result[Any], which ty resolves
+        # as a length-1 Row TypeVarTuple; positional indexing past 0 is
+        # therefore flagged as out-of-bounds even though the query selects
+        # two columns. See docs/architecture/raw-sql-convention.md.
+        next_group_order = row.next_group_order
+        next_tag_order = row.next_tag_order
 
-        await _import_groups(
-            session,
-            source_groups,
-            target_workspace_id,
-            row[0],
-            result_obj,
-            group_id_map,
+        ctx = _ImportContext(
+            session=session,
+            target_workspace_id=target_workspace_id,
+            group_id_map=group_id_map,
+            result_obj=result_obj,
         )
-        await _import_tags(
-            session,
-            source_tags,
-            target_workspace_id,
-            row[1],
-            group_id_map,
-            result_obj,
-        )
+        await _import_groups(ctx, source_groups, next_group_order)
+        await _import_tags(ctx, source_tags, next_tag_order)
 
         # Counter bumps
         if result_obj.created_groups:

--- a/src/promptgrimoire/db/users.py
+++ b/src/promptgrimoire/db/users.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import tstring
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import col, select
 
@@ -142,10 +143,13 @@ async def _find_or_create_user_with_session(
         created_at=datetime.now(UTC),
     )
     stmt = stmt.on_conflict_do_nothing(index_elements=["email"])
-    result = await session.execute(stmt)
+    # session.exec(), not .execute() -- the deprecated .execute() stub
+    # declares Result[Any] with no .rowcount; .exec() resolves an Insert
+    # statement to CursorResult[Any], which has it.
+    result = await session.exec(stmt)
     await session.flush()
 
-    created = result.rowcount == 1  # type: ignore[union-attr]  -- CursorResult always has rowcount
+    created = result.rowcount == 1
 
     user_result = await session.exec(select(User).where(User.email == normalized_email))
     user = user_result.one()
@@ -294,11 +298,30 @@ async def list_users(*, include_inactive: bool = False) -> list[User]:
         List of User objects ordered by email.
     """
     async with get_session() as session:
-        query = select(User).order_by("email")
-        if not include_inactive:
-            query = query.where(User.last_login != None)  # noqa: E711
-        result = await session.exec(query)
-        return list(result.all())
+        if include_inactive:
+            result = await session.execute(
+                tstring(
+                    t"""
+                    SELECT id, email, display_name, stytch_member_id, is_admin,
+                           is_banned, banned_at, student_id, created_at, last_login
+                    FROM "user"
+                    ORDER BY email
+                    """
+                )
+            )
+        else:
+            result = await session.execute(
+                tstring(
+                    t"""
+                    SELECT id, email, display_name, stytch_member_id, is_admin,
+                           is_banned, banned_at, student_id, created_at, last_login
+                    FROM "user"
+                    WHERE last_login IS NOT NULL
+                    ORDER BY email
+                    """
+                )
+            )
+        return [User(**row._mapping) for row in result.all()]
 
 
 async def list_all_users() -> list[User]:
@@ -308,8 +331,17 @@ async def list_all_users() -> list[User]:
         List of User objects ordered by email.
     """
     async with get_session() as session:
-        result = await session.exec(select(User).order_by("email"))
-        return list(result.all())
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, email, display_name, stytch_member_id, is_admin,
+                       is_banned, banned_at, student_id, created_at, last_login
+                FROM "user"
+                ORDER BY email
+                """
+            )
+        )
+        return [User(**row._mapping) for row in result.all()]
 
 
 async def upsert_user_on_login(

--- a/src/promptgrimoire/db/weeks.py
+++ b/src/promptgrimoire/db/weeks.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlmodel import or_, select
+from sqlalchemy import tstring
+from sqlmodel import select
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -73,10 +74,18 @@ async def list_weeks(course_id: UUID) -> list[Week]:
         List of Week objects ordered by week_number.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Week).where(Week.course_id == course_id).order_by("week_number")
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, course_id, week_number, title, is_published,
+                       visible_from, created_at
+                FROM week
+                WHERE course_id = {course_id}
+                ORDER BY week_number
+                """
+            )
         )
-        return list(result.all())
+        return [Week(**row._mapping) for row in result.all()]
 
 
 async def publish_week(week_id: UUID) -> bool:
@@ -320,26 +329,35 @@ async def get_visible_weeks(
         # Instructors and above see all weeks
         staff_roles = await get_staff_roles(session=session)
         if enrollment.role in staff_roles:
-            result = await session.exec(
-                select(Week).where(Week.course_id == course_id).order_by("week_number")
+            result = await session.execute(
+                tstring(
+                    t"""
+                    SELECT id, course_id, week_number, title, is_published,
+                           visible_from, created_at
+                    FROM week
+                    WHERE course_id = {course_id}
+                    ORDER BY week_number
+                    """
+                )
             )
-            return list(result.all())
+            return [Week(**row._mapping) for row in result.all()]
 
         # Students see published weeks where visible_from has passed
         now = datetime.now(UTC)
-        result = await session.exec(
-            select(Week)
-            .where(Week.course_id == course_id)
-            .where(Week.is_published == True)  # noqa: E712
-            .where(
-                or_(
-                    Week.visible_from == None,  # noqa: E711
-                    Week.visible_from <= now,  # type: ignore[operator]  # or_ handles None
-                )
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, course_id, week_number, title, is_published,
+                       visible_from, created_at
+                FROM week
+                WHERE course_id = {course_id}
+                  AND is_published = true
+                  AND (visible_from IS NULL OR visible_from <= {now})
+                ORDER BY week_number
+                """
             )
-            .order_by("week_number")
         )
-        return list(result.all())
+        return [Week(**row._mapping) for row in result.all()]
 
 
 async def can_access_week(

--- a/src/promptgrimoire/db/workspace_documents.py
+++ b/src/promptgrimoire/db/workspace_documents.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
-from sqlalchemy import func
+from sqlalchemy import func, tstring
 from sqlalchemy.orm import QueryableAttribute, defer
 from sqlmodel import select
 
@@ -25,11 +25,12 @@ if TYPE_CHECKING:
     from uuid import UUID
 
 
-async def add_document(
+async def add_document(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     workspace_id: UUID,
     type: str,
     content: str,
     source_type: str,
+    *,
     title: str | None = None,
     auto_number_paragraphs: bool = True,
     paragraph_map: dict[str, int] | None = None,
@@ -111,9 +112,13 @@ async def list_document_headers(workspace_id: UUID) -> list[WorkspaceDocument]:
             .options(
                 defer(cast("QueryableAttribute[Any]", WorkspaceDocument.content))
             )  # SQLModel exposes str; cast for ty
-            .order_by("order_index")
         )
-        return list(result.all())
+        # Kept ORM (defer() + DetachedInstanceError contract, see
+        # test_document_headers.py). Ordering can't live in SQL here without
+        # a magic-string order_by, so it's applied in Python instead.
+        headers = list(result.all())
+        headers.sort(key=lambda doc: doc.order_index)
+        return headers
 
 
 async def list_documents_with_first_content(
@@ -136,9 +141,12 @@ async def list_documents_with_first_content(
             .options(
                 defer(cast("QueryableAttribute[Any]", WorkspaceDocument.content))
             )  # SQLModel exposes str; cast for ty
-            .order_by("order_index")
         )
+        # Kept ORM (defer() + populate_existing() identity-map refresh below
+        # requires session-attached instances). Ordering applied in Python
+        # rather than a magic-string order_by.
         headers = list(result.all())
+        headers.sort(key=lambda doc: doc.order_index)
         if not headers:
             return headers, None
         # populate_existing refreshes the identity-mapped header instance so
@@ -161,12 +169,19 @@ async def list_documents(workspace_id: UUID) -> list[WorkspaceDocument]:
         List of WorkspaceDocument objects ordered by order_index.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(WorkspaceDocument)
-            .where(WorkspaceDocument.workspace_id == workspace_id)
-            .order_by("order_index")
+        result = await session.execute(
+            tstring(
+                t"""
+                SELECT id, workspace_id, type, content, source_type,
+                       order_index, title, created_at, auto_number_paragraphs,
+                       paragraph_map, source_document_id
+                FROM workspace_document
+                WHERE workspace_id = {workspace_id}
+                ORDER BY order_index
+                """
+            )
         )
-        return list(result.all())
+        return [WorkspaceDocument(**row._mapping) for row in result.all()]
 
 
 async def workspaces_with_documents(workspace_ids: set[UUID]) -> set[UUID]:
@@ -176,10 +191,13 @@ async def workspaces_with_documents(workspace_ids: set[UUID]) -> set[UUID]:
     """
     if not workspace_ids:
         return set()
+    # ty cannot type ``WorkspaceDocument.workspace_id.in_(...)`` (Model.field
+    # descriptor, astral-sh/ty#3421); use the plain Core Column instead.
+    doc_table = WorkspaceDocument.metadata.tables[WorkspaceDocument.__tablename__]
     async with get_session() as session:
         result = await session.exec(
             select(WorkspaceDocument.workspace_id)
-            .where(WorkspaceDocument.workspace_id.in_(workspace_ids))  # type: ignore[union-attr]  -- SQLAlchemy Column has .in_(); TODO(2026-Q2): Revisit when SQLModel updates type stubs
+            .where(doc_table.c.workspace_id.in_(workspace_ids))
             .distinct()
         )
         return set(result.all())

--- a/src/promptgrimoire/db/workspaces.py
+++ b/src/promptgrimoire/db/workspaces.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 import structlog
-from sqlalchemy import exists, func, text
-from sqlalchemy import select as sa_select
+from sqlalchemy import exists, func, text, tstring
 from sqlmodel import select
 
 from promptgrimoire.db.engine import get_session
@@ -23,9 +22,7 @@ from promptgrimoire.db.models import (
     Activity,
     Course,
     CourseEnrollment,
-    CourseRoleRef,
     ExportJob,
-    Permission,
     Tag,
     TagGroup,
     User,
@@ -57,16 +54,21 @@ async def get_user_workspace_for_activity(
     button and show "Resume" instead).
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Workspace)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement, not bool
-            .where(
-                Workspace.activity_id == activity_id,
-                ACLEntry.user_id == user_id,
-                ACLEntry.permission == "owner",
+        row = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.* FROM workspace w
+                    JOIN acl_entry a ON a.workspace_id = w.id
+                    WHERE w.activity_id = {activity_id}
+                      AND a.user_id = {user_id}
+                      AND a.permission = 'owner'
+                    LIMIT 1
+                    """
+                )
             )
-        )
-        return result.first()
+        ).first()
+        return Workspace.model_validate(row, from_attributes=True) if row else None
 
 
 async def has_student_workspaces(
@@ -268,38 +270,70 @@ class AnnotationContext:
     """
 
 
+@dataclass(frozen=True)
+class _HydratedRowEntities:
+    """Pre-fetched rows from a single joined query.
+
+    resolve_annotation_context's mega-join hydrates the explicit ACL
+    entry, Course, and Activity for a workspace in one round trip.
+    Threading them through as one object (rather than three positional
+    parameters) lets ``_resolve_effective_permission`` /
+    ``_resolve_enrollment_permission`` skip the ``session.get()`` calls a
+    naive port of the query would still make, while staying within the
+    PLR0913 argument-count limit (ADR 0007).
+
+    All fields are optional and independently nullable -- None always
+    falls back to a fresh lookup. When a field is not None, the caller
+    must guarantee ``course.id`` equals the course_id being resolved and
+    ``activity.id`` equals ``workspace.activity_id``;
+    resolve_annotation_context's join guarantees this by construction
+    (see its docstring's comment on the mega-join).
+    """
+
+    explicit: ACLEntry | None = None
+    course: Course | None = None
+    activity: Activity | None = None
+
+
 async def _resolve_enrollment_permission(
     session: AsyncSession,
     workspace: Workspace,
     course_id: UUID,
     user_id: UUID,
+    joined: _HydratedRowEntities | None = None,
 ) -> str | None:
     """Derive permission from course enrollment for a single user.
 
     Returns the derived permission string or None if the user has no
     enrollment-based access. Extracted from resolve_annotation_context
     to keep branch/statement counts within linter limits.
+
+    ``joined.course``/``joined.activity``, when the caller already holds
+    hydrated instances, are used instead of a fresh ``session.get()``.
+    See ``_HydratedRowEntities`` for the identity contract.
     """
-    enrollment_result = await session.exec(
-        select(CourseEnrollment.role, CourseRoleRef.is_staff)
-        .join(
-            CourseRoleRef,
-            CourseEnrollment.role == CourseRoleRef.name,  # type: ignore[arg-type] -- SQLAlchemy column comparison
+    enrollment = (
+        await session.execute(
+            tstring(
+                t"""
+                SELECT ce.role, cr.is_staff
+                FROM course_enrollment ce
+                JOIN course_role cr ON cr.name = ce.role
+                WHERE ce.course_id = {course_id} AND ce.user_id = {user_id}
+                """
+            )
         )
-        .where(
-            CourseEnrollment.course_id == course_id,
-            CourseEnrollment.user_id == user_id,
-        )
-    )
-    enrollment = enrollment_result.one_or_none()
+    ).first()
     if enrollment is None:
         return None
 
-    _enrollment_role, is_staff = enrollment
+    is_staff = enrollment.is_staff
     if not is_staff and not workspace.shared_with_class:
         return None
 
-    course = await session.get(Course, course_id)
+    course = joined.course if joined else None
+    if course is None:
+        course = await session.get(Course, course_id)
     if course is None:
         return None
 
@@ -309,10 +343,11 @@ async def _resolve_enrollment_permission(
     if not workspace.shared_with_class:
         return None
 
-    # Activity override for allow_sharing (identity map absorbs re-fetch)
+    activity = joined.activity if joined else None
     activity_override = None
     if workspace.activity_id is not None:
-        activity = await session.get(Activity, workspace.activity_id)
+        if activity is None:
+            activity = await session.get(Activity, workspace.activity_id)
         if activity is not None:
             activity_override = activity.allow_sharing
     allow_sharing = resolve_tristate(activity_override, course.default_allow_sharing)
@@ -324,7 +359,7 @@ async def _resolve_effective_permission(
     workspace: Workspace,
     placement: PlacementContext,
     user_id: UUID,
-    explicit: ACLEntry | None,
+    joined: _HydratedRowEntities,
 ) -> str | None:
     """Resolve the effective permission for a user on a workspace.
 
@@ -333,7 +368,13 @@ async def _resolve_effective_permission(
     permission level. Returns None if no access. Extracted from
     resolve_annotation_context to keep branch/statement counts within
     linter limits.
+
+    ``joined`` bundles the explicit ACL entry with the caller's already-
+    hydrated Course/Activity instances (see ``_HydratedRowEntities``) so
+    permission resolution never re-fetches rows resolve_annotation_context
+    already holds in memory.
     """
+    explicit = joined.explicit
     if explicit is not None and explicit.permission == "owner":
         return "owner"
 
@@ -345,17 +386,18 @@ async def _resolve_effective_permission(
     derived_permission: str | None = None
     if course_id is not None:
         derived_permission = await _resolve_enrollment_permission(
-            session, workspace, course_id, user_id
+            session, workspace, course_id, user_id, joined
         )
 
     # Highest wins
     if explicit and derived_permission:
-        level_result = await session.exec(
-            select(Permission.name, Permission.level).where(
-                Permission.name.in_([explicit.permission, derived_permission])  # type: ignore[unresolved-attribute]  -- Column has in_ at runtime
+        names = [explicit.permission, derived_permission]
+        level_rows = (
+            await session.execute(
+                tstring(t"SELECT name, level FROM permission WHERE name = ANY({names})")
             )
-        )
-        levels = dict(level_result.all())
+        ).all()
+        levels = {row.name: row.level for row in level_rows}
         e_level = levels[explicit.permission]
         d_level = levels[derived_permission]
         return explicit.permission if e_level >= d_level else derived_permission
@@ -376,19 +418,25 @@ async def _resolve_privileged_user_ids(
     """
     priv_course_id = placement.course_id or workspace.course_id
     if priv_course_id is not None:
-        privileged_result = await session.execute(
-            select(CourseEnrollment.user_id)
-            .join(
-                CourseRoleRef,
-                CourseEnrollment.role == CourseRoleRef.name,  # type: ignore[arg-type] -- SQLAlchemy column comparison
+        privileged_ids = (
+            (
+                await session.execute(
+                    tstring(
+                        t"""
+                    SELECT ce.user_id AS id
+                    FROM course_enrollment ce
+                    JOIN course_role cr ON cr.name = ce.role
+                    WHERE ce.course_id = {priv_course_id} AND cr.is_staff = true
+                    UNION
+                    SELECT id FROM "user" WHERE is_admin = true
+                    """
+                    )
+                )
             )
-            .where(
-                CourseEnrollment.course_id == priv_course_id,
-                CourseRoleRef.is_staff == True,  # noqa: E712
-            )
-            .union(select(User.id).where(User.is_admin == True))  # noqa: E712
+            .scalars()
+            .all()
         )
-        return frozenset(str(row[0]) for row in privileged_result.all())
+        return frozenset(str(uid) for uid in privileged_ids)
 
     admin_result = await session.exec(
         select(User.id).where(User.is_admin == True)  # noqa: E712
@@ -440,55 +488,75 @@ async def resolve_annotation_context(
         # unique per (workspace, user); activity/week join on primary keys;
         # course joins on the activity chain's course or, for course-placed
         # workspaces, the workspace's own course.
-        template_exists = exists(
-            select(Activity.id).where(Activity.template_workspace_id == workspace_id)
-        )
-        ws_result = await session.execute(
-            sa_select(
-                Workspace,
-                template_exists.label("is_template"),
-                ACLEntry,
-                Activity,
-                Week,
-                Course,
+        #
+        # Workspace's own columns come back unprefixed (`w.*`) so
+        # Workspace.model_validate() hydrates it directly -- this keeps
+        # crdt_state as real bytes. The other three joined tables are
+        # scalar-only (no bytea columns), so `to_jsonb(...)` avoids the
+        # column-name collisions a flat multi-table SELECT would hit,
+        # without paying for a manual per-column alias list.
+        ws_row = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.*,
+                           EXISTS(
+                               SELECT 1 FROM activity
+                               WHERE activity.template_workspace_id = w.id
+                           ) AS is_template,
+                           to_jsonb(acl.*) AS acl_json,
+                           to_jsonb(a.*) AS activity_json,
+                           to_jsonb(wk.*) AS week_json,
+                           to_jsonb(c.*) AS course_json
+                    FROM workspace w
+                    LEFT JOIN acl_entry acl
+                        ON acl.workspace_id = w.id AND acl.user_id = {user_id}
+                    LEFT JOIN activity a ON a.id = w.activity_id
+                    LEFT JOIN week wk ON wk.id = a.week_id
+                    LEFT JOIN course c ON c.id = COALESCE(wk.course_id, w.course_id)
+                    WHERE w.id = {workspace_id}
+                    """
+                )
             )
-            .outerjoin(
-                ACLEntry,
-                (ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- Column == returns ColumnElement
-                & (ACLEntry.user_id == user_id),
-            )
-            .outerjoin(
-                Activity,
-                Activity.id == Workspace.activity_id,  # type: ignore[arg-type]  -- Column == returns ColumnElement
-            )
-            .outerjoin(
-                Week,
-                Week.id == Activity.week_id,  # type: ignore[arg-type]  -- Column == returns ColumnElement
-            )
-            .outerjoin(
-                Course,
-                Course.id  # type: ignore[arg-type]  -- Column == returns ColumnElement
-                == func.coalesce(Week.course_id, Workspace.course_id),
-            )
-            .where(Workspace.id == workspace_id)  # type: ignore[arg-type]  -- Column == returns ColumnElement
-        )
-        ws_row = ws_result.first()
+        ).first()
         if ws_row is None:
             return None
 
-        workspace, is_template, explicit_acl, activity, week, course = ws_row
+        workspace = Workspace.model_validate(ws_row, from_attributes=True)
+        is_template = ws_row.is_template
+        explicit_acl = (
+            ACLEntry.model_validate(ws_row.acl_json) if ws_row.acl_json else None
+        )
+        activity = (
+            Activity.model_validate(ws_row.activity_json)
+            if ws_row.activity_json
+            else None
+        )
+        week = Week.model_validate(ws_row.week_json) if ws_row.week_json else None
+        course = (
+            Course.model_validate(ws_row.course_json) if ws_row.course_json else None
+        )
 
         # 2. Hierarchy resolution from the joined rows
         placement = _placement_from_joined_rows(
             workspace, activity, week, course, is_template=is_template
         )
 
-        # 3. Permission resolution (ACL pre-fetched by the query above)
+        # 3. Permission resolution. ACL, Course, and Activity were all
+        # hydrated by the query above -- threading them through avoids the
+        # session.get() re-fetches a naive per-field port of this query
+        # would still make on the staff/peer permission paths.
         if is_admin:
             permission: str | None = "owner"
         else:
             permission = await _resolve_effective_permission(
-                session, workspace, placement, user_id, explicit_acl
+                session,
+                workspace,
+                placement,
+                user_id,
+                _HydratedRowEntities(
+                    explicit=explicit_acl, course=course, activity=activity
+                ),
             )
 
         # 4. Privileged user IDs (staff + admins)
@@ -497,19 +565,27 @@ async def resolve_annotation_context(
         )
 
         # 5. Tags and tag groups
-        tags_result = await session.exec(
-            select(Tag)
-            .where(Tag.workspace_id == workspace_id)
-            .order_by(Tag.order_index)  # type: ignore[arg-type]  -- Column expression valid at runtime
-        )
-        tags = list(tags_result.all())
+        tag_rows = (
+            await session.execute(
+                tstring(
+                    t"SELECT * FROM tag WHERE workspace_id = {workspace_id}"
+                    t" ORDER BY order_index"
+                )
+            )
+        ).all()
+        tags = [Tag.model_validate(row, from_attributes=True) for row in tag_rows]
 
-        groups_result = await session.exec(
-            select(TagGroup)
-            .where(TagGroup.workspace_id == workspace_id)
-            .order_by(TagGroup.order_index)  # type: ignore[arg-type]  -- Column expression valid at runtime
-        )
-        tag_groups = list(groups_result.all())
+        group_rows = (
+            await session.execute(
+                tstring(
+                    t"SELECT * FROM tag_group WHERE workspace_id = {workspace_id}"
+                    t" ORDER BY order_index"
+                )
+            )
+        ).all()
+        tag_groups = [
+            TagGroup.model_validate(row, from_attributes=True) for row in group_rows
+        ]
 
         # 6. Active export job for the header, riding the same session so
         # the page render does not spend a separate pool checkout on it.
@@ -548,15 +624,22 @@ async def get_workspace_export_metadata(
             return None
 
         # Resolve owner display name via ACL -> User join
-        owner_result = await session.exec(
-            select(User.display_name)
-            .join(ACLEntry, ACLEntry.user_id == User.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement, not bool
-            .where(
-                ACLEntry.workspace_id == workspace_id,
-                ACLEntry.permission == "owner",
+        owner_display_name = (
+            (
+                await session.execute(
+                    tstring(
+                        t"""
+                        SELECT u.display_name
+                        FROM "user" u
+                        JOIN acl_entry a ON a.user_id = u.id
+                        WHERE a.workspace_id = {workspace_id} AND a.permission = 'owner'
+                        """
+                    )
+                )
             )
+            .scalars()
+            .first()
         )
-        owner_display_name: str | None = owner_result.first()
 
         # Resolve placement using private helpers (same session)
         if workspace.activity_id is not None:
@@ -638,17 +721,27 @@ async def _resolve_activity_placement(
 
     Falls back to loose placement if any link in the chain is missing.
     """
-    result = await session.exec(
-        select(Activity, Week, Course)
-        .join(Week, Activity.week_id == Week.id)  # type: ignore[arg-type]  -- Column == returns ColumnElement
-        .join(Course, Week.course_id == Course.id)  # type: ignore[arg-type]  -- Column == returns ColumnElement
-        .where(Activity.id == activity_id)
-    )
-    row = result.first()
+    row = (
+        await session.execute(
+            tstring(
+                t"""
+                SELECT to_jsonb(a.*) AS activity_json,
+                       to_jsonb(wk.*) AS week_json,
+                       to_jsonb(c.*) AS course_json
+                FROM activity a
+                JOIN week wk ON wk.id = a.week_id
+                JOIN course c ON c.id = wk.course_id
+                WHERE a.id = {activity_id}
+                """
+            )
+        )
+    ).first()
     if row is None:
         return PlacementContext(placement_type="loose")
 
-    activity, week, course = row
+    activity = Activity.model_validate(row.activity_json)
+    week = Week.model_validate(row.week_json)
+    course = Course.model_validate(row.course_json)
     return _activity_placement(activity, week, course)
 
 
@@ -915,12 +1008,18 @@ async def list_workspaces_for_activity(
         List of Workspaces ordered by created_at.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Workspace)
-            .where(Workspace.activity_id == activity_id)
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  # TODO(2026-Q2): Revisit when SQLModel updates type stubs
-        )
-        return list(result.all())
+        rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT * FROM workspace
+                    WHERE activity_id = {activity_id}
+                    ORDER BY created_at
+                    """
+                )
+            )
+        ).all()
+        return [Workspace.model_validate(row, from_attributes=True) for row in rows]
 
 
 async def list_loose_workspaces_for_course(
@@ -940,13 +1039,18 @@ async def list_loose_workspaces_for_course(
         List of loose Workspaces ordered by created_at.
     """
     async with get_session() as session:
-        result = await session.exec(
-            select(Workspace)
-            .where(Workspace.course_id == course_id)
-            .where(Workspace.activity_id == None)  # noqa: E711
-            .order_by(Workspace.created_at)  # type: ignore[arg-type]  # TODO(2026-Q2): Revisit when SQLModel updates type stubs
-        )
-        return list(result.all())
+        rows = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT * FROM workspace
+                    WHERE course_id = {course_id} AND activity_id IS NULL
+                    ORDER BY created_at
+                    """
+                )
+            )
+        ).all()
+        return [Workspace.model_validate(row, from_attributes=True) for row in rows]
 
 
 def _remap_uuid_str(raw: str, id_map: dict[UUID, UUID] | None) -> str:
@@ -1195,17 +1299,22 @@ async def clone_workspace_from_activity(
         )
 
         # Idempotency check: return existing workspace if already cloned
-        existing = await session.exec(
-            select(Workspace)
-            .join(ACLEntry, ACLEntry.workspace_id == Workspace.id)  # type: ignore[arg-type]  -- SQLAlchemy == returns ColumnElement, not bool
-            .where(
-                Workspace.activity_id == activity_id,
-                ACLEntry.user_id == user_id,
-                ACLEntry.permission == "owner",
+        existing_row = (
+            await session.execute(
+                tstring(
+                    t"""
+                    SELECT w.* FROM workspace w
+                    JOIN acl_entry a ON a.workspace_id = w.id
+                    WHERE w.activity_id = {activity_id}
+                      AND a.user_id = {user_id}
+                      AND a.permission = 'owner'
+                    LIMIT 1
+                    """
+                )
             )
-        )
-        found = existing.first()
-        if found is not None:
+        ).first()
+        if existing_row is not None:
+            found = Workspace.model_validate(existing_row, from_attributes=True)
             return found, {}
 
         activity = await session.get(Activity, activity_id)

--- a/src/promptgrimoire/docs/screenshot.py
+++ b/src/promptgrimoire/docs/screenshot.py
@@ -144,7 +144,7 @@ def remove_highlight(page: Page, overlay_ids: list[str] | None) -> None:
     )
 
 
-def capture_screenshot(
+def capture_screenshot(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     page: Page,
     path: Path,
     *,

--- a/src/promptgrimoire/docs/seed.py
+++ b/src/promptgrimoire/docs/seed.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+from typing import TYPE_CHECKING
 
 import structlog
 from sqlmodel import select
@@ -18,6 +19,9 @@ from promptgrimoire.db.courses import DuplicateEnrollmentError, enroll_user
 from promptgrimoire.db.engine import get_session, init_db
 from promptgrimoire.db.models import Course
 from promptgrimoire.db.users import create_user, get_user_by_email
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
 
 logger = structlog.get_logger()
 
@@ -69,7 +73,7 @@ async def _seed_user_and_enrol(
     logger.debug("[SEED] done: %s", email)
 
 
-def _run_in_thread(coro: object) -> None:
+def _run_in_thread(coro: Coroutine[object, object, object]) -> None:
     """Run an async coroutine in a new thread with its own event loop.
 
     The NiceGUI server occupies the main event loop, so ``asyncio.run()``
@@ -81,7 +85,7 @@ def _run_in_thread(coro: object) -> None:
     def target() -> None:
         nonlocal exc
         try:
-            asyncio.run(coro)  # type: ignore[arg-type]
+            asyncio.run(coro)
         except BaseException as e:
             exc = e  # Deferred re-raise after thread cleanup (line 94)
 

--- a/src/promptgrimoire/elements/sortable/sortable.py
+++ b/src/promptgrimoire/elements/sortable/sortable.py
@@ -29,7 +29,7 @@ class Sortable(
         weakref.WeakValueDictionary()
     )
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 -- NiceGUI element callback options, one per event by design
         self,
         options: dict[str, Any] | None = None,
         *,

--- a/src/promptgrimoire/export/filename.py
+++ b/src/promptgrimoire/export/filename.py
@@ -7,7 +7,7 @@ side-effect-free so they can be tested in isolation.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from slugify import slugify
@@ -62,33 +62,35 @@ def _safe_segment(value: str) -> str:
     return result
 
 
-def _assemble_stem(
-    course: str,
-    last: str,
-    first: str,
-    activity: str,
-    workspace: str,
-    date_part: str,
-) -> str:
+@dataclass(frozen=True, slots=True)
+class _FilenameSegments:
+    """Sanitised filename segments that travel together through assembly
+    and truncation. Grouped into one param object (rather than passed as
+    six positional arguments) because every function in this module that
+    touches one segment needs all six to reconstruct the assembled stem.
+    """
+
+    course: str
+    last: str
+    first: str
+    activity: str
+    workspace: str
+    date_part: str
+
+
+def _assemble_stem(segments: _FilenameSegments) -> str:
     """Join non-empty segments with underscores."""
-    parts = [course, last, first]
-    if activity:
-        parts.append(activity)
-    if workspace:
-        parts.append(workspace)
-    parts.append(date_part)
+    parts = [segments.course, segments.last, segments.first]
+    if segments.activity:
+        parts.append(segments.activity)
+    if segments.workspace:
+        parts.append(segments.workspace)
+    parts.append(segments.date_part)
     return "_".join(parts)
 
 
-def _truncate_for_budget(
-    course: str,
-    last: str,
-    first: str,
-    activity: str,
-    workspace: str,
-    date_part: str,
-) -> tuple[str, str, str]:
-    """Return trimmed (first, activity, workspace) under the filename budget.
+def _truncate_for_budget(segments: _FilenameSegments) -> _FilenameSegments:
+    """Return *segments* with first/activity/workspace trimmed to fit the budget.
 
     Truncation order:
     1. workspace (right-truncated)
@@ -101,38 +103,37 @@ def _truncate_for_budget(
     pathological overflow to stand.
     """
     budget = _MAX_FILENAME_LENGTH - len(_PDF_SUFFIX)
+    first, activity, workspace = segments.first, segments.activity, segments.workspace
 
-    def _current_len(f: str, a: str, w: str) -> int:
-        return len(_assemble_stem(course, last, f, a, w, date_part))
+    def _fits(f: str, a: str, w: str) -> bool:
+        candidate = replace(segments, first=f, activity=a, workspace=w)
+        return len(_assemble_stem(candidate)) <= budget
 
     # Already fits?
-    if _current_len(first, activity, workspace) <= budget:
-        return (first, activity, workspace)
+    if _fits(first, activity, workspace):
+        return replace(segments, first=first, activity=activity, workspace=workspace)
 
     # Step 1: trim workspace
-    while workspace and _current_len(first, activity, workspace) > budget:
+    while workspace and not _fits(first, activity, workspace):
         workspace = workspace[:-1]
 
-    if _current_len(first, activity, workspace) <= budget:
-        return (first, activity, workspace)
+    if _fits(first, activity, workspace):
+        return replace(segments, first=first, activity=activity, workspace=workspace)
 
     # Step 2: trim activity
-    while activity and _current_len(first, activity, workspace) > budget:
+    while activity and not _fits(first, activity, workspace):
         activity = activity[:-1]
 
-    if _current_len(first, activity, workspace) <= budget:
-        return (first, activity, workspace)
+    if _fits(first, activity, workspace):
+        return replace(segments, first=first, activity=activity, workspace=workspace)
 
     # Step 3: trim first name to 1-char initial
     if len(first) > 1:
         first = first[0]
 
-    if _current_len(first, activity, workspace) <= budget:
-        return (first, activity, workspace)
-
     # AC3.6: overflow is legal only after every trimmable segment has already
     # been exhausted and the first-name segment is down to one character.
-    return (first, activity, workspace)
+    return replace(segments, first=first, activity=activity, workspace=workspace)
 
 
 def build_pdf_export_stem(ctx: PdfExportFilenameContext) -> str:
@@ -158,21 +159,16 @@ def build_pdf_export_stem(ctx: PdfExportFilenameContext) -> str:
     if ctx.workspace_title and ctx.workspace_title == ctx.activity_title:
         workspace = ""
 
-    # Truncate to fit budget
-    first, activity, workspace = _truncate_for_budget(
-        course,
-        last,
-        first,
-        activity,
-        workspace,
-        date_part,
+    segments = _FilenameSegments(
+        course=course,
+        last=last,
+        first=first,
+        activity=activity,
+        workspace=workspace,
+        date_part=date_part,
     )
 
-    return _assemble_stem(
-        course,
-        last,
-        first,
-        activity,
-        workspace,
-        date_part,
-    )
+    # Truncate to fit budget
+    segments = _truncate_for_budget(segments)
+
+    return _assemble_stem(segments)

--- a/src/promptgrimoire/export/highlight_spans.py
+++ b/src/promptgrimoire/export/highlight_spans.py
@@ -316,7 +316,7 @@ def _build_span_tag(
     return open_tag, close_tag
 
 
-def _insert_spans_into_html(
+def _insert_spans_into_html(  # noqa: PLR0913, PLR0917 -- caller passes positionally; param-object migration: tracker ledger 8
     html: str,
     regions: list[_HlRegion],
     text_nodes: list[TextNodeInfo],

--- a/src/promptgrimoire/export/html_normaliser.py
+++ b/src/promptgrimoire/export/html_normaliser.py
@@ -20,6 +20,9 @@ from lxml.html import HtmlElement
 logger = structlog.get_logger()
 
 
+_NON_CONTENT_TAGS = ("script", "style", "noscript")
+
+
 def strip_scripts_and_styles(html_content: str) -> str:
     """Remove script, style, and noscript elements from HTML.
 
@@ -50,30 +53,49 @@ def strip_scripts_and_styles(html_content: str) -> str:
         )
         return _strip_scripts_regex_fallback(html_content)
 
-    # Remove script, style, noscript elements and their content
-    for tag in ("script", "style", "noscript"):
-        for element in tree.xpath(f"//{tag}"):
-            parent = element.getparent()
-            if parent is not None:
-                # Preserve tail text (text after the element)
-                if element.tail:
-                    prev = element.getprevious()
-                    if prev is not None:
-                        prev.tail = (prev.tail or "") + element.tail
-                    else:
-                        parent.text = (parent.text or "") + element.tail
-                parent.remove(element)
-
-    # Remove inline event handlers (onclick, onload, etc.)
-    for element in tree.iter():
-        if hasattr(element, "attrib"):
-            attrs_to_remove = [
-                attr for attr in element.attrib if attr.lower().startswith("on")
-            ]
-            for attr in attrs_to_remove:
-                del element.attrib[attr]
+    _remove_non_content_elements(tree)
+    _strip_event_handler_attributes(tree)
 
     return lxml_html.tostring(tree, encoding="unicode")
+
+
+def _remove_non_content_elements(tree: HtmlElement) -> None:
+    """Remove script/style/noscript elements from *tree*, preserving tail text."""
+    for tag in _NON_CONTENT_TAGS:
+        for element in tree.xpath(f"//{tag}"):
+            _remove_element_preserving_tail(element)
+
+
+def _remove_element_preserving_tail(element: HtmlElement) -> None:
+    """Detach *element* from its parent, reattaching any tail text.
+
+    Tail text (text after the element, before the next sibling) would
+    otherwise be lost along with the element. It is appended to the
+    previous sibling's tail, or to the parent's own text if there is no
+    previous sibling.
+    """
+    parent = element.getparent()
+    if parent is None:
+        return
+    if element.tail:
+        prev = element.getprevious()
+        if prev is not None:
+            prev.tail = (prev.tail or "") + element.tail
+        else:
+            parent.text = (parent.text or "") + element.tail
+    parent.remove(element)
+
+
+def _strip_event_handler_attributes(tree: HtmlElement) -> None:
+    """Remove inline event-handler attributes (onclick, onload, etc.) from *tree*."""
+    for element in tree.iter():
+        if not hasattr(element, "attrib"):
+            continue
+        attrs_to_remove = [
+            attr for attr in element.attrib if attr.lower().startswith("on")
+        ]
+        for attr in attrs_to_remove:
+            del element.attrib[attr]
 
 
 def _strip_scripts_regex_fallback(html_content: str) -> str:

--- a/src/promptgrimoire/export/latex_render.py
+++ b/src/promptgrimoire/export/latex_render.py
@@ -70,6 +70,34 @@ def latex_cmd(name: str, *args: str | NoEscape) -> NoEscape:
     return NoEscape("".join(parts))
 
 
+def _apply_conversion(value: object, conversion: str | None) -> object:
+    """Apply an f-string-style conversion specifier (``!r``, ``!s``, ``!a``).
+
+    Returns *value* unchanged when *conversion* is ``None`` or unrecognised.
+    """
+    if conversion == "r":
+        return repr(value)
+    if conversion == "s":
+        return str(value)
+    if conversion == "a":
+        return ascii(value)
+    return value
+
+
+def _render_interpolation(item: Interpolation) -> str:
+    """Render one t-string interpolation: conversion, format spec, escaping.
+
+    Matches Python's f-string evaluation order -- conversion first, then
+    format spec, then (unless the result is ``NoEscape``) LaTeX escaping.
+    """
+    value = _apply_conversion(item.value, item.conversion)
+    if item.format_spec:
+        value = format(value, item.format_spec)
+    if isinstance(value, NoEscape):
+        return str(value)
+    return str(escape_latex(str(value)))
+
+
 def render_latex(template: Template) -> str:
     """Render a t-string template with auto-escaping of interpolations.
 
@@ -85,20 +113,5 @@ def render_latex(template: Template) -> str:
         if isinstance(item, str):
             parts.append(item)
         elif isinstance(item, Interpolation):
-            value = item.value
-            # Apply conversion (!r, !s, !a) if specified
-            if item.conversion == "r":
-                value = repr(value)
-            elif item.conversion == "s":
-                value = str(value)
-            elif item.conversion == "a":
-                value = ascii(value)
-            # Apply format_spec if specified
-            if item.format_spec:
-                value = format(value, item.format_spec)
-            # Auto-escape unless NoEscape
-            if isinstance(value, NoEscape):
-                parts.append(str(value))
-            else:
-                parts.append(str(escape_latex(str(value))))
+            parts.append(_render_interpolation(item))
     return "".join(parts)

--- a/src/promptgrimoire/export/pdf_export.py
+++ b/src/promptgrimoire/export/pdf_export.py
@@ -407,16 +407,23 @@ def _build_word_count_badge(
     return r"\noindent\textit{" + label + "}\n" + r"\vspace{1em}" + "\n"
 
 
-async def generate_tex_only(
+# PLR0913 (too many arguments): html_content/highlights/tag_colours/output_dir
+# plus independent, orthogonal export knobs (content, notes, word-count
+# limits, destination), all already keyword-only (PLR0917 satisfied below)
+# and consumed as kwargs by every call site. Splitting into a param object
+# would require updating call sites in cli/export.py, cli/testing.py,
+# pages/highlight_api_demo.py and export/worker.py plus ~18 test modules --
+# out of scope for this cleanup pass.
+async def generate_tex_only(  # noqa: PLR0913
     html_content: str,
     highlights: list[dict[str, Any]],
     tag_colours: dict[str, str],
     output_dir: Path,
+    *,
     general_notes: str = "",
     notes_latex: str = "",
     word_to_legal_para: dict[int, int | None] | None = None,
     filename: str = "annotated_document",
-    *,
     word_count: int | None = None,
     word_minimum: int | None = None,
     word_limit: int | None = None,
@@ -484,17 +491,21 @@ async def generate_tex_only(
     return tex_path
 
 
-async def export_annotation_pdf(
+# PLR0913: same rationale as generate_tex_only above -- independent,
+# orthogonal export knobs, already keyword-only, consumed as kwargs by
+# every call site (see the comment there for the external callers a
+# param-object split would need to touch).
+async def export_annotation_pdf(  # noqa: PLR0913
     html_content: str,
     highlights: list[dict[str, Any]],
     tag_colours: dict[str, str],
+    *,
     general_notes: str = "",
     notes_latex: str = "",
     word_to_legal_para: dict[int, int | None] | None = None,
     output_dir: Path | None = None,
     user_id: str | None = None,
     filename: str = "annotated_document",
-    *,
     workspace_id: str | None = None,
     word_count: int | None = None,
     word_minimum: int | None = None,

--- a/src/promptgrimoire/export/platforms/base.py
+++ b/src/promptgrimoire/export/platforms/base.py
@@ -48,6 +48,10 @@ _CHROME_ID_PATTERNS = [
 # Pattern for thinking time indicators
 _THINKING_TIME_PATTERN = re.compile(r"^\d+s$")
 
+# Images at or below this pixel size in either dimension are treated as
+# chrome (icons, avatars) rather than content and removed.
+_SMALL_ICON_MAX_PX = 32
+
 
 def _remove_chrome_by_patterns(tree: LexborHTMLParser) -> None:
     """Remove elements matching chrome class and ID patterns."""
@@ -67,7 +71,9 @@ def _remove_chrome_images(tree: LexborHTMLParser) -> None:
         width = attrs.get("width", "")
         height = attrs.get("height", "")
         try:
-            if (width and int(width) < 32) or (height and int(height) < 32):
+            if (width and int(width) < _SMALL_ICON_MAX_PX) or (
+                height and int(height) < _SMALL_ICON_MAX_PX
+            ):
                 img.decompose()
                 continue
         except ValueError:

--- a/src/promptgrimoire/export/platforms/openrouter.py
+++ b/src/promptgrimoire/export/platforms/openrouter.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 # Platform detection pattern
 _DETECTION_PATTERN = re.compile(r'data-testid="playground-container"', re.IGNORECASE)
 
+# Index of the assistant message's content-wrapper child among its direct
+# children; all other direct children (chrome) are removed.
+_CONTENT_WRAPPER_CHILD_INDEX = 2
+
 
 def _element_children(node: LexborNode) -> list[LexborNode]:
     """Collect direct element children, skipping text nodes."""
@@ -80,7 +84,7 @@ class OpenRouterHandler:
         # Remove all direct children except child 2 (content wrapper)
         children = _element_children(msg)
         for i, ch in enumerate(children):
-            if i != 2:
+            if i != _CONTENT_WRAPPER_CHILD_INDEX:
                 ch.decompose()
 
         # Inside content wrapper, keep only the last child

--- a/src/promptgrimoire/export/span_boundaries.py
+++ b/src/promptgrimoire/export/span_boundaries.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from promptgrimoire.input_pipeline.html_input import TextNodeInfo
 
 # Block-level elements that Pandoc treats as block-level.
@@ -81,8 +83,61 @@ INLINE_FORMATTING_ELEMENTS: frozenset[str] = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Shared backwards tag scan
+# ---------------------------------------------------------------------------
+
+
+def _iter_tags_backwards(html: str, byte_pos: int) -> Iterator[tuple[int, str, bool]]:
+    """Yield ``(tag_start, tag_name, is_closing)`` for each tag scanning
+    backwards from *byte_pos* through the serialised HTML.
+
+    Comment/doctype markers (tag content starting with ``!``) are skipped.
+    A stray ``>`` with no matching ``<`` before it is skipped rather than
+    treated as a tag.
+    """
+    i = byte_pos - 1
+    while i >= 0:
+        if html[i] != ">":
+            i -= 1
+            continue
+        tag_end = i
+        tag_start = html.rfind("<", 0, i)
+        if tag_start == -1:
+            i -= 1
+            continue
+        tag_content = html[tag_start + 1 : tag_end]
+        i = tag_start - 1
+        if tag_content.startswith("!"):
+            continue
+        is_closing = tag_content.startswith("/")
+        name_part = tag_content[1:] if is_closing else tag_content
+        tag_name = name_part.split()[0].strip("/").lower()
+        yield tag_start, tag_name, is_closing
+
+
+# ---------------------------------------------------------------------------
 # Block-boundary detection
 # ---------------------------------------------------------------------------
+
+
+def _find_block_ancestor_at(html: str, byte_pos: int) -> str:
+    """Find the innermost block-level ancestor tag at a byte position.
+
+    Scans backwards through the HTML to find the nearest open tag that is a
+    block element, tracking already-closed block elements via *depth* so
+    they are not mistaken for an open ancestor.
+    """
+    depth = 0
+    for tag_start, tag_name, is_closing in _iter_tags_backwards(html, byte_pos):
+        if tag_name not in PANDOC_BLOCK_ELEMENTS:
+            continue
+        if is_closing:
+            depth += 1
+            continue
+        if depth == 0:
+            return f"{tag_name}@{tag_start}"
+        depth -= 1
+    return "root@0"
 
 
 def _detect_block_boundaries(
@@ -95,10 +150,6 @@ def _detect_block_boundaries(
     A block boundary is the ``char_start`` of a text node whose nearest
     block-level ancestor differs from that of the preceding text node.
 
-    Scans backwards through the serialized HTML to find the nearest
-    block-level ancestor tag for each text node, then compares consecutive
-    text nodes to detect boundary transitions.
-
     Args:
         html: Serialized HTML string.
         text_nodes: List of text node info from walk_and_map.
@@ -107,48 +158,12 @@ def _detect_block_boundaries(
     if len(text_nodes) <= 1:
         return set()
 
-    def _find_block_ancestor_at(byte_pos: int) -> str:
-        """Find the innermost block-level ancestor tag at a byte position.
-
-        Scans backwards through the HTML to find the nearest open tag that
-        is a block element. Uses a simple tag-stack approach.
-        """
-        # Walk backwards from byte_pos looking for the nearest block tag
-        # We look for the most recent unclosed block-level opening tag.
-        depth = 0
-        i = byte_pos - 1
-        while i >= 0:
-            if html[i] == ">":
-                # Found a tag end, scan backwards to find tag start
-                tag_end = i
-                tag_start = html.rfind("<", 0, i)
-                if tag_start == -1:
-                    i -= 1
-                    continue
-                tag_content = html[tag_start + 1 : tag_end]
-                if tag_content.startswith("/"):
-                    # Closing tag
-                    tag_name = tag_content[1:].split()[0].strip("/").lower()
-                    if tag_name in PANDOC_BLOCK_ELEMENTS:
-                        depth += 1
-                elif not tag_content.startswith("!"):
-                    # Opening tag
-                    tag_name = tag_content.split()[0].strip("/").lower()
-                    if tag_name in PANDOC_BLOCK_ELEMENTS:
-                        if depth == 0:
-                            return f"{tag_name}@{tag_start}"
-                        depth -= 1
-                i = tag_start - 1
-            else:
-                i -= 1
-        return "root@0"
-
     # Build block ancestor identity for each text node
     prev_block: str | None = None
     boundaries: set[int] = set()
 
     for i, tn in enumerate(text_nodes):
-        block_id = _find_block_ancestor_at(byte_offsets[i])
+        block_id = _find_block_ancestor_at(html, byte_offsets[i])
         if prev_block is not None and block_id != prev_block:
             boundaries.add(tn.char_start)
         prev_block = block_id
@@ -175,37 +190,21 @@ def _inline_context_at(
     # open tag (it's a completed element, not an ancestor).
     depth: dict[str, int] = {}
     ancestors: list[str] = []
-    i = byte_pos - 1
 
-    while i >= 0:
-        if html[i] == ">":
-            tag_end = i
-            tag_start = html.rfind("<", 0, i)
-            if tag_start == -1:
-                i -= 1
-                continue
-            tag_content = html[tag_start + 1 : tag_end]
-            if tag_content.startswith("/"):
-                # Closing tag -- the element is completed, skip its opener
-                tag_name = tag_content[1:].split()[0].strip("/").lower()
-                if tag_name in PANDOC_BLOCK_ELEMENTS:
-                    break  # Stop at block boundary
-                if tag_name in INLINE_FORMATTING_ELEMENTS:
-                    depth[tag_name] = depth.get(tag_name, 0) + 1
-            elif not tag_content.startswith("!"):
-                # Opening tag
-                tag_name = tag_content.split()[0].strip("/").lower()
-                if tag_name in PANDOC_BLOCK_ELEMENTS:
-                    break  # Stop at block boundary
-                if tag_name in INLINE_FORMATTING_ELEMENTS:
-                    d = depth.get(tag_name, 0)
-                    if d > 0:
-                        depth[tag_name] = d - 1
-                    else:
-                        ancestors.append(tag_name)
-            i = tag_start - 1
+    for _tag_start, tag_name, is_closing in _iter_tags_backwards(html, byte_pos):
+        if tag_name in PANDOC_BLOCK_ELEMENTS:
+            break  # Stop at block boundary
+        if tag_name not in INLINE_FORMATTING_ELEMENTS:
+            continue
+        if is_closing:
+            # Closing tag -- the element is completed, skip its opener
+            depth[tag_name] = depth.get(tag_name, 0) + 1
+            continue
+        d = depth.get(tag_name, 0)
+        if d > 0:
+            depth[tag_name] = d - 1
         else:
-            i -= 1
+            ancestors.append(tag_name)
 
     return tuple(sorted(ancestors))
 

--- a/src/promptgrimoire/export/worker.py
+++ b/src/promptgrimoire/export/worker.py
@@ -122,10 +122,52 @@ async def _run_cleanup() -> None:
         logger.info("export_worker_cleanup", deleted_count=count)
 
 
+async def _run_cleanup_safely() -> None:
+    """Run cleanup, logging (not raising) on failure."""
+    try:
+        await _run_cleanup()
+    except Exception:
+        logger.exception("export_worker_cleanup_failed")
+
+
+async def _run_poll_iteration(iteration: int, *, cleanup_interval: int) -> int:
+    """Claim and process one job; run cleanup every ``cleanup_interval`` iterations.
+
+    Returns the incremented iteration count. ``asyncio.CancelledError``
+    propagates uncancelled so the caller's loop can exit; any other
+    exception is logged and swallowed so polling continues.
+    """
+    iteration += 1
+    try:
+        job = await claim_next_job()
+        if job is not None:
+            await _process_job(job)
+
+        if iteration % cleanup_interval == 0:
+            await _run_cleanup_safely()
+
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("export_worker_iteration_failed")
+
+    return iteration
+
+
+def _fire_poll_cycle_callback(on_poll_cycle: Callable[[], object] | None) -> None:
+    """Invoke the optional poll-cycle callback, logging (not raising) on failure."""
+    if on_poll_cycle is None:
+        return
+    try:
+        on_poll_cycle()
+    except Exception:
+        logger.warning("on_poll_cycle_failed", exc_info=True)
+
+
 async def start_export_worker(
     poll_interval: float = 5.0,
     cleanup_interval: int = 60,
-    on_poll_cycle: Callable[[], None] | None = None,
+    on_poll_cycle: Callable[[], object] | None = None,
 ) -> None:
     """Start the background export polling worker.
 
@@ -156,28 +198,8 @@ async def start_export_worker(
     )
     iteration = 0
     while True:
-        try:
-            iteration += 1
-
-            job = await claim_next_job()
-            if job is not None:
-                await _process_job(job)
-
-            if iteration % cleanup_interval == 0:
-                try:
-                    await _run_cleanup()
-                except Exception:
-                    logger.exception("export_worker_cleanup_failed")
-
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("export_worker_iteration_failed")
-
-        if on_poll_cycle is not None:
-            try:
-                on_poll_cycle()
-            except Exception:
-                logger.warning("on_poll_cycle_failed", exc_info=True)
-
+        iteration = await _run_poll_iteration(
+            iteration, cleanup_interval=cleanup_interval
+        )
+        _fire_poll_cycle_callback(on_poll_cycle)
         await asyncio.sleep(poll_interval)

--- a/src/promptgrimoire/input_pipeline/marker_insertion.py
+++ b/src/promptgrimoire/input_pipeline/marker_insertion.py
@@ -11,6 +11,7 @@ client-side JS text walker (Issue #129).
 
 from __future__ import annotations
 
+import dataclasses
 import html as html_module
 from typing import Any
 
@@ -25,6 +26,11 @@ from promptgrimoire.input_pipeline.text_extraction import (
     walk_and_map,
 )
 
+# Upper bound on how far past "&" to scan for the terminating ";" of an
+# HTML entity reference (e.g. "&#x10FFFF;" is 10 chars; a few chars of
+# margin keeps this from mistaking a stray ";" in plain text for one).
+_MAX_ENTITY_REF_LEN = 12
+
 
 def _try_entity_match(
     html: str, html_pos: int, decoded_text: str, decoded_pos: int
@@ -35,7 +41,7 @@ def _try_entity_match(
     if the entity does not match.
     """
     semicolon = html.find(";", html_pos + 1)
-    if semicolon == -1 or semicolon - html_pos >= 12:
+    if semicolon == -1 or semicolon - html_pos >= _MAX_ENTITY_REF_LEN:
         return None
     entity_text = html[html_pos : semicolon + 1]
     decoded_entity = html_module.unescape(entity_text)
@@ -175,7 +181,7 @@ def _html_char_length(html_text: str, html_pos: int, decoded_char: str) -> int:
                 return len(entity)
         # Try numeric entity &#NNN; or &#xHHH;
         semicolon = html_text.find(";", html_pos + 1)
-        if semicolon != -1 and semicolon - html_pos < 12:
+        if semicolon != -1 and semicolon - html_pos < _MAX_ENTITY_REF_LEN:
             return semicolon - html_pos + 1
     return 1
 
@@ -218,11 +224,18 @@ def collapsed_to_html_offset(
     return html_pos
 
 
+@dataclasses.dataclass(frozen=True)
+class _CharSpan:
+    """A single highlight's [start, end) character range."""
+
+    start: int
+    end: int
+
+
 def _add_marker_insertions(
     text_nodes: list[TextNodeInfo],
     byte_offsets: list[int],
-    start_char: int,
-    end_char: int,
+    span: _CharSpan,
     marker_idx: int,
     insertions: list[tuple[int, str]],
 ) -> None:
@@ -230,6 +243,8 @@ def _add_marker_insertions(
 
     Handles boundary cases where markers fall outside all text nodes.
     """
+    start_char, end_char = span.start, span.end
+
     # Find start position
     start_node_found = False
     for i, node_info in enumerate(text_nodes):
@@ -343,7 +358,11 @@ def insert_markers_into_dom(
         marker_to_highlight.append(hl)
 
         _add_marker_insertions(
-            text_nodes, byte_offsets, start_char, end_char, marker_idx, insertions
+            text_nodes,
+            byte_offsets,
+            _CharSpan(start_char, end_char),
+            marker_idx,
+            insertions,
         )
 
     # Sort insertions by byte offset descending -- insert back-to-front

--- a/src/promptgrimoire/input_pipeline/paragraph_map.py
+++ b/src/promptgrimoire/input_pipeline/paragraph_map.py
@@ -35,6 +35,15 @@ from promptgrimoire.input_pipeline.text_extraction import (
 # not discourse-level paragraphs).
 _PARA_TAGS = frozenset(("p", "li", "blockquote", "div"))
 
+# Number of consecutive <br> elements that starts a new br-br
+# pseudo-paragraph within a block (used by both the mapping walk and the
+# mirrored injection walk).
+_BR_BR_SPLIT_THRESHOLD = 2
+
+# Minimum count of <li value="..."> elements that marks a document as
+# AustLII-style source-numbered (see detect_source_numbering()).
+_MIN_AUSTLII_VALUED_LI = 2
+
 # Known inline/phrasing tags.  Any immediate child element whose tag
 # is NOT in this set is treated as block-level, making the parent a
 # wrapper.  Using an inline allowlist (rather than a block blocklist)
@@ -162,7 +171,7 @@ def _handle_text_node(node: Any, state: _WalkState) -> None:
 
     # After 2+ consecutive <br>, this text starts a new
     # paragraph (br-br split within a block).
-    if state.consecutive_br >= 2 and state.auto_number:
+    if state.consecutive_br >= _BR_BR_SPLIT_THRESHOLD and state.auto_number:
         state.current_para += 1
         state.result[state.char_offset] = state.current_para
         state.block_recorded = True
@@ -333,7 +342,10 @@ def _inject_handle_text(node: Any, state: _InjectState) -> None:
     # br-br pseudo-paragraph: record for post-serialisation wrapping.
     # selectolax escapes HTML when replacing text nodes, so we must
     # do string-level insertion after the DOM is serialised.
-    if state.consecutive_br >= 2 and state.char_offset in state.paragraph_map:
+    if (
+        state.consecutive_br >= _BR_BR_SPLIT_THRESHOLD
+        and state.char_offset in state.paragraph_map
+    ):
         para_num = state.paragraph_map[state.char_offset]
         raw_text = node.html or node.text_content
         state.br_br_wraps.append((raw_text, para_num))
@@ -609,4 +621,4 @@ def detect_source_numbering(html: str) -> bool:
         return False
     tree = LexborHTMLParser(html)
     matches = tree.css("li[value]")
-    return len(matches) >= 2
+    return len(matches) >= _MIN_AUSTLII_VALUED_LI

--- a/src/promptgrimoire/llm/prompt.py
+++ b/src/promptgrimoire/llm/prompt.py
@@ -3,19 +3,12 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from anthropic.types import MessageParam
 
     from promptgrimoire.models import Character, LorebookEntry, Turn
-
-
-class MessageDict(TypedDict):
-    """Message format compatible with Claude API."""
-
-    role: Literal["user", "assistant"]
-    content: str
 
 
 def estimate_tokens(text: str) -> int:
@@ -130,11 +123,10 @@ def build_messages(turns: list[Turn]) -> list[MessageParam]:
     Returns:
         List of message dicts with 'role' and 'content' keys.
     """
-    messages: list[MessageDict] = []
+    messages: list[MessageParam] = []
 
     for turn in turns:
         role: Literal["user", "assistant"] = "user" if turn.is_user else "assistant"
         messages.append({"role": role, "content": turn.content})
 
-    # Cast to MessageParam for type compatibility with Anthropic SDK
-    return messages  # type: ignore[return-value]
+    return messages

--- a/src/promptgrimoire/logging_discord.py
+++ b/src/promptgrimoire/logging_discord.py
@@ -45,6 +45,10 @@ _CONTEXT_FIELDS = (
     "pid",
 )
 
+# exc_info tuples follow sys.exc_info()'s (exc_type, exc_value, traceback)
+# shape; this is the minimum length needed to safely read exc_info[1].
+_EXC_INFO_TUPLE_MIN_LEN = 2
+
 
 def _truncate(text: str, limit: int) -> str:
     """Truncate text to limit, appending ellipsis if truncated."""
@@ -57,7 +61,11 @@ def _exc_type_name(exc_info: object) -> str:
     """Extract exception type name from exc_info."""
     if isinstance(exc_info, BaseException):
         return type(exc_info).__name__
-    if isinstance(exc_info, tuple) and len(exc_info) >= 2 and exc_info[1] is not None:
+    if (
+        isinstance(exc_info, tuple)
+        and len(exc_info) >= _EXC_INFO_TUPLE_MIN_LEN
+        and exc_info[1] is not None
+    ):
         return type(exc_info[1]).__name__
     return ""
 
@@ -186,7 +194,7 @@ class DiscordAlertProcessor:
                 description = f"{type(exc_info).__name__}: {exc_info}"
             elif (
                 isinstance(exc_info, tuple)
-                and len(exc_info) >= 2
+                and len(exc_info) >= _EXC_INFO_TUPLE_MIN_LEN
                 and exc_info[1] is not None
             ):
                 description = f"{type(exc_info[1]).__name__}: {exc_info[1]}"
@@ -258,11 +266,11 @@ class DiscordAlertProcessor:
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.post(self._webhook_url, json=payload)
-                if response.status_code == 429:
+                if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
                     sys.stderr.write(
                         f"Discord webhook rate-limited (429) for {self._webhook_url}\n"
                     )
-                elif response.status_code >= 400:
+                elif response.status_code >= httpx.codes.BAD_REQUEST:
                     url = self._webhook_url
                     code = response.status_code
                     sys.stderr.write(f"Discord webhook returned {code} for {url}\n")

--- a/src/promptgrimoire/pages/annotation/broadcast.py
+++ b/src/promptgrimoire/pages/annotation/broadcast.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
-def resolve_broadcast_label(
+def resolve_broadcast_label(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     *,
     sender_name: str,
     sender_user_id: str | None,

--- a/src/promptgrimoire/pages/annotation/content_form.py
+++ b/src/promptgrimoire/pages/annotation/content_form.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
 
     from nicegui.events import GenericEventArguments
 
+# Index of the editor-content entry in the [paste, platform, editor] array
+# emitted by the client-side capture script (see js_capture below).
+_ARG_EDITOR_INDEX = 2
+
 
 def _render_add_content_form(
     workspace_id: UUID,
@@ -99,7 +103,11 @@ def _render_add_content_form(
         args = e.args if isinstance(e.args, list) else [None, None, ""]
         paste_html: str | None = args[0] if len(args) > 0 else None
         platform_hint_val: str | None = args[1] if len(args) > 1 else None
-        editor_val: str = str(args[2]) if len(args) > 2 and args[2] else ""
+        editor_val: str = (
+            str(args[_ARG_EDITOR_INDEX])
+            if len(args) > _ARG_EDITOR_INDEX and args[_ARG_EDITOR_INDEX]
+            else ""
+        )
 
         success = await handle_add_document_submission(
             workspace_id=workspace_id,

--- a/src/promptgrimoire/pages/annotation/css.py
+++ b/src/promptgrimoire/pages/annotation/css.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 _COMPACT_THRESHOLD = 5
 """Tag count at or above which toolbar buttons use compact icon-only style."""
 
+_MAX_KEYBOARD_SHORTCUT_TAGS = 10
+"""Number of single-digit keyboard shortcuts available (1-9, then 0)."""
+
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
     """Parse a ``#RRGGBB`` hex string into an (r, g, b) tuple."""
@@ -486,7 +489,11 @@ def _render_tag_group(
 
         with ui.row().classes("gap-1"):
             for idx, ti in members:
-                shortcut = str((idx + 1) % 10) if idx < 10 else ""
+                shortcut = (
+                    str((idx + 1) % _MAX_KEYBOARD_SHORTCUT_TAGS)
+                    if idx < _MAX_KEYBOARD_SHORTCUT_TAGS
+                    else ""
+                )
                 _render_tag_button(ti, shortcut, on_tag_click)
 
 

--- a/src/promptgrimoire/pages/annotation/document.py
+++ b/src/promptgrimoire/pages/annotation/document.py
@@ -7,6 +7,7 @@ setting up JS-based text selection detection, and keyboard shortcuts.
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from html import escape
 from typing import Any
 from urllib.parse import urlencode
@@ -485,6 +486,15 @@ def _create_annotation_sidebar(state: PageState) -> Any:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class DocumentRenderCallbacks:
+    """Optional toolbar/menu callbacks and footer for document rendering."""
+
+    on_add_click: Any | None = None
+    on_manage_click: Any | None = None
+    footer: Any | None = None
+
+
 def _render_document_content(doc: Any) -> None:
     """Emit the paragraph-injected document HTML into the current slot.
 
@@ -548,14 +558,12 @@ async def _render_document_with_highlights(
     state: PageState,
     doc: Any,
     crdt_doc: Any,
-    *,
-    on_add_click: Any | None = None,
-    on_manage_click: Any | None = None,
-    footer: Any | None = None,
+    callbacks: DocumentRenderCallbacks | None = None,
 ) -> None:
     """Render a document with highlight support."""
     from promptgrimoire.config import get_settings  # noqa: PLC0415, I001 -- lazy: matches sibling render helpers
 
+    cb = callbacks or DocumentRenderCallbacks()
     _t_render = time.monotonic()
     use_snapshot = get_settings().snapshot.enabled
     _init_document_state(state, doc, crdt_doc)
@@ -577,21 +585,21 @@ async def _render_document_with_highlights(
         state.toolbar_container = _build_tag_toolbar(
             state.tag_info_list or [],
             handle_tag_click,
-            on_add_click=on_add_click,
-            on_manage_click=on_manage_click,
-            footer=footer,
+            on_add_click=cb.on_add_click,
+            on_manage_click=cb.on_manage_click,
+            footer=cb.footer,
         )
 
     # Highlight creation menu (popup with abbreviated tag buttons)
     # Only built for users who can annotate
     if state.can_annotate:
-        _build_highlight_menu(state, handle_tag_click, on_add_click=on_add_click)
+        _build_highlight_menu(state, handle_tag_click, on_add_click=cb.on_add_click)
 
     # Two-column layout: document (70%) + sidebar (30%)
     # Takes up 80-90% of screen width for comfortable reading
     # When using Quasar footer, q-page handles padding automatically.
     # Fallback: manual padding-bottom for fixed-position toolbar.
-    pb = "" if footer is not None else "padding-bottom: 60px; "
+    pb = "" if cb.footer is not None else "padding-bottom: 60px; "
     layout_wrapper = (
         ui.element("div")
         .props(f'id="ann-layout-{doc.id}"')

--- a/src/promptgrimoire/pages/annotation/document_render.py
+++ b/src/promptgrimoire/pages/annotation/document_render.py
@@ -17,6 +17,7 @@ from nicegui import ui
 from promptgrimoire.pages.annotation.content_form import _render_add_content_form
 from promptgrimoire.pages.annotation.css import _build_tag_toolbar
 from promptgrimoire.pages.annotation.document import (
+    DocumentRenderCallbacks,
     _render_document_with_highlights,
 )
 from promptgrimoire.pages.annotation.highlights import _add_highlight
@@ -65,7 +66,7 @@ def render_content_form_outside_refreshable(
         return wrapper
 
 
-async def render_document_container(
+async def render_document_container(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     doc: Any,
     crdt_doc: Any,
@@ -80,9 +81,11 @@ async def render_document_container(
         state,
         doc,
         crdt_doc,
-        on_add_click=on_add_tag,
-        on_manage_click=on_manage_tags,
-        footer=footer,
+        DocumentRenderCallbacks(
+            on_add_click=on_add_tag,
+            on_manage_click=on_manage_tags,
+            footer=footer,
+        ),
     )
     logger.debug("[RENDER] document rendered")
 

--- a/src/promptgrimoire/pages/annotation/header.py
+++ b/src/promptgrimoire/pages/annotation/header.py
@@ -32,7 +32,10 @@ from promptgrimoire.pages.annotation.pdf_export import (
     apply_export_recovery,
 )
 from promptgrimoire.pages.annotation.placement import show_placement_dialog
-from promptgrimoire.pages.annotation.sharing import render_sharing_controls
+from promptgrimoire.pages.annotation.sharing import (
+    SharingUiFlags,
+    render_sharing_controls,
+)
 
 logger = structlog.get_logger()
 
@@ -314,7 +317,7 @@ def _render_placement_chip(
     return placement_chip
 
 
-async def render_workspace_header(
+async def render_workspace_header(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     workspace_id: UUID,
     protect: bool = False,
@@ -413,9 +416,11 @@ async def render_workspace_header(
         # Sharing controls (Phase 5)
         render_sharing_controls(
             workspace_id=workspace_id,
-            allow_sharing=allow_sharing,
-            shared_with_class=shared_with_class,
-            can_manage_sharing=can_manage_sharing,
-            viewer_is_privileged=state.viewer_is_privileged,
             grantor_id=user_id,
+            flags=SharingUiFlags(
+                allow_sharing=allow_sharing,
+                shared_with_class=shared_with_class,
+                can_manage_sharing=can_manage_sharing,
+                viewer_is_privileged=state.viewer_is_privileged,
+            ),
         )

--- a/src/promptgrimoire/pages/annotation/highlights.py
+++ b/src/promptgrimoire/pages/annotation/highlights.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import re
 import time
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import structlog
@@ -25,12 +26,32 @@ from promptgrimoire.pages.annotation import (
 )
 from promptgrimoire.pages.annotation.css import _build_highlight_pseudo_css
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 logger = structlog.get_logger()
 
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
+
+
+def _resolve_warp_target_doc_id(
+    document_id: str | None,
+    document_tabs: Mapping[UUID, Any],
+) -> str:
+    """Resolve which document tab id a highlight-warp should land on.
+
+    Prefers ``document_id`` when it names a syntactically valid UUID that
+    is a key of ``document_tabs``; otherwise falls back to the first
+    available tab. Caller guarantees ``document_tabs`` is non-empty.
+    """
+    if document_id:
+        doc_uuid = UUID(document_id) if _UUID_RE.match(document_id) else None
+        if doc_uuid is not None and doc_uuid in document_tabs:
+            return document_id
+    return str(next(iter(document_tabs)))
 
 
 async def _warp_to_highlight(
@@ -52,12 +73,7 @@ async def _warp_to_highlight(
     # Resolve target document tab
     target_doc_id: str | None = None
     if state.tab_panels is not None and state.document_tabs:
-        if document_id:
-            doc_uuid = UUID(document_id) if _UUID_RE.match(document_id) else None
-            if doc_uuid is not None and doc_uuid in state.document_tabs:
-                target_doc_id = document_id
-        if target_doc_id is None:
-            target_doc_id = str(next(iter(state.document_tabs)))
+        target_doc_id = _resolve_warp_target_doc_id(document_id, state.document_tabs)
 
     # Store pending scroll for the tab change handler to execute.
     state._pending_scroll = (start_char, end_char)

--- a/src/promptgrimoire/pages/annotation/organise.py
+++ b/src/promptgrimoire/pages/annotation/organise.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import html as _html
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -46,6 +47,23 @@ _UNTAGGED_COLOUR = "#999999"
 
 # Raw key for the untagged pseudo-tag (empty string in CRDT)
 _UNTAGGED_RAW_KEY = ""
+
+
+@dataclass(frozen=True, slots=True)
+class TagDisplay:
+    """Display metadata for a tag column and its cards."""
+
+    name: str
+    colour: str
+    raw_key: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class TagHighlights:
+    """A tag's highlights plus their CRDT tags-Map ordering."""
+
+    highlights: list[dict[str, Any]]
+    ordered_ids: list[str]
 
 
 def _render_organise_card_html(
@@ -189,10 +207,8 @@ def _build_highlight_card_html(
 
 
 def _render_ordered_cards(
-    highlights: list[dict[str, Any]],
-    ordered_ids: list[str],
-    tag_colour: str,
-    tag_name: str,
+    tag: TagDisplay,
+    hl: TagHighlights,
     state: PageState,
     on_locate: Callable[..., Any] | None,
 ) -> None:
@@ -203,40 +219,35 @@ def _render_ordered_cards(
     when the column has no highlights at all.
 
     Args:
-        highlights: All highlights assigned to this tag.
-        ordered_ids: Ordered highlight IDs from CRDT tags Map.
-        tag_colour: Hex colour for card left borders.
-        tag_name: Display name for card tag label.
+        tag: Display metadata (name, colour) for card tag labels.
+        hl: The tag's highlights plus their CRDT tags-Map ordering.
         state: Page state for anonymisation context.
         on_locate: Optional locate callback for Tab 1 warp.
     """
-    hl_by_id = {h.get("id", ""): h for h in highlights}
+    hl_by_id = {h.get("id", ""): h for h in hl.highlights}
     rendered_ids: set[str] = set()
 
-    for hid in ordered_ids:
+    for hid in hl.ordered_ids:
         if hid in hl_by_id:
             _build_highlight_card_html(
-                hl_by_id[hid], tag_colour, tag_name, state, on_locate
+                hl_by_id[hid], tag.colour, tag.name, state, on_locate
             )
             rendered_ids.add(hid)
 
-    for hl in highlights:
-        hid = hl.get("id", "")
+    for h in hl.highlights:
+        hid = h.get("id", "")
         if hid not in rendered_ids:
-            _build_highlight_card_html(hl, tag_colour, tag_name, state, on_locate)
+            _build_highlight_card_html(h, tag.colour, tag.name, state, on_locate)
 
-    if not highlights:
+    if not hl.highlights:
         ui.label("No highlights").classes(
             "text-xs text-gray-400 italic p-2 sortable-ignore"
         )
 
 
 def _build_tag_column(
-    tag_name: str,
-    tag_colour: str,
-    raw_key: str,
-    highlights: list[dict[str, Any]],
-    ordered_ids: list[str],
+    tag: TagDisplay,
+    hl: TagHighlights,
     on_sort_end: Callable[[GenericEventArguments], Any] | None,
     state: PageState,
     on_locate: Callable[..., Any] | None = None,
@@ -248,11 +259,8 @@ def _build_tag_column(
     in a SortableJS container enabling drag reorder and cross-column moves.
 
     Args:
-        tag_name: Display name for column header.
-        tag_colour: Hex colour for header background and card borders.
-        raw_key: Raw tag key for CRDT operations.
-        highlights: All highlights assigned to this tag.
-        ordered_ids: Ordered highlight IDs from CRDT tags Map.
+        tag: Display metadata (name, colour, raw CRDT key) for the column.
+        hl: The tag's highlights plus their CRDT tags-Map ordering.
         on_sort_end: Callback for sort-end events (None to disable drag).
         state: Page state for anonymisation context.
         on_locate: Optional async callback(start_char, end_char) to warp to
@@ -264,14 +272,14 @@ def _build_tag_column(
     column = (
         ui.column()
         .classes("min-w-64 max-w-80 flex-shrink-0 self-stretch")
-        .props(f'data-testid="tag-column" data-tag-name="{tag_name}"')
+        .props(f'data-testid="tag-column" data-tag-name="{tag.name}"')
     )
 
     with column:
         # Coloured header
-        ui.label(tag_name).classes(
+        ui.label(tag.name).classes(
             "text-white font-bold text-sm px-3 py-1 rounded-t w-full text-center"
-        ).style(f"background-color: {tag_colour};")
+        ).style(f"background-color: {tag.colour};")
 
         # Create Sortable container for cards
         sortable = Sortable(
@@ -283,19 +291,17 @@ def _build_tag_column(
             on_end=on_sort_end,
         )
         # Set HTML id so event handler can identify the tag
-        sortable_id = f"sort-{raw_key}" if raw_key else "sort-untagged"
+        sortable_id = f"sort-{tag.raw_key}" if tag.raw_key else "sort-untagged"
         sortable.props(f'id="{sortable_id}"')
         sortable.classes("w-full flex-grow min-h-24 pb-4")
 
         with sortable:
-            _render_ordered_cards(
-                highlights, ordered_ids, tag_colour, tag_name, state, on_locate
-            )
+            _render_ordered_cards(tag, hl, state, on_locate)
 
     return column
 
 
-def render_organise_tab(
+def render_organise_tab(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     panel: ui.element,
     tags: list[TagInfo],
     crdt_doc: AnnotationDocument,
@@ -359,11 +365,12 @@ def render_organise_tab(
             highlights_for_tag = tagged_highlights[tag_info.name]
             ordered_ids = crdt_doc.get_tag_highlights(tag_info.raw_key)
             _build_tag_column(
-                tag_info.name,
-                tag_info.colour,
-                tag_info.raw_key,
-                highlights_for_tag,
-                ordered_ids,
+                TagDisplay(
+                    name=tag_info.name,
+                    colour=tag_info.colour,
+                    raw_key=tag_info.raw_key,
+                ),
+                TagHighlights(highlights=highlights_for_tag, ordered_ids=ordered_ids),
                 on_sort_end,
                 state,
                 on_locate,
@@ -374,11 +381,10 @@ def render_organise_tab(
         if untagged_highlights:
             ordered_ids = crdt_doc.get_tag_highlights(_UNTAGGED_RAW_KEY)
             _build_tag_column(
-                "Untagged",
-                _UNTAGGED_COLOUR,
-                _UNTAGGED_RAW_KEY,
-                untagged_highlights,
-                ordered_ids,
+                TagDisplay(
+                    name="Untagged", colour=_UNTAGGED_COLOUR, raw_key=_UNTAGGED_RAW_KEY
+                ),
+                TagHighlights(highlights=untagged_highlights, ordered_ids=ordered_ids),
                 on_sort_end,
                 state,
                 on_locate,

--- a/src/promptgrimoire/pages/annotation/pdf_export.py
+++ b/src/promptgrimoire/pages/annotation/pdf_export.py
@@ -15,6 +15,7 @@ Includes pre-export word count enforcement (AC5, AC6):
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
@@ -47,7 +48,8 @@ from promptgrimoire.word_count_enforcement import (
 )
 
 if TYPE_CHECKING:
-    from promptgrimoire.db.models import ExportJob
+    from promptgrimoire.crdt.annotation_doc import AnnotationDocument
+    from promptgrimoire.db.models import ExportJob, WorkspaceDocument
     from promptgrimoire.pages.annotation import PageState
 
 logger = structlog.get_logger()
@@ -419,12 +421,119 @@ def apply_export_recovery(state: PageState, job: ExportJob | None) -> None:
         _show_download_button(job.download_token, state)
 
 
+async def _gather_source_documents(
+    workspace_id: UUID,
+) -> list[WorkspaceDocument] | None:
+    """Fetch the workspace's non-empty source documents.
+
+    Returns None (after notifying the user) if there is nothing to export.
+    """
+    all_docs = await list_documents(workspace_id)
+    source_docs = [d for d in all_docs if d.type == "source" and d.content]
+    if not source_docs:
+        ui.notify(
+            "No document content to export. Please paste or upload content first.",
+            type="warning",
+        )
+        return None
+    return source_docs
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportBuildContext:
+    """Shared inputs for building a workspace's export document entries."""
+
+    crdt_doc: AnnotationDocument
+    tag_name_map: dict[str, str]
+    is_anonymous: bool
+    user_id: str
+    viewer_is_privileged: bool
+    privileged_user_ids: frozenset[str]
+
+
+def _build_export_document_entry(
+    doc: WorkspaceDocument,
+    ctx: _ExportBuildContext,
+    fallback_index: int,
+) -> tuple[dict[str, Any], int]:
+    """Build one source document's export payload entry.
+
+    Returns the entry dict plus the count of highlights dropped because
+    their tag no longer exists (dangling tags).
+    """
+    doc_highlights = ctx.crdt_doc.get_highlights_for_document(str(doc.id))
+    if ctx.is_anonymous and ctx.user_id:
+        doc_highlights = anonymise_highlights(
+            doc_highlights,
+            viewing_user_id=ctx.user_id,
+            anonymous_sharing=True,
+            viewer_is_privileged=ctx.viewer_is_privileged,
+            privileged_user_ids=ctx.privileged_user_ids,
+        )
+
+    valid = [hl for hl in doc_highlights if hl.get("tag", "") in ctx.tag_name_map]
+    dangling = len(doc_highlights) - len(valid)
+
+    enriched = [
+        {**hl, "tag_name": ctx.tag_name_map.get(str(hl.get("tag", "")))} for hl in valid
+    ]
+
+    doc_para_map = doc.paragraph_map
+    legal_para_map: dict[int, int | None] | None = (
+        {int(k): v for k, v in doc_para_map.items()} if doc_para_map else None
+    )
+
+    entry = {
+        "title": doc.title or f"Source {fallback_index + 1}",
+        "html_content": doc.content,
+        "highlights": enriched,
+        "word_to_legal_para": legal_para_map,
+    }
+    return entry, dangling
+
+
+def _build_export_documents(
+    source_docs: list[WorkspaceDocument],
+    ctx: _ExportBuildContext,
+) -> tuple[list[dict[str, Any]], int]:
+    """Build export payload entries for every source document.
+
+    Returns the entry list plus the total dangling-tag count across all
+    documents.
+    """
+    documents: list[dict[str, Any]] = []
+    total_dangling = 0
+    for doc in source_docs:
+        entry, dangling = _build_export_document_entry(doc, ctx, len(documents))
+        documents.append(entry)
+        total_dangling += dangling
+    return documents, total_dangling
+
+
+async def _submit_pdf_export_job(
+    user_id: str, workspace_id: UUID, payload: dict[str, Any]
+) -> ExportJob | None:
+    """Submit the export job, or notify and return None on rejection.
+
+    The per-user concurrency check is handled by create_export_job()
+    (DB-level partial unique index), not an in-memory lock.
+    """
+    try:
+        return await create_export_job(UUID(user_id), workspace_id, payload)
+    except BusinessLogicError:  # only raised by per-user concurrency check
+        logger.debug("export_job_rejected", user_id=user_id)
+        ui.notify(
+            "An earlier export is still processing."
+            " Reload the page to check its status.",
+            type="warning",
+        )
+        return None
+
+
 async def _handle_pdf_export(state: PageState, workspace_id: UUID) -> bool:
     """Handle PDF export: gather data, submit job, start polling.
 
     Returns True if a job was successfully submitted, False otherwise.
-    The per-user concurrency check is handled by create_export_job()
-    (DB-level partial unique index), not an in-memory lock.
     """
     bind_contextvars(workspace_id=str(workspace_id))
     if state.crdt_doc is None or state.document_id is None or state.user_id is None:
@@ -433,6 +542,8 @@ async def _handle_pdf_export(state: PageState, workspace_id: UUID) -> bool:
             type="warning",
         )
         return False
+    crdt_doc = state.crdt_doc
+    user_id = state.user_id
 
     # --- Extract response markdown once (live JS path, with CRDT fallback) ---
     # This single extraction is shared by both enforcement and the export
@@ -449,51 +560,22 @@ async def _handle_pdf_export(state: PageState, workspace_id: UUID) -> bool:
 
     # --- Gather payload: all source documents + their highlights ---
     tag_name_map = {ti.raw_key: ti.name for ti in (state.tag_info_list or [])}
-    tag_colours = state.tag_colours()
 
-    all_docs = await list_documents(workspace_id)
-    source_docs = [d for d in all_docs if d.type == "source" and d.content]
-    if not source_docs:
-        ui.notify(
-            "No document content to export. Please paste or upload content first.",
-            type="warning",
-        )
+    source_docs = await _gather_source_documents(workspace_id)
+    if source_docs is None:
         return False
 
-    documents: list[dict[str, Any]] = []
-    total_dangling = 0
-    for doc in source_docs:
-        doc_highlights = state.crdt_doc.get_highlights_for_document(str(doc.id))
-        if state.is_anonymous and state.user_id:
-            doc_highlights = anonymise_highlights(
-                doc_highlights,
-                viewing_user_id=state.user_id,
-                anonymous_sharing=True,
-                viewer_is_privileged=state.viewer_is_privileged,
-                privileged_user_ids=state.privileged_user_ids,
-            )
-
-        valid = [hl for hl in doc_highlights if hl.get("tag", "") in tag_name_map]
-        total_dangling += len(doc_highlights) - len(valid)
-
-        enriched = [
-            {**hl, "tag_name": tag_name_map.get(str(hl.get("tag", "")))} for hl in valid
-        ]
-
-        doc_para_map = doc.paragraph_map
-        legal_para_map: dict[int, int | None] | None = (
-            {int(k): v for k, v in doc_para_map.items()} if doc_para_map else None
-        )
-
-        documents.append(
-            {
-                "title": doc.title or f"Source {len(documents) + 1}",
-                "html_content": doc.content,
-                "highlights": enriched,
-                "word_to_legal_para": legal_para_map,
-            }
-        )
-
+    documents, total_dangling = _build_export_documents(
+        source_docs,
+        _ExportBuildContext(
+            crdt_doc=crdt_doc,
+            tag_name_map=tag_name_map,
+            is_anonymous=state.is_anonymous,
+            user_id=user_id,
+            viewer_is_privileged=state.viewer_is_privileged,
+            privileged_user_ids=state.privileged_user_ids,
+        ),
+    )
     if total_dangling > 0:
         ui.notify(
             f"{total_dangling} annotation(s) reference deleted tags "
@@ -507,7 +589,7 @@ async def _handle_pdf_export(state: PageState, workspace_id: UUID) -> bool:
 
     payload: dict[str, Any] = {
         "documents": documents,
-        "tag_colours": tag_colours,
+        "tag_colours": state.tag_colours(),
         "general_notes": "",
         "notes_latex": notes_latex,
         "filename": filename,
@@ -516,18 +598,10 @@ async def _handle_pdf_export(state: PageState, workspace_id: UUID) -> bool:
         "word_limit": state.word_limit,
     }
 
-    # --- Submit job to queue ---
-    try:
-        job = await create_export_job(UUID(state.user_id), workspace_id, payload)
-    except BusinessLogicError:  # only raised by per-user concurrency check
-        logger.debug("export_job_rejected", user_id=state.user_id)
-        ui.notify(
-            "An earlier export is still processing."
-            " Reload the page to check its status.",
-            type="warning",
-        )
+    # --- Submit job to queue and start polling for status updates ---
+    job = await _submit_pdf_export_job(user_id, workspace_id, payload)
+    if job is None:
         return False
 
-    # --- Start polling for status updates ---
     _start_export_polling(job.id, state)
     return True

--- a/src/promptgrimoire/pages/annotation/placement.py
+++ b/src/promptgrimoire/pages/annotation/placement.py
@@ -64,6 +64,60 @@ def _reset_select(
         selected[key] = None
 
 
+async def _on_cascade_course_change(
+    e: events.ValueChangeEventArguments,
+    week_select: ui.select,
+    activity_select: ui.select,
+    selected: dict[str, UUID | None],
+) -> None:
+    """Repopulate the Week select when the Course select changes."""
+    _reset_select(week_select, selected, "course", "week", "activity")
+    _reset_select(activity_select, selected)
+    if e.value:
+        try:
+            cid = UUID(e.value)
+            selected["course"] = cid
+            weeks = await list_weeks(cid)
+            week_select.options = {
+                str(w.id): f"Week {w.week_number}: {w.title}" for w in weeks
+            }
+            week_select.update()
+            if weeks:
+                week_select.enable()
+        except Exception as exc:
+            logger.exception("course_select_failed", operation="on_course_change")
+            ui.notify(str(exc), type="negative")
+
+
+async def _on_cascade_week_change(
+    e: events.ValueChangeEventArguments,
+    activity_select: ui.select,
+    selected: dict[str, UUID | None],
+) -> None:
+    """Repopulate the Activity select when the Week select changes."""
+    _reset_select(activity_select, selected, "week", "activity")
+    if e.value:
+        try:
+            wid = UUID(e.value)
+            selected["week"] = wid
+            activities = await list_activities_for_week(wid)
+            activity_select.options = {str(a.id): a.title for a in activities}
+            activity_select.update()
+            if activities:
+                activity_select.enable()
+        except Exception as exc:
+            logger.exception("week_select_failed", operation="on_week_change")
+            ui.notify(str(exc), type="negative")
+
+
+def _on_cascade_activity_change(
+    e: events.ValueChangeEventArguments,
+    selected: dict[str, UUID | None],
+) -> None:
+    """Record the selected Activity id."""
+    selected["activity"] = UUID(e.value) if e.value else None
+
+
 def _build_activity_cascade(
     course_options: dict[str, str],
     selected: dict[str, UUID | None],
@@ -96,47 +150,13 @@ def _build_activity_cascade(
     _add_option_testids(week_select, "placement-week-opt")
     _add_option_testids(activity_select, "placement-activity-opt")
 
-    async def on_course_change(e: events.ValueChangeEventArguments) -> None:
-        _reset_select(week_select, selected, "course", "week", "activity")
-        _reset_select(activity_select, selected)
-        if e.value:
-            try:
-                cid = UUID(e.value)
-                selected["course"] = cid
-                weeks = await list_weeks(cid)
-                week_select.options = {
-                    str(w.id): f"Week {w.week_number}: {w.title}" for w in weeks
-                }
-                week_select.update()
-                if weeks:
-                    week_select.enable()
-            except Exception as exc:
-                logger.exception("course_select_failed", operation="on_course_change")
-                ui.notify(str(exc), type="negative")
-
-    course_select.on_value_change(on_course_change)
-
-    async def on_week_change(e: events.ValueChangeEventArguments) -> None:
-        _reset_select(activity_select, selected, "week", "activity")
-        if e.value:
-            try:
-                wid = UUID(e.value)
-                selected["week"] = wid
-                activities = await list_activities_for_week(wid)
-                activity_select.options = {str(a.id): a.title for a in activities}
-                activity_select.update()
-                if activities:
-                    activity_select.enable()
-            except Exception as exc:
-                logger.exception("week_select_failed", operation="on_week_change")
-                ui.notify(str(exc), type="negative")
-
-    week_select.on_value_change(on_week_change)
-
-    def on_activity_change(e: events.ValueChangeEventArguments) -> None:
-        selected["activity"] = UUID(e.value) if e.value else None
-
-    activity_select.on_value_change(on_activity_change)
+    course_select.on_value_change(
+        lambda e: _on_cascade_course_change(e, week_select, activity_select, selected)
+    )
+    week_select.on_value_change(
+        lambda e: _on_cascade_week_change(e, activity_select, selected)
+    )
+    activity_select.on_value_change(lambda e: _on_cascade_activity_change(e, selected))
 
 
 def _build_course_only_select(

--- a/src/promptgrimoire/pages/annotation/respond.py
+++ b/src/promptgrimoire/pages/annotation/respond.py
@@ -24,6 +24,7 @@ import base64
 import html as _html
 import json
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -37,6 +38,8 @@ from promptgrimoire.word_count import word_count
 if TYPE_CHECKING:
     from collections.abc import Callable
     from uuid import UUID
+
+    from nicegui.events import GenericEventArguments
 
     from promptgrimoire.crdt.annotation_doc import AnnotationDocument
     from promptgrimoire.pages.annotation import PageState
@@ -62,6 +65,52 @@ _EDITOR_CSS = """
         padding: 24px 0 24px 82px;
     }
 """
+
+# A Yjs update encoding an empty/no-op delta is 2 bytes (sync-step markers
+# only). Anything longer carries real document state worth syncing/relaying.
+_EMPTY_YJS_UPDATE_BYTES = 2
+
+
+@dataclass(slots=True)
+class ReferenceCardContent:
+    """Content for a single reference card body (PLR0913: bundles fields
+    that always travel together into ``_render_reference_card_html``).
+    """
+
+    tag_display: str
+    color: str
+    display_author: str
+    text: str
+    para_ref: str
+    comments: list[tuple[str, str]]
+
+
+@dataclass(slots=True)
+class ReferencePanelContext:
+    """Read-only source data for reference-panel rendering.
+
+    Bundles the tag list and CRDT doc that are threaded unchanged through
+    ``_build_reference_panel``, ``_build_reference_column``, and
+    ``render_respond_tab`` (PLR0913).
+    """
+
+    tags: list[TagInfo]
+    crdt_doc: AnnotationDocument
+
+
+@dataclass(slots=True)
+class ClientContext:
+    """Identifies the connected client for Yjs broadcast/persistence routing.
+
+    Bundles the workspace/client identifiers and broadcast callback threaded
+    unchanged through ``_setup_yjs_event_handler`` and ``render_respond_tab``
+    (PLR0913).
+    """
+
+    workspace_key: str
+    workspace_id: UUID
+    client_id: str
+    on_yjs_update_broadcast: Any
 
 
 def group_highlights_by_tag(
@@ -108,15 +157,7 @@ def group_highlights_by_tag(
     return tagged_highlights, untagged_highlights, has_any_highlights
 
 
-def _render_reference_card_html(
-    *,
-    tag_display: str,
-    color: str,
-    display_author: str,
-    text: str,
-    para_ref: str,
-    comments: list[tuple[str, str]],
-) -> str:
+def _render_reference_card_html(content: ReferenceCardContent) -> str:
     """Render the body of a reference card as an HTML string.
 
     Returns an HTML fragment for use with ``ui.html(sanitize=False)``.
@@ -129,13 +170,19 @@ def _render_reference_card_html(
     by the caller.
 
     Args:
-        tag_display: Human-readable tag name.
-        color: Hex colour for tag label.
-        display_author: Pre-anonymised author display name.
-        text: Highlighted text content.
-        para_ref: Paragraph reference (empty string if absent).
-        comments: List of (display_author, text) tuples, pre-anonymised.
+        content: Card fields -- tag_display (human-readable tag name), color
+            (hex colour for tag label), display_author (pre-anonymised author
+            display name), text (highlighted text content), para_ref
+            (paragraph reference, empty string if absent), and comments
+            (list of (display_author, text) tuples, pre-anonymised).
     """
+    tag_display = content.tag_display
+    color = content.color
+    display_author = content.display_author
+    text = content.text
+    para_ref = content.para_ref
+    comments = content.comments
+
     esc = _html.escape
     parts: list[str] = [
         # Tag label
@@ -220,12 +267,14 @@ def _build_reference_card_html(
         comments.append((display_c_author, c_text))
 
     html_str = _render_reference_card_html(
-        tag_display=display_tag_name,
-        color=tag_colour,
-        display_author=display_author,
-        text=full_text,
-        para_ref=para_ref,
-        comments=comments,
+        ReferenceCardContent(
+            tag_display=display_tag_name,
+            color=tag_colour,
+            display_author=display_author,
+            text=full_text,
+            para_ref=para_ref,
+            comments=comments,
+        )
     )
 
     with (
@@ -323,8 +372,7 @@ def _tracked_expansion(
 
 
 def _build_reference_panel(
-    tags: list[TagInfo],
-    crdt_doc: AnnotationDocument,
+    ctx: ReferencePanelContext,
     state: PageState,
     filter_text: str | None = None,
     accordion_state: dict[str, bool] | None = None,
@@ -336,8 +384,7 @@ def _build_reference_panel(
     If no highlights exist, shows an empty-state message.
 
     Args:
-        tags: List of TagInfo instances for grouping.
-        crdt_doc: The CRDT annotation document.
+        ctx: Reference-panel source data (tag list + CRDT annotation doc).
         state: Page state for anonymisation context.
         filter_text: Optional search string to filter highlights by text or author.
         accordion_state: Dict mapping tag name to open/closed state. Mutated in
@@ -346,6 +393,8 @@ def _build_reference_panel(
         on_locate: Optional async callback(start_char, end_char) to warp to
             a highlight in Tab 1.
     """
+    tags = ctx.tags
+    crdt_doc = ctx.crdt_doc
     tagged_highlights, untagged_highlights, has_any_highlights = (
         group_highlights_by_tag(tags, crdt_doc)
     )
@@ -390,8 +439,7 @@ def _build_reference_panel(
 
 def _build_reference_column(
     splitter: ui.splitter,
-    tags: list[TagInfo],
-    crdt_doc: AnnotationDocument,
+    ctx: ReferencePanelContext,
     accordion_state: dict[str, bool],
     state: PageState,
     on_locate: Callable[..., Any] | None = None,
@@ -424,8 +472,7 @@ def _build_reference_column(
         reference_container = ui.column().classes("w-full")
         with reference_container:
             _build_reference_panel(
-                tags,
-                crdt_doc,
+                ctx,
                 state,
                 accordion_state=accordion_state,
                 on_locate=on_locate,
@@ -472,10 +519,7 @@ def _update_markdown_mirror(
 
 def _setup_yjs_event_handler(
     crdt_doc: AnnotationDocument,
-    workspace_key: str,
-    workspace_id: UUID,
-    client_id: str,
-    on_yjs_update_broadcast: Any,
+    client_ctx: ClientContext,
     state: PageState,
 ) -> None:
     """Register the NiceGUI event handler for Yjs updates from the Milkdown editor.
@@ -486,17 +530,21 @@ def _setup_yjs_event_handler(
 
     Args:
         crdt_doc: The CRDT annotation document.
-        workspace_key: Workspace identifier for broadcast lookup.
-        workspace_id: Workspace UUID for persistence.
-        client_id: This client's unique ID (for echo prevention).
-        on_yjs_update_broadcast: Callable(b64_update, origin_client_id) to
-            broadcast Yjs updates to other clients.
+        client_ctx: Workspace/client identifiers and the broadcast callback
+            (workspace_key for broadcast lookup, workspace_id for
+            persistence, client_id for echo prevention,
+            on_yjs_update_broadcast(b64_update, origin_client_id) to relay
+            updates to other clients).
         state: PageState containing word count limits and badge reference.
     """
+    workspace_key = client_ctx.workspace_key
+    workspace_id = client_ctx.workspace_id
+    client_id = client_ctx.client_id
+    on_yjs_update_broadcast = client_ctx.on_yjs_update_broadcast
 
-    async def on_yjs_update(e: object) -> None:
+    async def on_yjs_update(e: GenericEventArguments) -> None:
         """Receive a Yjs update from the JS Milkdown editor."""
-        b64_update: str = e.args["update"]  # type: ignore[union-attr]  # NiceGUI GenericEventArguments.args is untyped
+        b64_update: str = e.args["update"]
         raw = base64.b64decode(b64_update)
         # Apply to server-side CRDT Doc
         crdt_doc.apply_update(raw, origin_client_id=client_id)
@@ -509,7 +557,7 @@ def _setup_yjs_event_handler(
             len(raw),
         )
         # Write markdown from event payload to CRDT mirror (no JS round-trip).
-        md: str | None = e.args.get("markdown")  # type: ignore[union-attr]  # NiceGUI GenericEventArguments.args is untyped
+        md: str | None = e.args.get("markdown")
         _update_markdown_mirror(crdt_doc, md, workspace_key, client_id)
         # Update word count badge if limits configured
         if state.word_count_badge is not None:
@@ -532,7 +580,7 @@ def _setup_yjs_event_handler(
 
 
 def _on_markdown_flush(
-    e: object,
+    e: GenericEventArguments,
     *,
     crdt_doc: AnnotationDocument,
     workspace_id: UUID,
@@ -551,7 +599,7 @@ def _on_markdown_flush(
         workspace_id: Workspace UUID (str or UUID).
         client_id: Client identifier for logging.
     """
-    md: str | None = e.args.get("markdown")  # type: ignore[union-attr]  # NiceGUI GenericEventArguments.args is untyped
+    md: str | None = e.args.get("markdown")
     if md is None:
         logger.debug("RESPOND_FLUSH_NO_MARKDOWN client=%s", client_id[:8])
         return
@@ -593,7 +641,7 @@ def _build_editor_init_js(
     """
     full_state = crdt_doc.get_full_state()
     b64_state = ""
-    if len(full_state) > 2:
+    if len(full_state) > _EMPTY_YJS_UPDATE_BYTES:
         b64_state = base64.b64encode(full_state).decode("ascii")
         logger.debug(
             "RESPOND_FULL_STATE_SYNC ws=%s to_client=%s bytes=%d",
@@ -687,7 +735,7 @@ def _build_editor_init_js(
 
 
 def _handle_editor_ready(
-    e: object,
+    e: GenericEventArguments,
     state: PageState,
     workspace_key: str,
     client_id: str,
@@ -702,7 +750,7 @@ def _handle_editor_ready(
         _workspace_presence,
     )
 
-    args = e.args  # type: ignore[union-attr]  # NiceGUI GenericEventArguments
+    args = e.args
     if args.get("status") == "ok":
         state.has_milkdown_editor = True
         clients = _workspace_presence.get(workspace_key, {})
@@ -714,7 +762,7 @@ def _handle_editor_ready(
         # was False. Send a fresh full-state to converge.
         if state.crdt_doc is not None:
             full_state = state.crdt_doc.get_full_state()
-            if len(full_state) > 2:
+            if len(full_state) > _EMPTY_YJS_UPDATE_BYTES:
                 b64_state = base64.b64encode(full_state).decode("ascii")
                 presence = clients.get(client_id)
                 if presence and presence.nicegui_client:
@@ -737,12 +785,8 @@ def _handle_editor_ready(
 
 async def render_respond_tab(
     panel: ui.element,
-    tags: list[TagInfo],
-    crdt_doc: AnnotationDocument,
-    workspace_key: str,
-    workspace_id: UUID,
-    client_id: str,
-    on_yjs_update_broadcast: Any,
+    ctx: ReferencePanelContext,
+    client_ctx: ClientContext,
     on_locate: Callable[..., Any] | None = None,
     *,
     state: PageState,
@@ -760,12 +804,10 @@ async def render_respond_tab(
 
     Args:
         panel: The ui.tab_panel element to populate.
-        tags: List of TagInfo instances for the reference panel.
-        crdt_doc: The CRDT annotation document.
-        workspace_key: String key for the workspace (for broadcast lookup).
-        client_id: This client's unique ID (for echo prevention).
-        on_yjs_update_broadcast: Callable(b64_update, origin_client_id) to
-            broadcast Yjs updates to other clients.
+        ctx: Reference-panel source data (tag list + CRDT annotation doc).
+        client_ctx: Workspace/client identifiers and the Yjs broadcast
+            callback -- Callable(b64_update, origin_client_id) to broadcast
+            Yjs updates to other clients.
         on_locate: Optional async callback(start_char, end_char) to warp to
             a highlight in Tab 1.
         state: PageState containing word count limits and badge reference,
@@ -774,6 +816,10 @@ async def render_respond_tab(
     Returns:
         refresh_references: Callable that refreshes the reference panel.
     """
+    crdt_doc = ctx.crdt_doc
+    workspace_key = client_ctx.workspace_key
+    client_id = client_ctx.client_id
+
     panel.clear()
     editor_id = "milkdown-respond-editor"
 
@@ -802,22 +848,21 @@ async def render_respond_tab(
         )
 
         reference_container, search_input = _build_reference_column(
-            splitter, tags, crdt_doc, accordion_state, state=state, on_locate=on_locate
+            splitter, ctx, accordion_state, state=state, on_locate=on_locate
         )
 
-        def _filter_highlights(e: object) -> None:
+        def _filter_highlights(e: GenericEventArguments) -> None:
             """Re-render reference panel filtered by search text.
 
             Uses the event value directly rather than search_input.value because
             NiceGUI debounces server-side value sync — reading .value here would
             return stale data.
             """
-            filter_val = e.args if isinstance(e.args, str) else ""  # type: ignore[union-attr]  # NiceGUI GenericEventArguments.args is untyped
+            filter_val = e.args if isinstance(e.args, str) else ""
             reference_container.clear()
             with reference_container:
                 _build_reference_panel(
-                    tags,
-                    crdt_doc,
+                    ctx,
                     state,
                     filter_text=filter_val,
                     accordion_state=accordion_state,
@@ -845,10 +890,7 @@ async def render_respond_tab(
 
     _setup_yjs_event_handler(
         crdt_doc,
-        workspace_key,
-        workspace_id,
-        client_id,
-        on_yjs_update_broadcast,
+        client_ctx,
         state=state,
     )
 
@@ -886,7 +928,7 @@ async def render_respond_tab(
         lambda e: _on_markdown_flush(
             e,
             crdt_doc=crdt_doc,
-            workspace_id=workspace_id,
+            workspace_id=client_ctx.workspace_id,
             client_id=client_id,
         ),
     )
@@ -906,8 +948,7 @@ async def render_respond_tab(
         reference_container.clear()
         with reference_container:
             _build_reference_panel(
-                tags,
-                crdt_doc,
+                ctx,
                 state,
                 filter_text=search_input.value,
                 accordion_state=accordion_state,

--- a/src/promptgrimoire/pages/annotation/sharing.py
+++ b/src/promptgrimoire/pages/annotation/sharing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import structlog
@@ -23,28 +24,51 @@ from promptgrimoire.db.workspaces import update_workspace_sharing
 
 logger = structlog.get_logger()
 
+# An email address splits into exactly local-part and domain around "@".
+_EMAIL_PARTS = 2
+
+
+@dataclass(frozen=True, slots=True)
+class SharingUiFlags:
+    """Flags controlling which sharing controls render, and their state."""
+
+    allow_sharing: bool
+    shared_with_class: bool
+    can_manage_sharing: bool
+    viewer_is_privileged: bool
+
+    @property
+    def shows_class_toggle(self) -> bool:
+        """Share-with-class toggle: activity allows sharing AND viewer manages."""
+        return self.allow_sharing and self.can_manage_sharing
+
+    @property
+    def shows_share_button(self) -> bool:
+        """Share-with-user button: sharing allowed or staff bypass, AND manages.
+
+        Staff (viewer_is_privileged) can share even when the activity
+        disallows it; nobody shares without manage rights.
+        """
+        return (
+            self.allow_sharing or self.viewer_is_privileged
+        ) and self.can_manage_sharing
+
 
 def render_sharing_controls(
     *,
     workspace_id: UUID,
-    allow_sharing: bool,
-    shared_with_class: bool,
-    can_manage_sharing: bool,
-    viewer_is_privileged: bool,
     grantor_id: UUID | None,
+    flags: SharingUiFlags,
 ) -> None:
     """Render sharing toggle and share button in the workspace header.
 
     Args:
         workspace_id: Workspace UUID.
-        allow_sharing: Whether the placement context allows sharing.
-        shared_with_class: Current workspace shared_with_class state.
-        can_manage_sharing: Whether the user can toggle sharing.
-        viewer_is_privileged: Whether the viewer is an instructor/admin.
         grantor_id: The local User UUID for the current session, or None.
+        flags: Sharing permission/state flags (see SharingUiFlags).
     """
     # "Share with class" toggle -- only when activity allows sharing
-    if allow_sharing and can_manage_sharing:
+    if flags.shows_class_toggle:
 
         async def _handle_share_toggle(value: bool) -> None:
             try:
@@ -59,12 +83,12 @@ def render_sharing_controls(
 
         ui.switch(
             "Share with class",
-            value=shared_with_class,
+            value=flags.shared_with_class,
             on_change=lambda e: _handle_share_toggle(e.value),
         ).props('data-testid="share-with-class-toggle"')
 
     # "Share with user" button -- visible when sharing allowed, or staff bypass
-    if (allow_sharing or viewer_is_privileged) and can_manage_sharing:
+    if flags.shows_share_button:
 
         async def _open_share_dialog() -> None:
             if grantor_id is None:
@@ -72,8 +96,8 @@ def render_sharing_controls(
             await open_sharing_dialog(
                 workspace_id=workspace_id,
                 grantor_id=grantor_id,
-                sharing_allowed=allow_sharing,
-                grantor_is_staff=viewer_is_privileged,
+                sharing_allowed=flags.allow_sharing,
+                grantor_is_staff=flags.viewer_is_privileged,
             )
 
         ui.button(
@@ -91,7 +115,7 @@ def _is_plausible_email(email: str) -> bool:
     round-trip to the database.
     """
     parts = email.split("@")
-    if len(parts) != 2 or not parts[0]:
+    if len(parts) != _EMAIL_PARTS or not parts[0]:
         return False
     domain = parts[1]
     return "." in domain and not domain.startswith(".") and not domain.endswith(".")

--- a/src/promptgrimoire/pages/annotation/sidebar.py
+++ b/src/promptgrimoire/pages/annotation/sidebar.py
@@ -24,7 +24,7 @@ _JS_PATH = (
 class AnnotationSidebar(ui.element, component=_JS_PATH):
     """Custom Vue component wrapper for annotation sidebar."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
         self,
         items: list[dict[str, Any]] | None = None,
         *,
@@ -64,11 +64,12 @@ class AnnotationSidebar(ui.element, component=_JS_PATH):
         self._props["items"] = items
         self.update()
 
-    def refresh_items(
+    def refresh_items(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
         self,
         highlights: list[dict[str, Any]],
         tag_info_map: dict[str, TagInfo],
         tag_colours: dict[str, str],
+        *,
         user_id: str | None,
         viewer_is_privileged: bool,
         privileged_user_ids: frozenset[str],

--- a/src/promptgrimoire/pages/annotation/tab_bar.py
+++ b/src/promptgrimoire/pages/annotation/tab_bar.py
@@ -35,7 +35,11 @@ from promptgrimoire.pages.annotation.highlights import (
     _warp_to_highlight,
 )
 from promptgrimoire.pages.annotation.organise import render_organise_tab
-from promptgrimoire.pages.annotation.respond import render_respond_tab
+from promptgrimoire.pages.annotation.respond import (
+    ClientContext,
+    ReferencePanelContext,
+    render_respond_tab,
+)
 from promptgrimoire.pages.annotation.tags import workspace_tags_from_crdt
 
 if TYPE_CHECKING:
@@ -298,12 +302,13 @@ async def _initialise_respond_tab(state: PageState, workspace_id: UUID) -> None:
 
     state.refresh_respond_references = await render_respond_tab(
         panel=state.respond_panel,
-        tags=tags,
-        crdt_doc=state.crdt_doc,
-        workspace_key=str(workspace_id),
-        workspace_id=workspace_id,
-        client_id=state.client_id,
-        on_yjs_update_broadcast=_on_broadcast,
+        ctx=ReferencePanelContext(tags=tags, crdt_doc=state.crdt_doc),
+        client_ctx=ClientContext(
+            workspace_key=str(workspace_id),
+            workspace_id=workspace_id,
+            client_id=state.client_id,
+            on_yjs_update_broadcast=_on_broadcast,
+        ),
         on_locate=_on_respond_locate,
         state=state,
     )
@@ -408,7 +413,7 @@ def _restore_source_tab_state(
     state.toolbar_container = doc_tab.toolbar_container
 
 
-async def _render_source_tab_content(
+async def _render_source_tab_content(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     doc_tab: DocumentTabState,
     *,
@@ -452,7 +457,7 @@ async def _render_source_tab_content(
     _save_source_tab_state(state, doc_tab)
 
 
-async def _handle_source_tab_switch(
+async def _handle_source_tab_switch(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     tab_name: str,
     *,
@@ -519,7 +524,7 @@ def _save_previous_source_tab(state: PageState, prev_tab: str) -> None:
         _save_source_tab_state(state, prev_doc)
 
 
-def _make_tab_change_handler(
+def _make_tab_change_handler(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     workspace_id: UUID,
     *,
@@ -599,7 +604,7 @@ async def _load_crdt_for_workspace(
     )
 
 
-async def _build_first_source_panel(
+async def _build_first_source_panel(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     workspace_id: UUID,
     *,
@@ -702,7 +707,7 @@ async def _build_first_source_panel(
     )
 
 
-async def _build_tab_panels(
+async def _build_tab_panels(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     state: PageState,
     workspace_id: UUID,
     tabs: ui.tabs,

--- a/src/promptgrimoire/pages/annotation/tag_import.py
+++ b/src/promptgrimoire/pages/annotation/tag_import.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
     from promptgrimoire.db.tags import ImportResult
     from promptgrimoire.pages.annotation import PageState
 
+_TAG_PREVIEW_LIMIT = 5
+"""Number of tag names shown before collapsing the rest into a "+N" suffix."""
+
 logger = structlog.get_logger()
 
 
@@ -76,9 +79,9 @@ def _build_workspace_options(
     for ws, course_name, tag_names in workspaces:
         title = ws.title or "Untitled workspace"
         prefix = f"{course_name} / " if course_name else ""
-        tag_preview = ", ".join(tag_names[:5])
-        if len(tag_names) > 5:
-            tag_preview += f" (+{len(tag_names) - 5})"
+        tag_preview = ", ".join(tag_names[:_TAG_PREVIEW_LIMIT])
+        if len(tag_names) > _TAG_PREVIEW_LIMIT:
+            tag_preview += f" (+{len(tag_names) - _TAG_PREVIEW_LIMIT})"
         options[str(ws.id)] = f"{prefix}{title} ({tag_preview})"
     return options
 

--- a/src/promptgrimoire/pages/annotation/tag_management.py
+++ b/src/promptgrimoire/pages/annotation/tag_management.py
@@ -8,7 +8,8 @@ save logic from ``tag_management_save``, and import section from
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 import structlog
 from nicegui import ui
@@ -18,6 +19,9 @@ from promptgrimoire.pages.annotation.tag_import import (
     _render_import_section,
 )
 from promptgrimoire.pages.annotation.tag_management_rows import (
+    TagListCallbacks,
+    TagListCollectors,
+    TagListRenderContext,
     _open_confirm_delete,
     _render_tag_list_content,
 )
@@ -32,6 +36,9 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from uuid import UUID
 
+    from nicegui.elements.timer import Timer
+
+    from promptgrimoire.crdt.annotation_doc import AnnotationDocument
     from promptgrimoire.db.models import Tag
     from promptgrimoire.db.workspaces import PlacementContext
     from promptgrimoire.pages.annotation import PageState
@@ -82,10 +89,43 @@ class TagRowInputs(TypedDict):
     color: str
     description: str
     group_id: str | None
+    # Runtime-only slot: _setup_color_debounce parks its pending Timer here so
+    # _cancel_pending_timers can cancel it before a batch save.
+    _pending_timer: NotRequired[Timer | None]
     orig_name: str
     orig_color: str
     orig_desc: str
     orig_group: str | None
+
+
+@dataclass(slots=True)
+class TagDbOps:
+    """DB mutation callables shared by the management dialog's callback
+    builders (PLR0913).
+    """
+
+    update_tag: Callable[..., Awaitable[object]]
+    update_tag_group: Callable[..., Awaitable[object]]
+    create_tag: Callable[..., Awaitable[object]]
+    create_tag_group: Callable[..., Awaitable[object]]
+    reorder_tags: Callable[..., Awaitable[None]]
+    reorder_tag_groups: Callable[..., Awaitable[None]]
+
+
+@dataclass(slots=True)
+class TagOrderState:
+    """Mutable per-render drag-order tracking for reorder callbacks (PLR0913)."""
+
+    tag_id_lists: dict[UUID | None, list[UUID]]
+    group_id_list: list[UUID]
+
+
+@dataclass(slots=True)
+class TagRowInputCollectors:
+    """Batch-save model-dict collectors read by the Done button (PLR0913)."""
+
+    tag_row_inputs: dict[UUID, TagRowInputs]
+    group_row_inputs: dict[UUID, dict[str, Any]]
 
 
 _PRESET_PALETTE: list[str] = [
@@ -122,21 +162,17 @@ def _unique_tag_name(existing_names: set[str]) -> str:
 
 
 def _highlight_count_for_tag(
-    crdt_doc: object | None,
+    crdt_doc: AnnotationDocument | None,
     tag_id: UUID,
 ) -> int:
     """Count CRDT highlights referencing *tag_id*.
 
     Returns 0 if *crdt_doc* is None or has no highlights.
     """
-    if not crdt_doc:
+    if crdt_doc is None:
         return 0
     tag_str = str(tag_id)
-    return sum(
-        1
-        for hl in crdt_doc.get_all_highlights()  # type: ignore[union-attr]
-        if hl.get("tag") == tag_str
-    )
+    return sum(1 for hl in crdt_doc.get_all_highlights() if hl.get("tag") == tag_str)
 
 
 def _delete_confirmation_body(highlight_count: int) -> str:
@@ -184,10 +220,8 @@ def _build_done_button(
     *,
     dialog: ui.dialog,
     state: PageState,
-    tag_row_inputs: dict[UUID, TagRowInputs],
-    group_row_inputs: dict[UUID, dict[str, Any]],
-    update_tag: Callable[..., Awaitable[object]],
-    update_tag_group: Callable[..., Awaitable[object]],
+    row_inputs: TagRowInputCollectors,
+    db_ops: TagDbOps,
     is_instructor: bool,
 ) -> None:
     """Render a Done button that batch-saves and shows a spinner during save.
@@ -200,6 +234,11 @@ def _build_done_button(
         _cancel_pending_timers,
         _save_all_modified_rows,
     )
+
+    tag_row_inputs = row_inputs.tag_row_inputs
+    group_row_inputs = row_inputs.group_row_inputs
+    update_tag = db_ops.update_tag
+    update_tag_group = db_ops.update_tag_group
 
     done_btn = ui.button("Done", icon="check").props(
         'color=primary data-testid="tag-management-done-btn"'
@@ -257,6 +296,15 @@ async def open_tag_management(
         update_tag_group,
     )
 
+    db_ops = TagDbOps(
+        update_tag=update_tag,
+        update_tag_group=update_tag_group,
+        create_tag=create_tag,
+        create_tag_group=create_tag_group,
+        reorder_tags=reorder_tags,
+        reorder_tag_groups=reorder_tag_groups,
+    )
+
     # Instructor = template workspace owner OR org-level admin.
     # Students never access templates (ACL gate in workspace.py), so
     # is_template reliably identifies instructor context.  Org admins
@@ -309,13 +357,11 @@ async def open_tag_management(
             callbacks = _build_management_callbacks(
                 state=state,
                 render_tag_list=_render_tag_list,
-                update_tag=update_tag,
-                create_tag=create_tag,
-                create_tag_group=create_tag_group,
-                reorder_tags=reorder_tags,
-                reorder_tag_groups=reorder_tag_groups,
-                tag_id_lists=tag_id_lists,
-                group_id_list=group_id_list,
+                db_ops=db_ops,
+                order_state=TagOrderState(
+                    tag_id_lists=tag_id_lists,
+                    group_id_list=group_id_list,
+                ),
                 is_instructor=is_instructor,
             )
 
@@ -344,24 +390,32 @@ async def open_tag_management(
                 _render_tag_list_content(
                     groups=groups,
                     tags_by_group=tags_by_group,
-                    group_options=group_options,
-                    is_instructor=is_instructor,
-                    on_delete_tag=callbacks["delete_tag"],
-                    on_delete_group=callbacks["delete_group"],
-                    on_add_tag=callbacks["add_tag"],
-                    on_add_group=callbacks["add_group"],
-                    on_lock_toggle=callbacks["lock_toggle"] if is_instructor else None,
-                    on_tag_reorder_for_group=callbacks["tag_reorder"],
-                    on_group_reorder=callbacks["group_reorder"],
-                    on_move_group=callbacks["move_group"],
-                    on_move_tag=callbacks["move_tag"],
-                    tag_id_lists=tag_id_lists,
-                    group_id_list=group_id_list,
-                    tag_row_collector=tag_row_inputs,
-                    group_row_collector=group_row_inputs,
-                    on_field_save=_save_tag_field,
-                    on_group_field_save=_save_group_field,
-                    highlight_counts=highlight_counts,
+                    render_ctx=TagListRenderContext(
+                        group_options=group_options,
+                        is_instructor=is_instructor,
+                        highlight_counts=highlight_counts,
+                    ),
+                    callbacks=TagListCallbacks(
+                        on_delete_tag=callbacks["delete_tag"],
+                        on_delete_group=callbacks["delete_group"],
+                        on_add_tag=callbacks["add_tag"],
+                        on_add_group=callbacks["add_group"],
+                        on_lock_toggle=(
+                            callbacks["lock_toggle"] if is_instructor else None
+                        ),
+                        on_tag_reorder_for_group=callbacks["tag_reorder"],
+                        on_group_reorder=callbacks["group_reorder"],
+                        on_move_group=callbacks["move_group"],
+                        on_move_tag=callbacks["move_tag"],
+                        on_field_save=_save_tag_field,
+                        on_group_field_save=_save_group_field,
+                    ),
+                    collectors=TagListCollectors(
+                        tag_id_lists=tag_id_lists,
+                        group_id_list=group_id_list,
+                        tag_row_collector=tag_row_inputs,
+                        group_row_collector=group_row_inputs,
+                    ),
                 )
 
                 # Import section -- available to all users (AC3.6)
@@ -377,10 +431,11 @@ async def open_tag_management(
             _build_done_button(
                 dialog=dialog,
                 state=state,
-                tag_row_inputs=tag_row_inputs,
-                group_row_inputs=group_row_inputs,
-                update_tag=update_tag,
-                update_tag_group=update_tag_group,
+                row_inputs=TagRowInputCollectors(
+                    tag_row_inputs=tag_row_inputs,
+                    group_row_inputs=group_row_inputs,
+                ),
+                db_ops=db_ops,
                 is_instructor=is_instructor,
             )
 
@@ -480,6 +535,40 @@ def _build_group_callbacks(
     }
 
 
+def _reordered_group_for_move(
+    tag_id: UUID,
+    tag_id_lists: dict[UUID | None, list[UUID]],
+    direction: int,
+) -> list[UUID] | None:
+    """Compute the reordered tag list for a move-up/move-down click.
+
+    Finds which group's list contains *tag_id* and returns that group's
+    ordering with the tag shifted by *direction* (-1 up, +1 down).
+    Returns ``None`` if the tag is not found in any group, or if the
+    move would go out of bounds (already first/last).
+
+    Pure -- performs no I/O. Extracted from ``_move_tag`` to keep the
+    reorder-callback factory's cognitive complexity low.
+    """
+    for id_list in tag_id_lists.values():
+        if tag_id not in id_list:
+            continue
+        try:
+            old_idx = id_list.index(tag_id)
+        except ValueError:
+            logger.warning(
+                "tag_not_found_for_move",
+                operation="move_tag",
+                tag_id=str(tag_id),
+            )
+            return None
+        new_idx = old_idx + direction
+        if new_idx < 0 or new_idx >= len(id_list):
+            return None
+        return _reorder_list(id_list, old_idx, new_idx)
+    return None
+
+
 def _build_tag_reorder_callbacks(
     *,
     state: PageState,
@@ -500,25 +589,12 @@ def _build_tag_reorder_callbacks(
 
     async def _move_tag(tag_id: UUID, direction: int) -> None:
         """Move a tag up (-1) or down (+1) within its group."""
-        for _gid, id_list in tag_id_lists.items():
-            if tag_id in id_list:
-                try:
-                    old_idx = id_list.index(tag_id)
-                except ValueError:
-                    logger.warning(
-                        "tag_not_found_for_move",
-                        operation="move_tag",
-                        tag_id=str(tag_id),
-                    )
-                    return
-                new_idx = old_idx + direction
-                if new_idx < 0 or new_idx >= len(id_list):
-                    return
-                new_order = _reorder_list(id_list, old_idx, new_idx)
-                await reorder_tags(new_order, crdt_doc=state.crdt_doc)
-                await _refresh_tag_state(state)
-                await render_tag_list()
-                return
+        new_order = _reordered_group_for_move(tag_id, tag_id_lists, direction)
+        if new_order is None:
+            return
+        await reorder_tags(new_order, crdt_doc=state.crdt_doc)
+        await _refresh_tag_state(state)
+        await render_tag_list()
 
     return {
         "tag_reorder": _tag_reorder,
@@ -605,19 +681,22 @@ def _build_management_callbacks(
     *,
     state: PageState,
     render_tag_list: Callable[[], Awaitable[None]],
-    update_tag: Callable[..., Awaitable[object]],
-    create_tag: Callable[..., Awaitable[object]],
-    create_tag_group: Callable[..., Awaitable[object]],
-    reorder_tags: Callable[..., Awaitable[None]],
-    reorder_tag_groups: Callable[..., Awaitable[None]],
-    tag_id_lists: dict[UUID | None, list[UUID]],
-    group_id_list: list[UUID],
+    db_ops: TagDbOps,
+    order_state: TagOrderState,
     is_instructor: bool,
 ) -> ManagementCallbacks:
     """Build all management dialog callbacks as a dict.
 
     Delegates to sub-builders for group, reorder, and tag CRUD callbacks.
     """
+    update_tag = db_ops.update_tag
+    create_tag = db_ops.create_tag
+    create_tag_group = db_ops.create_tag_group
+    reorder_tags = db_ops.reorder_tags
+    reorder_tag_groups = db_ops.reorder_tag_groups
+    tag_id_lists = order_state.tag_id_lists
+    group_id_list = order_state.group_id_list
+
     group_cbs = _build_group_callbacks(
         state=state,
         render_tag_list=render_tag_list,

--- a/src/promptgrimoire/pages/annotation/tag_management_rows.py
+++ b/src/promptgrimoire/pages/annotation/tag_management_rows.py
@@ -13,6 +13,7 @@ feedback.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import structlog
@@ -32,6 +33,89 @@ if TYPE_CHECKING:
     )
 
 logger = structlog.get_logger()
+
+
+@dataclass(slots=True)
+class TagListRenderContext:
+    """Read-only context shared across tag/group row rendering (PLR0913).
+
+    Bundles the fields that travel unchanged through
+    ``_render_tag_list_content``, ``_render_group_tags``, and
+    ``_render_tag_row``.
+    """
+
+    group_options: dict[str, str]
+    is_instructor: bool
+    highlight_counts: dict[UUID, int] | None = None
+
+
+@dataclass(slots=True)
+class TagRowContext:
+    """Per-row rendering context for a single tag row (PLR0913)."""
+
+    render_ctx: TagListRenderContext
+    can_edit: bool
+    on_delete: Callable[[UUID, str], None]
+    on_lock_toggle: Callable[[UUID, bool], Awaitable[None]] | None = None
+    on_move_tag: Callable[[UUID, int], Awaitable[None]] | None = None
+    tag_index: int = 0
+    total_tags: int = 1
+    row_collector: dict[UUID, TagRowInputs] | None = None
+    on_field_save: Callable[[UUID], Awaitable[None]] | None = None
+    highlight_count: int = 0
+
+
+@dataclass(slots=True)
+class GroupHeaderContext:
+    """Rendering context for a single group header row (PLR0913)."""
+
+    on_delete_group: Callable[[UUID, str], None]
+    on_move_group: Callable[[UUID, int], Awaitable[None]] | None = None
+    group_index: int = 0
+    total_groups: int = 1
+    row_collector: dict[UUID, dict[str, Any]] | None = None
+    on_group_field_save: Callable[[UUID], Awaitable[None]] | None = None
+    tag_count: int = 0
+
+
+@dataclass(slots=True)
+class GroupTagsContext:
+    """Rendering context for all tags within one group (PLR0913)."""
+
+    render_ctx: TagListRenderContext
+    on_delete_tag: Callable[[UUID, str], None]
+    on_lock_toggle: Callable[[UUID, bool], Awaitable[None]] | None
+    on_move_tag: Callable[[UUID, int], Awaitable[None]] | None = None
+    tag_row_collector: dict[UUID, TagRowInputs] | None = None
+    on_field_save: Callable[[UUID], Awaitable[None]] | None = None
+
+
+@dataclass(slots=True)
+class TagListCallbacks:
+    """Callbacks threaded unchanged through the tag list render tree (PLR0913)."""
+
+    on_delete_tag: Callable[[UUID, str], None]
+    on_delete_group: Callable[[UUID, str], None]
+    on_add_tag: Callable[[UUID | None, ui.button | None], Awaitable[None]]
+    on_add_group: Callable[[], Awaitable[None]]
+    on_lock_toggle: Callable[[UUID, bool], Awaitable[None]] | None
+    on_tag_reorder_for_group: Any
+    on_group_reorder: Any
+    on_move_group: Callable[[UUID, int], Awaitable[None]] | None = None
+    on_move_tag: Callable[[UUID, int], Awaitable[None]] | None = None
+    on_field_save: Callable[[UUID], Awaitable[None]] | None = None
+    on_group_field_save: Callable[[UUID], Awaitable[None]] | None = None
+
+
+@dataclass(slots=True)
+class TagListCollectors:
+    """Mutable order/save-state collectors populated during rendering (PLR0913)."""
+
+    tag_id_lists: dict[UUID | None, list[UUID]]
+    group_id_list: list[UUID]
+    tag_row_collector: dict[UUID, TagRowInputs]
+    group_row_collector: dict[UUID, dict[str, Any]]
+
 
 # ── Element creation helpers ────────────────────────────────────────
 
@@ -204,55 +288,43 @@ def _create_tag_fields(
 # ── Tag row rendering helper ─────────────────────────────────────────
 
 
-def _render_tag_row(
-    tag: Tag,
-    *,
-    can_edit: bool,
-    is_instructor: bool,
-    group_options: dict[str, str],
-    on_delete: Callable[[UUID, str], None],
-    on_lock_toggle: (Callable[[UUID, bool], Awaitable[None]] | None) = None,
-    on_move_tag: (Callable[[UUID, int], Awaitable[None]] | None) = None,
-    tag_index: int = 0,
-    total_tags: int = 1,
-    row_collector: dict[UUID, TagRowInputs] | None = None,
-    on_field_save: (Callable[[UUID], Awaitable[None]] | None) = None,
-    highlight_count: int = 0,
-) -> None:
+def _render_tag_row(tag: Tag, ctx: TagRowContext) -> None:
     """Render a single tag row with inline editing controls.
 
     Values are stored in a model dict and kept in sync with inputs
     via ``bind_value()``. The model dict is stored in
-    ``row_collector`` for the "Done" button to save all changes.
+    ``ctx.row_collector`` for the "Done" button to save all changes.
 
     Parameters
     ----------
     tag:
         A Tag model instance.
-    can_edit:
-        Whether inputs should be editable.
-    is_instructor:
-        Whether the current user is an instructor.
-    group_options:
-        Mapping of group UUID string -> group name.
-    on_delete:
-        Sync callback ``(tag_id, tag_name) -> None``.
-    on_lock_toggle:
-        Async callback ``(tag_id, locked) -> None``.
-    on_move_tag:
-        Async callback ``(tag_id, direction) -> None``.
-    tag_index:
-        Zero-based position within its group.
-    total_tags:
-        Total tags in this group.
-    row_collector:
-        Mutable dict to store model dicts for batch save.
-    on_field_save:
-        Async callback for immediate save (colour debounce).
-    highlight_count:
-        Number of CRDT highlights referencing this tag.  When > 0 the
-        delete button is disabled with a tooltip explaining the precondition.
+    ctx:
+        Rendering context: can_edit (whether inputs should be editable),
+        render_ctx.is_instructor, render_ctx.group_options (mapping of
+        group UUID string -> group name), on_delete (sync callback
+        ``(tag_id, tag_name) -> None``), on_lock_toggle (async callback
+        ``(tag_id, locked) -> None``), on_move_tag (async callback
+        ``(tag_id, direction) -> None``), tag_index (zero-based position
+        within its group), total_tags (total tags in this group),
+        row_collector (mutable dict to store model dicts for batch save),
+        on_field_save (async callback for immediate save on colour
+        debounce), and highlight_count (number of CRDT highlights
+        referencing this tag -- when > 0 the delete button is disabled
+        with a tooltip explaining the precondition).
     """
+    can_edit = ctx.can_edit
+    is_instructor = ctx.render_ctx.is_instructor
+    group_options = ctx.render_ctx.group_options
+    on_delete = ctx.on_delete
+    on_lock_toggle = ctx.on_lock_toggle
+    on_move_tag = ctx.on_move_tag
+    tag_index = ctx.tag_index
+    total_tags = ctx.total_tags
+    row_collector = ctx.row_collector
+    on_field_save = ctx.on_field_save
+    highlight_count = ctx.highlight_count
+
     # Model dict — bind_value keeps this in sync with inputs
     model: TagRowInputs = {
         "name": tag.name,
@@ -345,17 +417,7 @@ def _render_lock_toggle(
 # ── Group header rendering helper ────────────────────────────────────
 
 
-def _render_group_header(
-    group: TagGroup,
-    *,
-    on_delete_group: Callable[[UUID, str], None],
-    on_move_group: (Callable[[UUID, int], Awaitable[None]] | None) = None,
-    group_index: int = 0,
-    total_groups: int = 1,
-    row_collector: dict[UUID, dict[str, Any]] | None = None,
-    on_group_field_save: (Callable[[UUID], Awaitable[None]] | None) = None,
-    tag_count: int = 0,
-) -> None:
+def _render_group_header(group: TagGroup, ctx: GroupHeaderContext) -> None:
     """Render a group header with name input, colour, and delete.
 
     Values are stored in a model dict kept in sync via
@@ -365,22 +427,25 @@ def _render_group_header(
     ----------
     group:
         The TagGroup model instance.
-    on_delete_group:
-        Sync callback ``(group_id, group_name) -> None``.
-    on_move_group:
-        Async callback ``(group_id, direction) -> None``.
-    group_index:
-        Zero-based position within the group list.
-    total_groups:
-        Total number of groups.
-    row_collector:
-        Mutable dict to store model dicts for batch save.
-    on_group_field_save:
-        Async callback for immediate save (colour debounce).
-    tag_count:
-        Number of tags in this group.  When > 0 the delete button is
-        disabled with a tooltip explaining the precondition.
+    ctx:
+        Rendering context: on_delete_group (sync callback
+        ``(group_id, group_name) -> None``), on_move_group (async
+        callback ``(group_id, direction) -> None``), group_index
+        (zero-based position within the group list), total_groups
+        (total number of groups), row_collector (mutable dict to store
+        model dicts for batch save), on_group_field_save (async
+        callback for immediate save on colour debounce), and tag_count
+        (number of tags in this group -- when > 0 the delete button is
+        disabled with a tooltip explaining the precondition).
     """
+    on_delete_group = ctx.on_delete_group
+    on_move_group = ctx.on_move_group
+    group_index = ctx.group_index
+    total_groups = ctx.total_groups
+    row_collector = ctx.row_collector
+    on_group_field_save = ctx.on_group_field_save
+    tag_count = ctx.tag_count
+
     model: dict[str, Any] = {
         "name": group.name,
         "color": group.color or "",
@@ -510,20 +575,16 @@ def _render_group_tags(
     *,
     group_tags: list[Tag],
     tag_ids: list[UUID],
-    is_instructor: bool,
-    group_options: dict[str, str],
-    on_delete_tag: Callable[[UUID, str], None],
-    on_lock_toggle: (Callable[[UUID, bool], Awaitable[None]] | None),
     on_tag_reorder: Any,
-    on_move_tag: (Callable[[UUID, int], Awaitable[None]] | None) = None,
-    tag_row_collector: (dict[UUID, TagRowInputs] | None) = None,
-    on_field_save: (Callable[[UUID], Awaitable[None]] | None) = None,
-    highlight_counts: dict[UUID, int] | None = None,
+    ctx: GroupTagsContext,
 ) -> None:
     """Render tags within a group in a Sortable."""
     from promptgrimoire.elements.sortable.sortable import (  # noqa: PLC0415
         Sortable,
     )
+
+    is_instructor = ctx.render_ctx.is_instructor
+    highlight_counts = ctx.render_ctx.highlight_counts
 
     total_tags = len(group_tags)
     with Sortable(
@@ -538,17 +599,18 @@ def _render_group_tags(
             can_edit = not tag.locked or is_instructor
             _render_tag_row(
                 tag,
-                can_edit=can_edit,
-                is_instructor=is_instructor,
-                group_options=group_options,
-                on_delete=on_delete_tag,
-                on_lock_toggle=on_lock_toggle,
-                on_move_tag=on_move_tag,
-                tag_index=idx,
-                total_tags=total_tags,
-                row_collector=tag_row_collector,
-                on_field_save=on_field_save,
-                highlight_count=(highlight_counts or {}).get(tag.id, 0),
+                TagRowContext(
+                    render_ctx=ctx.render_ctx,
+                    can_edit=can_edit,
+                    on_delete=ctx.on_delete_tag,
+                    on_lock_toggle=ctx.on_lock_toggle,
+                    on_move_tag=ctx.on_move_tag,
+                    tag_index=idx,
+                    total_tags=total_tags,
+                    row_collector=ctx.tag_row_collector,
+                    on_field_save=ctx.on_field_save,
+                    highlight_count=(highlight_counts or {}).get(tag.id, 0),
+                ),
             )
 
 
@@ -556,34 +618,51 @@ def _render_tag_list_content(
     *,
     groups: list[TagGroup],
     tags_by_group: dict[UUID | None, list[Tag]],
-    group_options: dict[str, str],
-    is_instructor: bool,
-    on_delete_tag: Callable[[UUID, str], None],
-    on_delete_group: Callable[[UUID, str], None],
-    on_add_tag: Callable[[UUID | None, ui.button | None], Awaitable[None]],
-    on_add_group: Callable[[], Awaitable[None]],
-    on_lock_toggle: (Callable[[UUID, bool], Awaitable[None]] | None),
-    on_tag_reorder_for_group: Any,
-    on_group_reorder: Any,
-    on_move_group: (Callable[[UUID, int], Awaitable[None]] | None) = None,
-    on_move_tag: (Callable[[UUID, int], Awaitable[None]] | None) = None,
-    tag_id_lists: dict[UUID | None, list[UUID]],
-    group_id_list: list[UUID],
-    tag_row_collector: dict[UUID, TagRowInputs],
-    group_row_collector: dict[UUID, dict[str, Any]],
-    on_field_save: (Callable[[UUID], Awaitable[None]] | None) = None,
-    on_group_field_save: (Callable[[UUID], Awaitable[None]] | None) = None,
-    highlight_counts: dict[UUID, int] | None = None,
+    render_ctx: TagListRenderContext,
+    callbacks: TagListCallbacks,
+    collectors: TagListCollectors,
 ) -> None:
     """Render all tag groups and ungrouped tags.
 
     Wraps groups in a top-level Sortable for group reordering and
     each group's tags in a nested Sortable for tag reordering.
     Model dicts are stored in the collector dicts for batch save.
+
+    Parameters
+    ----------
+    groups, tags_by_group:
+        Tag groups and the tags belonging to each (``None`` key for
+        ungrouped tags).
+    render_ctx:
+        Read-only rendering context (group_options, is_instructor,
+        highlight_counts).
+    callbacks:
+        CRUD/reorder/save callbacks threaded unchanged through the
+        render tree.
+    collectors:
+        Mutable dicts/lists populated during rendering: tag_id_lists,
+        group_id_list (drag-order tracking), tag_row_collector,
+        group_row_collector (batch-save model dicts).
     """
     from promptgrimoire.elements.sortable.sortable import (  # noqa: PLC0415
         Sortable,
     )
+
+    on_delete_tag = callbacks.on_delete_tag
+    on_delete_group = callbacks.on_delete_group
+    on_add_tag = callbacks.on_add_tag
+    on_add_group = callbacks.on_add_group
+    on_lock_toggle = callbacks.on_lock_toggle
+    on_tag_reorder_for_group = callbacks.on_tag_reorder_for_group
+    on_group_reorder = callbacks.on_group_reorder
+    on_move_group = callbacks.on_move_group
+    on_move_tag = callbacks.on_move_tag
+    on_field_save = callbacks.on_field_save
+    on_group_field_save = callbacks.on_group_field_save
+    tag_id_lists = collectors.tag_id_lists
+    group_id_list = collectors.group_id_list
+    tag_row_collector = collectors.tag_row_collector
+    group_row_collector = collectors.group_row_collector
 
     # Groups section -- wrapped in Sortable for group reorder
     with Sortable(
@@ -603,28 +682,30 @@ def _render_tag_list_content(
             with ui.column().classes("w-full"):
                 _render_group_header(
                     group,
-                    on_delete_group=on_delete_group,
-                    on_move_group=on_move_group,
-                    group_index=idx,
-                    total_groups=total_groups,
-                    row_collector=group_row_collector,
-                    on_group_field_save=on_group_field_save,
-                    tag_count=len(group_tags),
+                    GroupHeaderContext(
+                        on_delete_group=on_delete_group,
+                        on_move_group=on_move_group,
+                        group_index=idx,
+                        total_groups=total_groups,
+                        row_collector=group_row_collector,
+                        on_group_field_save=on_group_field_save,
+                        tag_count=len(group_tags),
+                    ),
                 )
                 _render_group_tags(
                     group_tags=group_tags,
                     tag_ids=tag_ids,
-                    is_instructor=is_instructor,
-                    group_options=group_options,
-                    on_delete_tag=on_delete_tag,
-                    on_lock_toggle=on_lock_toggle,
                     on_tag_reorder=lambda e, gid=group.id: on_tag_reorder_for_group(
                         e, gid
                     ),
-                    on_move_tag=on_move_tag,
-                    tag_row_collector=tag_row_collector,
-                    on_field_save=on_field_save,
-                    highlight_counts=highlight_counts,
+                    ctx=GroupTagsContext(
+                        render_ctx=render_ctx,
+                        on_delete_tag=on_delete_tag,
+                        on_lock_toggle=on_lock_toggle,
+                        on_move_tag=on_move_tag,
+                        tag_row_collector=tag_row_collector,
+                        on_field_save=on_field_save,
+                    ),
                 )
                 ui.button(
                     "+ Add tag",
@@ -643,15 +724,15 @@ def _render_tag_list_content(
         _render_group_tags(
             group_tags=ungrouped,
             tag_ids=ungrouped_ids,
-            is_instructor=is_instructor,
-            group_options=group_options,
-            on_delete_tag=on_delete_tag,
-            on_lock_toggle=on_lock_toggle,
             on_tag_reorder=lambda e: on_tag_reorder_for_group(e, None),
-            on_move_tag=on_move_tag,
-            tag_row_collector=tag_row_collector,
-            on_field_save=on_field_save,
-            highlight_counts=highlight_counts,
+            ctx=GroupTagsContext(
+                render_ctx=render_ctx,
+                on_delete_tag=on_delete_tag,
+                on_lock_toggle=on_lock_toggle,
+                on_move_tag=on_move_tag,
+                tag_row_collector=tag_row_collector,
+                on_field_save=on_field_save,
+            ),
         )
         ui.button(
             "+ Add tag",

--- a/src/promptgrimoire/pages/annotation/tag_management_save.py
+++ b/src/promptgrimoire/pages/annotation/tag_management_save.py
@@ -114,7 +114,7 @@ def _cancel_pending_timers(
             timer = row.get("_pending_timer")
             if timer is not None:
                 timer.active = False
-                row["_pending_timer"] = None  # type: ignore[literal-required]  # runtime-only key not in TypedDict
+                row["_pending_timer"] = None
 
 
 async def _create_tag_or_notify(
@@ -151,7 +151,7 @@ async def _create_tag_or_notify(
         return None
 
 
-async def _save_all_modified_rows(
+async def _save_all_modified_rows(  # noqa: PLR0913 -- called positionally from tag_management; param-object migration: tracker ledger 8
     tag_row_inputs: dict[UUID, TagRowInputs] | dict[UUID, dict[str, Any]],
     group_row_inputs: dict[UUID, dict[str, Any]],
     update_tag: Callable[..., Awaitable[object]],

--- a/src/promptgrimoire/pages/annotation/tag_quick_create.py
+++ b/src/promptgrimoire/pages/annotation/tag_quick_create.py
@@ -8,6 +8,7 @@ and ``_refresh_tag_state`` from ``tag_management_save`` (leaf module).
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -82,13 +83,20 @@ def _build_colour_picker(
     return swatch_buttons, color_el
 
 
+@dataclass(frozen=True, slots=True)
+class _SavedSelection:
+    """A captured text-selection range to restore before highlighting it."""
+
+    start: int
+    end: int
+
+
 async def _quick_create_save(
     state: PageState,
     tag_name: str,
     selected_color: list[str],
     group_select: ui.select,
-    saved_start: int | None,
-    saved_end: int | None,
+    saved_selection: _SavedSelection | None,
 ) -> bool:
     """Validate, create tag, optionally add highlight. Return True on success."""
     if not tag_name or not tag_name.strip():
@@ -115,13 +123,13 @@ async def _quick_create_save(
     await _refresh_tag_state(state, skip_card_rebuild=True)
 
     tag_id = getattr(new_tag, "id", None)
-    if saved_start is not None and saved_end is not None and tag_id is not None:
+    if saved_selection is not None and tag_id is not None:
         from promptgrimoire.pages.annotation.highlights import (  # noqa: PLC0415
             _add_highlight,
         )
 
-        state.selection_start = saved_start
-        state.selection_end = saved_end
+        state.selection_start = saved_selection.start
+        state.selection_end = saved_selection.end
         await _add_highlight(state, str(tag_id))
 
     return True
@@ -190,6 +198,12 @@ async def open_quick_create(state: PageState) -> None:
                 on_click=dialog.close,
             ).props('flat data-testid="quick-create-cancel-btn"')
 
+            saved_selection = (
+                _SavedSelection(start=saved_start, end=saved_end)
+                if saved_start is not None and saved_end is not None
+                else None
+            )
+
             async def _save(text: str) -> None:
                 create_btn.disable()
                 create_btn.props("loading")
@@ -199,8 +213,7 @@ async def open_quick_create(state: PageState) -> None:
                         text,
                         selected_color,
                         group_select,
-                        saved_start,
-                        saved_end,
+                        saved_selection,
                     )
                     if not ok:
                         return

--- a/src/promptgrimoire/pages/annotation/workspace.py
+++ b/src/promptgrimoire/pages/annotation/workspace.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 from uuid import UUID
 
@@ -57,7 +57,6 @@ from promptgrimoire.pages.annotation.tag_quick_create import open_quick_create
 if TYPE_CHECKING:
     from nicegui import Client
 
-    from promptgrimoire.pages.annotation import PermissionLevel
 
 logger = structlog.get_logger()
 
@@ -256,7 +255,7 @@ async def _resolve_db_context(
     return None if client._deleted else (context, documents, first_doc)
 
 
-def _log_page_load_profile(
+def _log_page_load_profile(  # noqa: PLR0913, PLR0917 -- flat signature pinned by test_diagnostics positional-call guard; param-object migration: tracker ledger 8
     workspace_id: UUID,
     t_total: float,
     t_db: float,
@@ -350,7 +349,7 @@ async def _load_workspace_content(
             workspace_id=workspace_id,
             user_name=_get_current_username(),
             user_id=auth_user.get("user_id"),
-            effective_permission=cast("PermissionLevel", context.permission),
+            effective_permission=context.permission,
             is_anonymous=ctx.anonymous_sharing,
             viewer_is_privileged=privileged,
             privileged_user_ids=context.privileged_user_ids,

--- a/src/promptgrimoire/pages/auth.py
+++ b/src/promptgrimoire/pages/auth.py
@@ -157,12 +157,13 @@ def _get_session_user() -> dict | None:
         return None
 
 
-def _set_session_user(
+def _set_session_user(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     email: str,
     member_id: str,
     organization_id: str,
     session_token: str,
     roles: list[str],
+    *,
     name: str | None = None,
     auth_method: str = "unknown",
     user_id: UUID | None = None,

--- a/src/promptgrimoire/pages/courses.py
+++ b/src/promptgrimoire/pages/courses.py
@@ -378,7 +378,7 @@ def _render_activity_management_controls(
         )
 
 
-def _render_activity_row(
+def _render_activity_row(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     act: Activity,
     *,
     can_manage: bool,
@@ -485,7 +485,7 @@ def _render_week_management_controls(
         _render_publish_toggle(week, on_publish_toggle=on_publish_toggle)
 
 
-def _render_week_header(
+def _render_week_header(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     week: Any,
     *,
     can_view_drafts: bool,
@@ -535,7 +535,7 @@ def _render_publish_toggle(
             ).props('outline color=primary dense data-testid="publish-week-btn"')
 
 
-async def _render_week_activities(
+async def _render_week_activities(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     week: Any,
     *,
     course_id: str,

--- a/src/promptgrimoire/pages/milkdown_spike.py
+++ b/src/promptgrimoire/pages/milkdown_spike.py
@@ -27,8 +27,12 @@ from promptgrimoire.pages.registry import page_route
 
 if TYPE_CHECKING:
     from nicegui import Client
+    from nicegui.events import GenericEventArguments
 
 logger = structlog.get_logger()
+
+# An empty Yjs doc encodes to exactly 2 bytes; anything larger has content.
+_EMPTY_YDOC_UPDATE_BYTES = 2
 # Serve the Milkdown bundle from static files
 _BUNDLE_DIR = Path(__file__).parent.parent / "static" / "milkdown" / "dist"
 app.add_static_files("/milkdown", str(_BUNDLE_DIR))
@@ -160,9 +164,9 @@ async def milkdown_spike_page() -> None:
     client.on_disconnect(on_disconnect)
 
     # Handle Yjs updates from this client
-    def on_yjs_update(e: object) -> None:
+    def on_yjs_update(e: GenericEventArguments) -> None:
         """Receive a Yjs update from the JS client, apply to server doc, broadcast."""
-        b64_update: str = e.args["update"]  # type: ignore[union-attr]
+        b64_update: str = e.args["update"]
         raw = base64.b64decode(b64_update)
         doc.apply_update(raw)
         _broadcast_to_others(_SPIKE_DOC_ID, client_id, b64_update)
@@ -213,8 +217,7 @@ async def milkdown_spike_page() -> None:
         # Server doc has accumulated state from prior clients — send to new joiner
         full_state = bytes(doc.get_update())
         b64_state = base64.b64encode(full_state).decode("ascii")
-        if len(full_state) > 2:
-            # >2 bytes means the doc has real content (empty doc is 2 bytes)
+        if len(full_state) > _EMPTY_YDOC_UPDATE_BYTES:
             client.run_javascript(f"window._applyRemoteUpdate('{b64_state}')")
             logger.debug(
                 "FULL_STATE_SYNC doc_id=%s to_client=%s bytes=%d",

--- a/src/promptgrimoire/pages/navigator/_cards.py
+++ b/src/promptgrimoire/pages/navigator/_cards.py
@@ -72,13 +72,93 @@ async def _persist_title_change(
         title_input.value = original_title
 
 
+@dataclasses.dataclass
+class _TitleEditIcons:
+    """Pencil/confirm/cancel icon trio for one inline title editor."""
+
+    pencil: ui.icon
+    confirm: ui.icon
+    cancel: ui.icon
+
+
+class _TitleEditController:
+    """Owns editing state and event handlers for one inline title editor.
+
+    Replaces a set of closures that shared mutable state through a dict;
+    each event handler is a plain method instead, so complexity is
+    attributed per-method rather than accumulating in one function that
+    nests four closures.
+    """
+
+    def __init__(
+        self,
+        *,
+        workspace_id: UUID,
+        title_input: Input,
+        icons: _TitleEditIcons,
+        fallback_title: str,
+        page_state: PageState | None,
+    ) -> None:
+        self.workspace_id = workspace_id
+        self.title_input = title_input
+        self.icons = icons
+        self.fallback_title = fallback_title
+        self.page_state = page_state
+        self.original_title = title_input.value
+        self.editing = False
+        self.saving = False
+
+    def _set_editing_mode(self, editing: bool) -> None:
+        if editing:
+            self.title_input.props(remove="readonly borderless", add="outlined")
+        else:
+            self.title_input.props(remove="outlined", add="readonly borderless")
+        self.editing = editing
+        self.saving = False
+        self.icons.pencil.set_visibility(not editing)
+        for ico in (self.icons.confirm, self.icons.cancel):
+            ico.set_visibility(editing)
+        if self.page_state is not None:
+            self.page_state["editing_active"] = editing
+
+    async def activate_edit(self, _e: object) -> None:
+        if self.editing:
+            return
+        self.original_title = self.title_input.value
+        self._set_editing_mode(True)
+        self.title_input.run_method("focus")
+        self.title_input.run_method("select")
+
+    async def save_title(self, _e: object) -> None:
+        if not self.editing or self.saving:
+            return
+        self.saving = True
+        await _persist_title_change(
+            workspace_id=self.workspace_id,
+            title_input=self.title_input,
+            fallback_title=self.fallback_title,
+            original_title=self.original_title,
+            page_state=self.page_state,
+        )
+        self._set_editing_mode(False)
+
+    async def cancel_edit(self, _e: object) -> None:
+        if not self.editing:
+            return
+        self.title_input.value = self.original_title
+        self._set_editing_mode(False)
+
+    def handle_title_click(self, _e: object) -> None:
+        if not self.editing:
+            ui.navigate.to(workspace_url(self.workspace_id))
+
+
 def _wire_title_edit_handlers(
     *,
-    row: NavigatorRow,
+    workspace_id: UUID,
     title_input: Input,
-    pencil_icon: ui.icon,
-    confirm_icon: ui.icon,
-    cancel_icon: ui.icon,
+    icons: _TitleEditIcons,
+    fallback_title: str,
     page_state: PageState | None,
 ) -> None:
     """Wire save/cancel handlers for an inline-editable title.
@@ -87,69 +167,20 @@ def _wire_title_edit_handlers(
     the input's ``blur`` event, preventing the blur-save from racing
     with a cancel click.
     """
-    workspace_id = row.workspace_id
-    if workspace_id is None:
-        return
-    original_title = title_input.value
-    _state: dict[str, object] = {"editing": False, "saving": False}
-
-    def _set_editing_mode(editing: bool) -> None:
-        if editing:
-            title_input.props(remove="readonly borderless", add="outlined")
-        else:
-            title_input.props(remove="outlined", add="readonly borderless")
-        _state["editing"] = editing
-        _state["saving"] = False
-        pencil_icon.set_visibility(not editing)
-        for ico in (confirm_icon, cancel_icon):
-            ico.set_visibility(editing)
-        if page_state is not None:
-            page_state["editing_active"] = editing
-
-    async def _activate_edit(_e: object) -> None:
-        nonlocal original_title
-        if _state["editing"]:
-            return
-        original_title = title_input.value
-        _set_editing_mode(True)
-        title_input.run_method("focus")
-        title_input.run_method("select")
-
-    pencil_icon.on("click", _activate_edit)
-
-    async def _save_title(_e: object) -> None:
-        if not _state["editing"] or _state["saving"]:
-            return
-        _state["saving"] = True
-        await _persist_title_change(
-            workspace_id=workspace_id,
-            title_input=title_input,
-            fallback_title=row.activity_title or "Untitled",
-            original_title=original_title,
-            page_state=page_state,
-        )
-        _set_editing_mode(False)
-
-    confirm_icon.on("mousedown", _save_title)
-    title_input.on("keydown.enter", _save_title)
-    title_input.on("blur", _save_title)
-
-    async def _cancel_edit(_e: object) -> None:
-        if not _state["editing"]:
-            return
-        title_input.value = original_title
-        _set_editing_mode(False)
-
-    cancel_icon.on("mousedown", _cancel_edit)
-    title_input.on("keydown.escape", _cancel_edit)
-    title_input.on(
-        "click",
-        lambda _e: (
-            ui.navigate.to(workspace_url(workspace_id))
-            if not _state["editing"]
-            else None
-        ),
+    controller = _TitleEditController(
+        workspace_id=workspace_id,
+        title_input=title_input,
+        icons=icons,
+        fallback_title=fallback_title,
+        page_state=page_state,
     )
+    icons.pencil.on("click", controller.activate_edit)
+    icons.confirm.on("mousedown", controller.save_title)
+    title_input.on("keydown.enter", controller.save_title)
+    title_input.on("blur", controller.save_title)
+    icons.cancel.on("mousedown", controller.cancel_edit)
+    title_input.on("keydown.escape", controller.cancel_edit)
+    title_input.on("click", controller.handle_title_click)
 
 
 def render_inline_title_edit(
@@ -192,11 +223,12 @@ def render_inline_title_edit(
     cancel_icon.set_visibility(False)
 
     _wire_title_edit_handlers(
-        row=row,
+        workspace_id=workspace_id,
         title_input=title_input,
-        pencil_icon=pencil_icon,
-        confirm_icon=confirm_icon,
-        cancel_icon=cancel_icon,
+        icons=_TitleEditIcons(
+            pencil=pencil_icon, confirm=confirm_icon, cancel=cancel_icon
+        ),
+        fallback_title=row.activity_title or "Untitled",
         page_state=page_state,
     )
 

--- a/src/promptgrimoire/pages/navigator/_page.py
+++ b/src/promptgrimoire/pages/navigator/_page.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -13,7 +14,7 @@ from promptgrimoire.auth import is_privileged_user
 from promptgrimoire.config import get_settings
 from promptgrimoire.db.courses import list_user_enrollments
 from promptgrimoire.db.engine import init_db
-from promptgrimoire.db.navigator import NavigatorRow, load_navigator_page
+from promptgrimoire.db.navigator import load_navigator_page
 from promptgrimoire.pages.layout import page_layout
 from promptgrimoire.pages.navigator._search import setup_search
 from promptgrimoire.pages.navigator._sections import (
@@ -33,15 +34,69 @@ logger = structlog.get_logger()
 
 _CSS_FILE = Path(__file__).resolve().parent.parent.parent / "static" / "navigator.css"
 
+# Scroll payload is [scrollTop, scrollHeight, clientHeight]; see the
+# js_handler passed to scroll_container.on(...) in _build_navigator_ui.
+_SCROLL_EVENT_ARG_COUNT = 3
+# Fraction of scrollHeight past which we treat the user as "near the
+# bottom" and prefetch the next page.
+_SCROLL_NEAR_BOTTOM_RATIO = 0.9
+
+
+async def _handle_scroll_event(e: object, *, page_state: PageState) -> None:
+    """Load more rows when the user scrolls near the bottom.
+
+    ``user_id``/``is_privileged``/``enrolled_course_ids`` are read from
+    ``page_state`` rather than taken as separate parameters; see
+    ``_build_navigator_ui`` for why.
+    """
+    if (
+        page_state["loading"]
+        or page_state["next_cursor"] is None
+        or page_state["search_active"]
+        or page_state["editing_active"]
+    ):
+        return
+
+    event_args = getattr(e, "args", None)
+    if (
+        not event_args
+        or not isinstance(event_args, (list, tuple))
+        or len(event_args) < _SCROLL_EVENT_ARG_COUNT
+    ):
+        return
+    scroll_top, scroll_height, client_height = event_args[:_SCROLL_EVENT_ARG_COUNT]
+    if not scroll_height or client_height >= scroll_height:
+        return
+    if (scroll_top + client_height) / scroll_height < _SCROLL_NEAR_BOTTOM_RATIO:
+        return
+
+    page_state["loading"] = True
+    try:
+        accumulated_rows = page_state["rows"]
+        cursor = page_state["next_cursor"]
+        new_rows, new_cursor = await load_navigator_page(
+            user_id=page_state["user_id"],
+            is_privileged=page_state["is_privileged"],
+            enrolled_course_ids=page_state["enrolled_course_ids"],
+            cursor=cursor,
+            limit=50,
+        )
+        accumulated_rows.extend(new_rows)
+        page_state["next_cursor"] = new_cursor
+        sections_container = page_state["sections_container"]
+        await append_new_rows(
+            new_rows,
+            page_state=page_state,
+            sections_container=sections_container,
+        )
+    finally:
+        page_state["loading"] = False
+
 
 async def _build_navigator_ui(
     *,
     page_state: PageState,
     handle_scroll: Callable[..., object],
-    rows: list[NavigatorRow],
-    user_id: UUID,
-    is_privileged: bool,
-    enrolled_course_ids: list[UUID],
 ) -> None:
     """Build the navigator page DOM.
 
@@ -49,7 +104,12 @@ async def _build_navigator_ui(
     The scroll event uses ``js_handler`` with ``emit()`` to extract
     ``scrollTop``, ``scrollHeight``, and ``clientHeight`` from the
     event target.
+
+    ``rows`` is read from ``page_state`` rather than taken as a separate
+    parameter -- it is a required key already populated by the caller, so
+    passing it again would only duplicate what ``page_state`` carries.
     """
+    rows = page_state["rows"]
     with page_layout("Home"):
         ui.add_css(_CSS_FILE)
 
@@ -97,13 +157,7 @@ async def _build_navigator_ui(
             else:
                 reset_header_tracking(page_state)
                 with sections_container:
-                    await render_sections(
-                        rows=rows,
-                        user_id=user_id,
-                        is_privileged=is_privileged,
-                        enrolled_course_ids=enrolled_course_ids,
-                        page_state=page_state,
-                    )
+                    await render_sections(rows=rows, page_state=page_state)
                 record_rendered_headers(rows, page_state)
 
 
@@ -157,59 +211,9 @@ async def navigator_page() -> None:
         "editing_active": False,
     }
 
-    async def _handle_scroll(e: object) -> None:
-        """Load more rows when the user scrolls near the bottom."""
-        if (
-            page_state["loading"]
-            or page_state["next_cursor"] is None
-            or page_state["search_active"]
-            or page_state["editing_active"]
-        ):
-            return
-
-        event_args = getattr(e, "args", None)
-        if (
-            not event_args
-            or not isinstance(event_args, (list, tuple))
-            or len(event_args) < 3
-        ):
-            return
-        scroll_top, scroll_height, client_height = event_args[:3]
-        if not scroll_height or client_height >= scroll_height:
-            return
-        if (scroll_top + client_height) / scroll_height < 0.9:
-            return
-
-        page_state["loading"] = True
-        try:
-            accumulated_rows = page_state["rows"]
-            cursor = page_state["next_cursor"]
-            new_rows, new_cursor = await load_navigator_page(
-                user_id=user_id,
-                is_privileged=is_privileged,
-                enrolled_course_ids=enrolled_course_ids,
-                cursor=cursor,
-                limit=50,
-            )
-            accumulated_rows.extend(new_rows)
-            page_state["next_cursor"] = new_cursor
-            sections_container = page_state["sections_container"]
-            await append_new_rows(
-                new_rows,
-                user_id=user_id,
-                is_privileged=is_privileged,
-                enrolled_course_ids=enrolled_course_ids,
-                page_state=page_state,
-                sections_container=sections_container,
-            )
-        finally:
-            page_state["loading"] = False
+    handle_scroll = functools.partial(_handle_scroll_event, page_state=page_state)
 
     await _build_navigator_ui(
         page_state=page_state,
-        handle_scroll=_handle_scroll,
-        rows=rows,
-        user_id=user_id,
-        is_privileged=is_privileged,
-        enrolled_course_ids=enrolled_course_ids,
+        handle_scroll=handle_scroll,
     )

--- a/src/promptgrimoire/pages/navigator/_search.py
+++ b/src/promptgrimoire/pages/navigator/_search.py
@@ -46,19 +46,9 @@ async def rerender_all(
     page_state["editing_active"] = False
     no_results_container.clear()
     sections_container.clear()
-    user_id = page_state["user_id"]
-    is_privileged = page_state["is_privileged"]
-    enrolled_course_ids = page_state["enrolled_course_ids"]
     reset_header_tracking(page_state)
     with sections_container:
-        await render_sections(
-            rows=rows,
-            user_id=user_id,
-            is_privileged=is_privileged,
-            enrolled_course_ids=enrolled_course_ids,
-            snippets=snippets,
-            page_state=page_state,
-        )
+        await render_sections(rows=rows, page_state=page_state, snippets=snippets)
     record_rendered_headers(rows, page_state)
 
 

--- a/src/promptgrimoire/pages/navigator/_sections.py
+++ b/src/promptgrimoire/pages/navigator/_sections.py
@@ -63,16 +63,21 @@ def _get_owner_display_name(
 
 def _render_owner_group(
     owner_rows: list[NavigatorRow],
-    user_id: UUID,
-    is_privileged: bool,
+    page_state: PageState,
     *,
     snippets: dict[UUID, str] | None = None,
-    page_state: PageState | None = None,
     show_header: bool = True,
 ) -> None:
-    """Render an owner group: header, placed entries, then loose entries."""
+    """Render an owner group: header, placed entries, then loose entries.
+
+    ``user_id``/``is_privileged`` are read from ``page_state`` rather than
+    taken as separate parameters -- every caller already threads the same
+    ``page_state`` through, so passing them again would only duplicate it.
+    """
     if show_header:
-        display_name = _get_owner_display_name(owner_rows[0], user_id, is_privileged)
+        display_name = _get_owner_display_name(
+            owner_rows[0], page_state["user_id"], page_state["is_privileged"]
+        )
         ui.label(display_name).classes(
             "text-sm font-semibold mt-3 mb-1 ml-2 text-gray-600"
         )
@@ -96,14 +101,16 @@ def _render_owner_group(
 
 async def _render_shared_in_unit(
     shared_in_unit_rows: list[NavigatorRow],
-    enrolled_course_ids: list[UUID],
     course_cache: dict[UUID, Course],
-    user_id: UUID,
-    is_privileged: bool,
     snippets: dict[UUID, str] | None,
-    page_state: PageState | None = None,
+    page_state: PageState,
 ) -> None:
-    """Render shared_in_unit sections grouped by course and owner."""
+    """Render shared_in_unit sections grouped by course and owner.
+
+    ``enrolled_course_ids`` is read from ``page_state``; see
+    ``_render_owner_group`` for why.
+    """
+    enrolled_course_ids = page_state["enrolled_course_ids"]
     by_course = group_shared_in_unit_by_course(shared_in_unit_rows)
     for course_id in enrolled_course_ids:
         course_rows = by_course.get(course_id, [])
@@ -115,24 +122,22 @@ async def _render_shared_in_unit(
         ).props('data-testid="section-header-shared-in-unit"')
 
         for _owner_id, owner_rows in group_by_owner(course_rows).items():
-            _render_owner_group(
-                owner_rows,
-                user_id,
-                is_privileged,
-                snippets=snippets,
-                page_state=page_state,
-            )
+            _render_owner_group(owner_rows, page_state, snippets=snippets)
 
 
 async def _render_simple_section(
     section_key: str,
     section_rows: list[NavigatorRow],
-    user_id: UUID,
-    is_privileged: bool,
     snippets: dict[UUID, str] | None,
-    page_state: PageState | None = None,
+    page_state: PageState,
 ) -> None:
-    """Render a non-shared_in_unit section."""
+    """Render a non-shared_in_unit section.
+
+    ``user_id``/``is_privileged`` are read from ``page_state``; see
+    ``_render_owner_group`` for why.
+    """
+    user_id = page_state["user_id"]
+    is_privileged = page_state["is_privileged"]
     display_name = SECTION_DISPLAY_NAMES.get(section_key, section_key)
     testid = f"section-header-{section_key.replace('_', '-')}"
     ui.label(display_name).classes(
@@ -170,16 +175,19 @@ async def _populate_course_cache(
 
 async def render_sections(
     rows: list[NavigatorRow],
-    user_id: UUID,
-    is_privileged: bool,
-    enrolled_course_ids: list[UUID],
+    page_state: PageState,
+    *,
     snippets: dict[UUID, str] | None = None,
-    page_state: PageState | None = None,
 ) -> None:
     """Render all navigator sections from the given rows.
 
     Groups rows by section and renders them in fixed order.
     Empty sections produce no output (AC1.7).
+
+    ``user_id``/``is_privileged``/``enrolled_course_ids`` are read from
+    ``page_state`` -- every caller already builds ``page_state`` from these
+    same values, so taking them as separate parameters would only duplicate
+    what ``page_state`` carries.
     """
     grouped = group_rows_by_section(rows)
     shared_rows = grouped.get("shared_in_unit", [])
@@ -189,24 +197,13 @@ async def render_sections(
         if section_key == "shared_in_unit":
             if shared_rows:
                 await _render_shared_in_unit(
-                    shared_rows,
-                    enrolled_course_ids,
-                    course_cache,
-                    user_id,
-                    is_privileged,
-                    snippets,
-                    page_state=page_state,
+                    shared_rows, course_cache, snippets, page_state
                 )
         else:
             section_rows = grouped.get(section_key, [])
             if section_rows:
                 await _render_simple_section(
-                    section_key,
-                    section_rows,
-                    user_id,
-                    is_privileged,
-                    snippets,
-                    page_state=page_state,
+                    section_key, section_rows, snippets, page_state
                 )
 
 
@@ -369,9 +366,6 @@ def _append_simple_section(
 async def append_new_rows(
     new_rows: list[NavigatorRow],
     *,
-    user_id: UUID,
-    is_privileged: bool,
-    enrolled_course_ids: list[UUID],
     page_state: PageState,
     sections_container: ui.column,
 ) -> None:
@@ -379,7 +373,13 @@ async def append_new_rows(
 
     Scroll position is preserved because existing DOM is never
     destroyed — new elements are appended at the bottom.
+
+    ``user_id``/``is_privileged``/``enrolled_course_ids`` are read from
+    ``page_state``; see ``render_sections`` for why.
     """
+    user_id = page_state["user_id"]
+    is_privileged = page_state["is_privileged"]
+    enrolled_course_ids = page_state["enrolled_course_ids"]
     grouped = group_rows_by_section(new_rows)
 
     with sections_container:

--- a/src/promptgrimoire/pages/registry.py
+++ b/src/promptgrimoire/pages/registry.py
@@ -216,7 +216,7 @@ def _get_auth_identity(
     return user_id, auth_user
 
 
-def page_route(
+def page_route(  # noqa: PLR0913 -- param-object migration: tracker ledger 8
     route: str,
     *,
     title: str,

--- a/src/promptgrimoire/pages/roleplay.py
+++ b/src/promptgrimoire/pages/roleplay.py
@@ -89,7 +89,7 @@ def _render_messages(session: Session, chat_container, scroll_area: ScrollArea) 
     scroll_area.scroll_to(percent=1.0)
 
 
-async def _handle_send(
+async def _handle_send(  # noqa: PLR0913, PLR0917 -- caller passes positionally; param-object migration: tracker ledger 8
     user_message: str,
     session: Session,
     client: ClaudeClient,

--- a/src/promptgrimoire/pages/text_selection.py
+++ b/src/promptgrimoire/pages/text_selection.py
@@ -26,10 +26,103 @@ _CSS_FILE = Path(__file__).parent.parent / "static" / "annotations.css"
 SELECTION_DEBOUNCE_MS = 10  # Debounce to let browser finalize selection
 MAX_DISPLAY_LENGTH = 50  # Truncate displayed text for readability
 
+_CREATE_HIGHLIGHT_JS = """
+    if (window._savedRange) {
+        const span = document.createElement('span');
+        span.className = 'annotation-highlight';
+        span.setAttribute('data-testid', 'highlight');
+        try {
+            window._savedRange.surroundContents(span);
+            window._savedRange = null;
+            return {success: true};
+        } catch (e) {
+            // surroundContents fails if range spans multiple elements
+            console.warn('surroundContents failed:', e.message);
+            try {
+                // Fall back to extractContents approach
+                const fragment = window._savedRange.extractContents();
+                span.appendChild(fragment);
+                window._savedRange.insertNode(span);
+                window._savedRange = null;
+                return {success: true};
+            } catch (e2) {
+                console.error('Highlight fallback failed:', e2.message);
+                return {success: false, error: e2.message};
+            }
+        }
+    }
+    return {success: false, error: 'No saved range'};
+"""
+
 
 def _get_session_user() -> dict | None:
     """Get the current user from session storage."""
     return app.storage.user.get("auth_user")
+
+
+async def _create_highlight_from_selection(
+    selection_data: dict[str, str | int],
+) -> None:
+    """Apply highlight CSS to the saved selection range via client-side JS."""
+    if not selection_data.get("text"):
+        ui.notify("No text selected", type="warning")
+        return
+
+    result = await ui.run_javascript(_CREATE_HIGHLIGHT_JS)
+    if result and result.get("success"):
+        ui.notify("Highlight created!")
+    else:
+        error = result.get("error", "Unknown error") if result else "No result"
+        ui.notify(f"Highlight failed: {error}", type="warning")
+
+
+def _validate_selection_args(
+    text: object, start: object, end: object
+) -> tuple[str, int, int, str] | None:
+    """Validate raw ``text_selected`` event args and compute the display string.
+
+    Returns None when the event should be ignored: wrong argument types, an
+    invalid (negative or inverted) range, or empty text. Otherwise returns
+    ``(text, start, end, display)``.
+    """
+    if (
+        not isinstance(text, str)
+        or not isinstance(start, int)
+        or not isinstance(end, int)
+    ):
+        return None
+    if start < 0 or end < 0 or start > end:
+        return None
+    if not text:
+        return None
+    display = (
+        f'"{text[:MAX_DISPLAY_LENGTH]}..."'
+        if len(text) > MAX_DISPLAY_LENGTH
+        else f'"{text}"'
+    )
+    return text, start, end, display
+
+
+def _handle_text_selected_event(
+    e: GenericEventArguments, selection_data: dict[str, str | int]
+) -> None:
+    """Update ``selection_data`` and notify from a ``text_selected`` event.
+
+    Expected e.args:
+        text (str): Selected text content
+        start (int): Start offset within container
+        end (int): End offset within container
+    """
+    parsed = _validate_selection_args(
+        e.args.get("text", ""), e.args.get("start", 0), e.args.get("end", 0)
+    )
+    if parsed is None:
+        return
+    text, start, end, display = parsed
+    selection_data.update(
+        {"text": text, "start": start, "end": end, "display": display}
+    )
+    ui.notify(f"Selected: {display}")
 
 
 @page_route(
@@ -113,80 +206,15 @@ async def text_selection_demo_page() -> None:
 
             async def create_highlight() -> None:
                 """Apply highlight CSS to saved selection range."""
-                if not selection_data.get("text"):
-                    ui.notify("No text selected", type="warning")
-                    return
-
-                result = await ui.run_javascript("""
-                    if (window._savedRange) {
-                        const span = document.createElement('span');
-                        span.className = 'annotation-highlight';
-                        span.setAttribute('data-testid', 'highlight');
-                        try {
-                            window._savedRange.surroundContents(span);
-                            window._savedRange = null;
-                            return {success: true};
-                        } catch (e) {
-                            // surroundContents fails if range spans multiple elements
-                            console.warn('surroundContents failed:', e.message);
-                            try {
-                                // Fall back to extractContents approach
-                                const fragment = window._savedRange.extractContents();
-                                span.appendChild(fragment);
-                                window._savedRange.insertNode(span);
-                                window._savedRange = null;
-                                return {success: true};
-                            } catch (e2) {
-                                console.error('Highlight fallback failed:', e2.message);
-                                return {success: false, error: e2.message};
-                            }
-                        }
-                    }
-                    return {success: false, error: 'No saved range'};
-                """)
-                if result and result.get("success"):
-                    ui.notify("Highlight created!")
-                else:
-                    error = (
-                        result.get("error", "Unknown error") if result else "No result"
-                    )
-                    ui.notify(f"Highlight failed: {error}", type="warning")
+                await _create_highlight_from_selection(selection_data)
 
             ui.button("Create Highlight", on_click=create_highlight).props(
                 'data-testid="create-highlight-btn"'
             ).classes("mt-4")
 
     def handle_selection(e: GenericEventArguments) -> None:
-        """Handle text selection from browser.
-
-        Expected e.args:
-            text (str): Selected text content
-            start (int): Start offset within container
-            end (int): End offset within container
-        """
-        text = e.args.get("text", "")
-        start = e.args.get("start", 0)
-        end = e.args.get("end", 0)
-
-        # Validate input types and constraints
-        if (
-            not isinstance(text, str)
-            or not isinstance(start, int)
-            or not isinstance(end, int)
-        ):
-            return
-        if start < 0 or end < 0 or start > end:
-            return
-
-        if text:
-            if len(text) > MAX_DISPLAY_LENGTH:
-                display = f'"{text[:MAX_DISPLAY_LENGTH]}..."'
-            else:
-                display = f'"{text}"'
-            selection_data.update(
-                {"text": text, "start": start, "end": end, "display": display}
-            )
-            ui.notify(f"Selected: {display}")
+        """Handle text selection from browser."""
+        _handle_text_selected_event(e, selection_data)
 
     ui.on("text_selected", handle_selection)
 

--- a/src/promptgrimoire/search_worker.py
+++ b/src/promptgrimoire/search_worker.py
@@ -69,10 +69,18 @@ async def process_dirty_workspaces(batch_size: int = 500) -> int:
                 ),
                 {"ws_ids": ws_ids},
             )
+            # Attribute access by label, not tag_row[0]/[1]/[2] -- SQLModel's
+            # AsyncSession.execute() stub declares Result[Any], which ty
+            # resolves as a length-1 Row TypeVarTuple. See
+            # docs/architecture/raw-sql-convention.md.
             for tag_row in tag_result.fetchall():
-                tag_map[str(tag_row[0])][str(tag_row[1])] = tag_row[2]
+                tag_map[str(tag_row.workspace_id)][str(tag_row.id)] = tag_row.name
 
-    for workspace_id, crdt_state, ws_title, activity_title in rows:
+    for row in rows:
+        workspace_id = row.id
+        crdt_state = row.crdt_state
+        ws_title = row.ws_title
+        activity_title = row.activity_title
         try:
             tag_names = tag_map.get(str(workspace_id), {})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -26,6 +27,20 @@ from promptgrimoire.export.pdf import (
     get_latexmk_path,
     set_latexmk_short_circuit,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_structlog_contextvars() -> Generator[None]:
+    """Clear structlog contextvars after every test.
+
+    Production code binds context (e.g. broadcast.py binds workspace_id)
+    and relies on the per-request clear in pages/registry.py. Tests have no
+    such request boundary, so a bound value leaks into whichever test runs
+    next on the same xdist worker — surfaced 2026-08-17 when pytest-randomly
+    ordered a broadcast test before TestNullContextFields.
+    """
+    yield
+    structlog.contextvars.clear_contextvars()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -300,8 +315,11 @@ async def db_canary(db_schema_guard: None) -> AsyncIterator[str]:  # noqa: ARG00
     )
 
     async with cleanup_factory() as session:
-        # ty doesn't understand SQLModel column comparison returns expression, not bool
-        await session.execute(delete(User).where(User.email == canary_email))  # type: ignore[arg-type]
+        # ty cannot type ``User.email == canary_email`` inside
+        # delete().where() (Model.field descriptor, astral-sh/ty#3421);
+        # use the plain Core Column instead.
+        user_table = User.metadata.tables[User.__tablename__]
+        await session.execute(delete(User).where(user_table.c.email == canary_email))
         await session.commit()
 
     await cleanup_engine.dispose()

--- a/tests/e2e/test_anonymous_sharing.py
+++ b/tests/e2e/test_anonymous_sharing.py
@@ -351,6 +351,7 @@ def _assert_instructor_perspective(
 
 def _assert_owner_perspective(
     browser: Browser,
+    *,
     app_server: str,
     workspace_id: str,
     student_owner_email: str,
@@ -439,6 +440,7 @@ def _assert_owner_perspective(
 
 def _assert_commenter_perspective(
     browser: Browser,
+    *,
     app_server: str,
     workspace_id: str,
     student_commenter_email: str,
@@ -629,17 +631,17 @@ class TestAnonymousSharing:
         )
         _assert_owner_perspective(
             browser,
-            app_server,
-            workspace_id,
-            owner_email,
-            labels,
-            subtests,
+            app_server=app_server,
+            workspace_id=workspace_id,
+            student_owner_email=owner_email,
+            labels=labels,
+            subtests=subtests,
         )
         _assert_commenter_perspective(
             browser,
-            app_server,
-            workspace_id,
-            commenter_email,
-            labels,
-            subtests,
+            app_server=app_server,
+            workspace_id=workspace_id,
+            student_commenter_email=commenter_email,
+            labels=labels,
+            subtests=subtests,
         )

--- a/tests/e2e/test_assessment_cram_load.py
+++ b/tests/e2e/test_assessment_cram_load.py
@@ -401,6 +401,7 @@ def _run_cram_session(
     app_server: str,
     observation: CramObservation,
     seed: int,
+    *,
     start_barrier: threading.Barrier,
     loaded_barrier: threading.Barrier,
     done_counter: list[int],
@@ -580,16 +581,14 @@ class TestAssessmentCramLoad:
         threads = [
             threading.Thread(
                 target=_run_cram_session,
-                args=(
-                    app_server,
-                    observation,
-                    i,
-                    start_barrier,
-                    loaded_barrier,
-                    done_counter,
-                    done_lock,
-                    release_event,
-                ),
+                args=(app_server, observation, i),
+                kwargs={
+                    "start_barrier": start_barrier,
+                    "loaded_barrier": loaded_barrier,
+                    "done_counter": done_counter,
+                    "done_lock": done_lock,
+                    "release_event": release_event,
+                },
                 name=f"cram-session-{i}",
             )
             for i, observation in enumerate(observations)

--- a/tests/e2e/test_edit_mode.py
+++ b/tests/e2e/test_edit_mode.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 import pytest
 from playwright.sync_api import expect
@@ -40,7 +40,15 @@ if TYPE_CHECKING:
     from pytest_subtests import SubTests
 
 
-def _fetch_document_db_state(workspace_id: str) -> dict[str, object]:
+class _DocumentDbState(TypedDict):
+    """DB state of a workspace_document row, as fetched for E2E assertions."""
+
+    doc_id: str
+    content: str
+    paragraph_map: dict[str, int]
+
+
+def _fetch_document_db_state(workspace_id: str) -> _DocumentDbState:
     """Query the DB for the first document in a workspace.
 
     Returns a dict with ``content`` (str), ``paragraph_map`` (dict[str, int]),
@@ -369,8 +377,8 @@ class TestEditMode:
             expect(doc).to_contain_text("Second paragraph text", timeout=10000)
 
             db_state = _fetch_document_db_state(workspace_id)
-            saved_content: str = db_state["content"]  # type: ignore[assignment]
-            stored_map: dict[str, int] = db_state["paragraph_map"]  # type: ignore[assignment]
+            saved_content = db_state["content"]
+            stored_map = db_state["paragraph_map"]
 
             # Recompute from saved HTML — same function used by update_document_content
             expected_map = build_paragraph_map_for_json(saved_content, auto_number=True)
@@ -385,7 +393,7 @@ class TestEditMode:
             )
 
         with subtests.test(msg="paragraph_map_has_sequential_numbers"):
-            stored_map = db_state["paragraph_map"]  # type: ignore[assignment]
+            stored_map = db_state["paragraph_map"]
             para_numbers = sorted(stored_map.values())
             assert para_numbers, "paragraph_map should not be empty after save"
             assert para_numbers[0] == 1, (

--- a/tests/e2e/test_instructor_marking.py
+++ b/tests/e2e/test_instructor_marking.py
@@ -1,0 +1,327 @@
+"""E2E test: instructor marking journey via enrollment-derived staff access.
+
+Covers a workflow live classes hit every week that previously had no
+end-to-end coverage: an instructor opens a student's workspace to mark it
+without ever receiving an explicit ACL grant. Access must come from
+``CourseEnrollment``-derived staff permission (the ``is_staff`` branch of
+``_resolve_enrollment_permission`` inside ``resolve_annotation_context``),
+a path flagged as untested by a DBA review.
+
+The "instructor" persona deliberately uses a plain, non-privileged
+mock-auth identity -- not ``instructor@uni.edu`` or ``admin@example.com``.
+Both of those get elevated ``roles``/``is_admin`` from
+``src/promptgrimoire/auth/mock.py``, and ``is_admin`` alone short-circuits
+``resolve_annotation_context`` straight to ``"owner"`` before enrollment
+is ever consulted. A test built on either identity could pass for the
+wrong reason. Course creation auto-enrols the creator with the
+``coordinator`` course role (``CourseRoleRef.is_staff=True``), which is
+what actually earns them access to the student's workspace later --
+resolved fresh from ``course_enrollment`` on each request, with no ACL
+row ever created for them.
+
+Journey:
+1. Instructor creates a course, week, and activity with template content,
+   publishes the week, and enrols a student.
+2. Student clones the activity workspace, highlights text, and adds a
+   comment (identifiable content). "Share with class" is left off --
+   staff access does not depend on it, unlike peer access.
+3. Instructor navigates directly to the student's workspace URL with no
+   explicit ACL grant. Editor-level capability (the tag toolbar) and the
+   student's comment are both visible.
+4. Instructor adds a marking comment on the student's highlight.
+5. The marking comment syncs live (CRDT broadcast) to the student's
+   still-open page.
+6. Final invariant check: no explicit ACLEntry was ever created for the
+   instructor on this workspace.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from playwright.sync_api import expect
+from sqlalchemy import create_engine, text
+
+from promptgrimoire.docs.helpers import wait_for_text_walker
+from tests.e2e.card_helpers import add_comment_to_highlight, expand_card
+from tests.e2e.conftest import _authenticate_page
+from tests.e2e.course_helpers import (
+    add_activity,
+    add_week,
+    create_course,
+    enrol_student,
+    publish_week,
+)
+from tests.e2e.highlight_tools import create_highlight, find_text_range
+from tests.e2e.page_interactions import clone_activity_workspace
+from tests.e2e.tag_helpers import _seed_tags_for_workspace
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page
+    from pytest_subtests import SubTests
+
+TEMPLATE_TEXT = "The plaintiff suffered injury at the workplace on Tuesday morning."
+STUDENT_COMMENT = "Initial submission notes: causation is unclear here."
+INSTRUCTOR_COMMENT = "Marking feedback: expand on causation before Friday."
+
+
+# ---------------------------------------------------------------------------
+# DB helper -- proves the instructor never received an explicit ACL row
+# ---------------------------------------------------------------------------
+
+
+def _has_acl_entry(workspace_id: str, email: str) -> bool:
+    """Check whether an explicit ACLEntry row exists for (workspace, user).
+
+    This test never calls the shared ``_grant_workspace_access`` helper
+    for the instructor persona -- their access must come solely from
+    enrollment-derived staff permission. This check turns that omission
+    into a positive, falsifiable assertion instead of leaving it implicit.
+    """
+    from promptgrimoire.config import get_settings
+
+    settings_url = get_settings().database.url
+    if not settings_url:
+        return False
+    db_url = str(settings_url)
+    sync_url = db_url.replace("postgresql+asyncpg://", "postgresql+psycopg://")
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                text(
+                    'SELECT 1 FROM acl_entry ae JOIN "user" u ON u.id = ae.user_id'
+                    " WHERE ae.workspace_id = CAST(:ws AS uuid) AND u.email = :email"
+                ),
+                {"ws": workspace_id, "email": email},
+            ).first()
+            return row is not None
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Phase helpers -- extracted to keep the test method under 50 statements
+# ---------------------------------------------------------------------------
+
+
+def _fill_template_workspace(page: Page) -> None:
+    """Click Create Template, add content, seed tags."""
+    page.locator('[data-testid^="template-btn-"]').first.click()
+    page.wait_for_url(re.compile(r"/annotation\?workspace_id="), timeout=10000)
+
+    content_input = page.get_by_test_id("content-editor").locator(".q-editor__content")
+    content_input.wait_for(state="visible", timeout=5000)
+    content_input.fill(TEMPLATE_TEXT)
+
+    page.get_by_test_id("add-document-btn").click()
+
+    confirm = page.get_by_test_id("confirm-content-type-btn")
+    confirm.wait_for(state="visible", timeout=5000)
+    confirm.click()
+
+    wait_for_text_walker(page, timeout=15000)
+
+    # Seed tags so the cloned workspace has tag buttons to highlight with.
+    ws_id = page.url.split("workspace_id=")[1].split("&")[0]
+    _seed_tags_for_workspace(ws_id)
+    page.reload()
+    wait_for_text_walker(page, timeout=15000)
+
+
+def _instructor_sets_up_course(
+    page: Page,
+    app_server: str,
+    *,
+    course_code: str,
+    instructor_email: str,
+    student_email: str,
+    subtests: SubTests,
+) -> str:
+    """Instructor creates course+week+activity, enrols the student.
+
+    Course creation auto-enrols the creator as "coordinator" -- a staff
+    course role -- which is the sole basis for the instructor's later
+    workspace access. Returns the course_id.
+    """
+    with subtests.test(msg="instructor_creates_course"):
+        _authenticate_page(page, app_server, email=instructor_email)
+        create_course(
+            page,
+            app_server,
+            code=course_code,
+            name="Marking Journey",
+            semester="2026-S1",
+        )
+
+    match = re.search(r"/courses/([0-9a-f-]+)", page.url)
+    assert match, "Expected course UUID in URL"
+    course_id = match.group(1)
+
+    with subtests.test(msg="add_week_and_activity"):
+        add_week(page, title="Marking Week")
+        add_activity(page, title="Marking Demo")
+
+    with subtests.test(msg="fill_template"):
+        _fill_template_workspace(page)
+
+    with subtests.test(msg="publish_week"):
+        page.goto(f"{app_server}/courses/{course_id}")
+        publish_week(page, "Marking Week")
+
+    with subtests.test(msg="enrol_student"):
+        enrol_student(page, email=student_email)
+
+    return course_id
+
+
+def _student_clones_and_annotates(
+    page: Page,
+    app_server: str,
+    *,
+    student_email: str,
+    course_id: str,
+    subtests: SubTests,
+) -> str:
+    """Student clones the activity workspace and adds identifiable content.
+
+    Deliberately does not toggle "share with class": the instructor's
+    later access must come purely from enrollment-derived staff
+    permission, which (unlike peer access) does not depend on sharing.
+    Returns the workspace_id.
+    """
+    with subtests.test(msg="student_clones_workspace"):
+        _authenticate_page(page, app_server, email=student_email)
+        workspace_id = clone_activity_workspace(
+            page, app_server, course_id, "Marking Demo"
+        )
+
+    with subtests.test(msg="student_creates_highlight_and_comment"):
+        create_highlight(page, *find_text_range(page, "plaintiff"))
+        page.get_by_test_id("annotation-card").first.wait_for(
+            state="visible", timeout=5000
+        )
+        add_comment_to_highlight(page, STUDENT_COMMENT)
+
+    return workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.cards
+@pytest.mark.timeout(60)
+class TestInstructorMarking:
+    """Instructor marks a student's workspace reached via staff enrollment."""
+
+    def test_instructor_marks_via_enrollment_derived_permission(
+        self,
+        browser: Browser,
+        app_server: str,
+        subtests: SubTests,
+    ) -> None:
+        """Instructor marks a student's submission with no explicit ACL grant.
+
+        Steps:
+        1. Instructor creates course/week/activity with template, publishes,
+           enrols student (auto-enrolled "coordinator" on course creation).
+        2. Student clones the activity workspace, highlights text, comments.
+        3. Instructor (same identity, same browser context as step 1) opens
+           the student's workspace URL directly -- no ACL grant call is ever
+           made. Editor-level capability and the student's comment are both
+           visible.
+        4. Instructor adds a marking comment.
+        5. The marking comment syncs live to the student's still-open page.
+        6. No explicit ACLEntry exists for the instructor on this workspace.
+        """
+        uid = uuid4().hex[:8]
+        instructor_email = f"marker-{uid}@test.edu"
+        student_email = f"student-{uid}@test.edu"
+        course_code = f"MARK-{uid}"
+
+        instructor_ctx = browser.new_context()
+        student_ctx = browser.new_context()
+        instructor_page = instructor_ctx.new_page()
+        student_page = student_ctx.new_page()
+
+        try:
+            course_id = _instructor_sets_up_course(
+                instructor_page,
+                app_server,
+                course_code=course_code,
+                instructor_email=instructor_email,
+                student_email=student_email,
+                subtests=subtests,
+            )
+
+            workspace_id = _student_clones_and_annotates(
+                student_page,
+                app_server,
+                student_email=student_email,
+                course_id=course_id,
+                subtests=subtests,
+            )
+
+            with subtests.test(
+                msg="instructor_accesses_via_enrollment_derived_permission"
+            ):
+                ws_url = f"{app_server}/annotation?workspace_id={workspace_id}"
+                instructor_page.goto(ws_url)
+                wait_for_text_walker(instructor_page, timeout=15000)
+
+                # The tag toolbar only renders when state.can_annotate is
+                # True -- proof the "coordinator" enrollment role resolved
+                # to course.default_instructor_permission ("editor"), not
+                # a silent read-only fallback.
+                expect(instructor_page.get_by_test_id("tag-toolbar")).to_be_visible(
+                    timeout=10000
+                )
+
+                # Comments live in the card's lazily-built detail section --
+                # expand it before looking for the student's comment text.
+                expand_card(instructor_page, 0)
+                expect(
+                    instructor_page.get_by_test_id("comment-item").filter(
+                        has_text=STUDENT_COMMENT
+                    )
+                ).to_be_visible(timeout=5000)
+
+            with subtests.test(msg="instructor_adds_marking_comment"):
+                add_comment_to_highlight(instructor_page, INSTRUCTOR_COMMENT)
+                expect(instructor_page.get_by_test_id("comment-item")).to_have_count(
+                    2, timeout=5000
+                )
+
+            with subtests.test(msg="marking_comment_syncs_to_student"):
+                expect(
+                    student_page.locator(
+                        "[data-testid='annotation-card']"
+                    ).first.get_by_test_id("comment-count-badge")
+                ).to_be_visible(timeout=10000)
+                expand_card(student_page, 0)
+                expect(
+                    student_page.get_by_test_id("comment-item").filter(
+                        has_text=INSTRUCTOR_COMMENT
+                    )
+                ).to_be_visible(timeout=5000)
+
+            with subtests.test(msg="no_explicit_acl_grant_for_instructor"):
+                assert not _has_acl_entry(workspace_id, instructor_email), (
+                    "Instructor must reach the workspace via "
+                    "enrollment-derived permission only -- an explicit "
+                    "ACLEntry row appeared, which would mask the code "
+                    "path this test exists to cover."
+                )
+        finally:
+            for p in (instructor_page, student_page):
+                with contextlib.suppress(Exception):
+                    p.goto("about:blank")
+            instructor_ctx.close()
+            student_ctx.close()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -237,6 +237,7 @@ def pdf_exporter() -> Callable[..., Coroutine[Any, Any, PdfExportResult]]:
         html: str,
         highlights: list[dict[str, Any]],
         test_name: str,
+        *,
         tag_colours: dict[str, str] | None = None,
         general_notes: str = "",
         acceptance_criteria: str = "",

--- a/tests/integration/nicegui_helpers.py
+++ b/tests/integration/nicegui_helpers.py
@@ -18,7 +18,7 @@ import asyncio
 import inspect
 import re
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from nicegui import ElementFilter
 
@@ -35,6 +35,21 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+# Overloads so an async condition binds T through Awaitable[T]: with the
+# plain `T | Awaitable[T]` union, type checkers unify T with the coroutine
+# itself and callers get a Coroutine back instead of the awaited type.
+@overload
+async def wait_for[T](
+    condition: Callable[[], Awaitable[T]],
+    timeout: float = 5.0,
+    interval: float = 0.05,
+) -> T: ...
+@overload
+async def wait_for[T](
+    condition: Callable[[], T],
+    timeout: float = 5.0,
+    interval: float = 0.05,
+) -> T: ...
 async def wait_for[T](
     condition: Callable[[], T | Awaitable[T]],
     timeout: float = 5.0,

--- a/tests/integration/test_acl_crud.py
+++ b/tests/integration/test_acl_crud.py
@@ -296,8 +296,11 @@ class TestCascadeDeleteUser:
         # for DELETE — session.exec is SELECT-only.  The SQLModel
         # DeprecationWarning is suppressed globally in pyproject.toml.
         async with get_session() as session:
-            # ty: SQLModel column comparison returns expression, not bool
-            stmt = delete(User).where(User.id == user_id)  # type: ignore[arg-type]
+            # ty cannot type ``User.id == user_id`` inside delete().where()
+            # (Model.field descriptor, astral-sh/ty#3421); use the plain
+            # Core Column instead.
+            user_table = User.metadata.tables[User.__tablename__]
+            stmt = delete(User).where(user_table.c.id == user_id)
             await session.execute(stmt)
 
         # Verify ACL entries for this user are gone
@@ -350,3 +353,85 @@ class TestDuplicateConstraint:
                 )
                 session.add(dup)
                 await session.flush()
+
+
+class TestGetPrivilegedUserIdsForWorkspace:
+    """Tests for get_privileged_user_ids_for_workspace().
+
+    Resolves the workspace's course context (via Activity -> Week -> Course,
+    or a direct Workspace.course_id), then returns the string-form User.id
+    of enrolled staff plus org-level admins.
+    """
+
+    @pytest.mark.asyncio
+    async def test_includes_enrolled_staff_and_org_admin(self) -> None:
+        """Staff enrolled in the workspace's course, and admins, are included."""
+        from promptgrimoire.db.acl import get_privileged_user_ids_for_workspace
+        from promptgrimoire.db.activities import create_activity
+        from promptgrimoire.db.courses import create_course, enroll_user
+        from promptgrimoire.db.users import create_user
+        from promptgrimoire.db.weeks import create_week
+        from promptgrimoire.db.workspaces import clone_workspace_from_activity
+
+        tag = uuid4().hex[:8]
+        course = await create_course(
+            code=f"PRIV-{tag[:6]}",
+            name="Privileged Lookup Test",
+            semester="2026-S1",
+        )
+        week = await create_week(course_id=course.id, week_number=1, title="Week 1")
+        activity = await create_activity(week_id=week.id, title="Privileged Activity")
+
+        instructor = await create_user(
+            email=f"priv-instr-{tag}@test.local",
+            display_name=f"Priv Instr {tag}",
+        )
+        await enroll_user(course.id, instructor.id, role="instructor")
+
+        student = await create_user(
+            email=f"priv-owner-{tag}@test.local",
+            display_name=f"Priv Owner {tag}",
+        )
+        await enroll_user(course.id, student.id, role="student")
+
+        admin = await create_user(
+            email=f"priv-admin-{tag}@test.local",
+            display_name=f"Priv Admin {tag}",
+            is_admin=True,
+        )
+
+        ws, _doc_map = await clone_workspace_from_activity(activity.id, student.id)
+
+        privileged_ids = await get_privileged_user_ids_for_workspace(ws.id)
+
+        assert str(instructor.id) in privileged_ids
+        assert str(admin.id) in privileged_ids
+        assert str(student.id) not in privileged_ids
+
+    @pytest.mark.asyncio
+    async def test_loose_workspace_returns_admins_only(self) -> None:
+        """A workspace with no course/activity placement still surfaces admins."""
+        from promptgrimoire.db.acl import get_privileged_user_ids_for_workspace
+        from promptgrimoire.db.users import create_user
+        from promptgrimoire.db.workspaces import create_workspace
+
+        tag = uuid4().hex[:8]
+        admin = await create_user(
+            email=f"priv-loose-admin-{tag}@test.local",
+            display_name=f"Priv Loose Admin {tag}",
+            is_admin=True,
+        )
+        workspace = await create_workspace()
+
+        privileged_ids = await get_privileged_user_ids_for_workspace(workspace.id)
+
+        assert str(admin.id) in privileged_ids
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_workspace_returns_empty(self) -> None:
+        """Unknown workspace id returns an empty frozenset, not an error."""
+        from promptgrimoire.db.acl import get_privileged_user_ids_for_workspace
+
+        privileged_ids = await get_privileged_user_ids_for_workspace(uuid4())
+
+        assert privileged_ids == frozenset()

--- a/tests/integration/test_activity_crud.py
+++ b/tests/integration/test_activity_crud.py
@@ -8,6 +8,7 @@ behaviors at the database level, and CRUD function correctness.
 
 from __future__ import annotations
 
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -133,7 +134,9 @@ class TestCreateActivity:
         with pytest.raises(IntegrityError):
             async with get_session() as session:
                 activity = Activity(
-                    week_id=None,  # type: ignore[arg-type]  # deliberately invalid to test NOT NULL constraint
+                    week_id=cast(
+                        "Any", None
+                    ),  # deliberately invalid to test NOT NULL constraint
                     template_workspace_id=template.id,
                     title="Should Fail",
                 )

--- a/tests/integration/test_annotation_context.py
+++ b/tests/integration/test_annotation_context.py
@@ -391,6 +391,65 @@ class TestResolveAnnotationContextPermission:
         assert ctx is not None
         assert ctx.permission is None
 
+    @pytest.mark.asyncio
+    async def test_staff_derived_permission(self) -> None:
+        """Staff enrollment derives course.default_instructor_permission.
+
+        No explicit ACL entry -- permission comes entirely from the
+        enrollment-derived path (_resolve_enrollment_permission). The
+        course is set to a permission distinct from the model default
+        ("editor") so this cannot pass by coincidentally matching a
+        field default; it also exercises the hydrated Course threaded
+        through from resolve_annotation_context's single joined query
+        (see _HydratedRowEntities in db/workspaces.py).
+        """
+        from promptgrimoire.db.engine import get_session
+        from promptgrimoire.db.models import Course, CourseEnrollment
+        from promptgrimoire.db.users import create_user
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_course,
+            resolve_annotation_context,
+        )
+
+        tag = uuid4().hex[:8]
+        instructor = await create_user(
+            email=f"ctx-staff-{tag}@test.local",
+            display_name=f"Ctx Staff {tag}",
+        )
+
+        async with get_session() as session:
+            course = Course(
+                id=uuid4(),
+                code=f"STF-{tag[:6]}",
+                name="Staff Permission Test",
+                semester="2026-S1",
+                default_instructor_permission="viewer",
+            )
+            session.add(course)
+            await session.flush()
+
+            enrollment = CourseEnrollment(
+                id=uuid4(),
+                course_id=course.id,
+                user_id=instructor.id,
+                role="instructor",
+            )
+            session.add(enrollment)
+            await session.flush()
+
+            course_id = course.id
+
+        ws = await create_workspace()
+        await place_workspace_in_course(ws.id, course_id)
+        # No ACL entry for `instructor` -- permission must come entirely
+        # from the course-enrollment path.
+
+        ctx = await resolve_annotation_context(ws.id, instructor.id)
+
+        assert ctx is not None
+        assert ctx.permission == "viewer"
+
 
 class TestResolveAnnotationContextPrivilegedUsers:
     """Tests for privileged user ID resolution."""
@@ -559,3 +618,51 @@ class TestResolveAnnotationContextNonexistent:
         result = await resolve_annotation_context(uuid4(), uuid4())
 
         assert result is None
+
+
+class TestResolveAnnotationContextCrdtStateFidelity:
+    """Regression coverage for the to_jsonb/bytea corruption class.
+
+    See docs/architecture/raw-sql-convention.md § "ty gotchas": to_jsonb
+    corrupts bytea columns. resolve_annotation_context's mega-join
+    deliberately hydrates Workspace from its own unprefixed columns
+    (`w.*` + ``Workspace.model_validate(row, from_attributes=True)``),
+    NOT ``to_jsonb(w.*)``, specifically so crdt_state survives as real
+    bytes. This test proves that byte-for-byte, not just "truthy".
+    """
+
+    @pytest.mark.asyncio
+    async def test_crdt_state_byte_identical(self) -> None:
+        """crdt_state round-trips byte-for-byte through the mega-join.
+
+        Uses every byte value 0-255 (including >=0x80, which is not
+        valid UTF-8 on its own) so a hex-encoding, UTF-8-decoding, or
+        truncating mangling of the bytea column could not coincidentally
+        produce a matching value.
+        """
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.users import create_user
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            resolve_annotation_context,
+            save_workspace_crdt_state,
+        )
+
+        tag = uuid4().hex[:8]
+        user = await create_user(
+            email=f"ctx-crdt-{tag}@test.local",
+            display_name=f"Ctx Crdt {tag}",
+        )
+
+        ws = await create_workspace()
+        await grant_permission(ws.id, user.id, "owner")
+
+        crdt_state = bytes(range(256)) * 4
+        saved = await save_workspace_crdt_state(ws.id, crdt_state)
+        assert saved is True
+
+        ctx = await resolve_annotation_context(ws.id, user.id)
+
+        assert ctx is not None
+        assert ctx.workspace.crdt_state == crdt_state
+        assert len(ctx.workspace.crdt_state or b"") == len(crdt_state)

--- a/tests/integration/test_bulk_enrolment.py
+++ b/tests/integration/test_bulk_enrolment.py
@@ -80,11 +80,12 @@ async def _count_users_by_email(emails: list[str]) -> int:
     """Count how many of the given emails exist as users."""
     from promptgrimoire.db.engine import get_session
 
+    # ty cannot type ``User.email.in_(...)`` (Model.field descriptor,
+    # astral-sh/ty#3421); use the plain Core Column instead.
+    user_table = User.metadata.tables[User.__tablename__]
     async with get_session() as session:
         result = await session.exec(
-            select(User).where(
-                User.email.in_([e.lower() for e in emails])  # type: ignore[arg-type]  -- SQLAlchemy in_
-            )
+            select(User).where(user_table.c.email.in_([e.lower() for e in emails]))
         )
         return len(list(result.all()))
 
@@ -105,12 +106,13 @@ async def _count_memberships(course_id: UUID) -> int:
     from promptgrimoire.db.engine import get_session
 
     async with get_session() as session:
+        # .join(StudentGroup) (single-arg) lets SQLAlchemy infer the ON
+        # clause from StudentGroupMembership.student_group_id's FK -- ty
+        # cannot type an explicit Model.field == Model.field onclause
+        # (astral-sh/ty#3421).
         result = await session.exec(
             select(StudentGroupMembership)
-            .join(
-                StudentGroup,
-                StudentGroup.id == StudentGroupMembership.student_group_id,  # type: ignore[invalid-argument-type]  -- SQLAlchemy join expression
-            )
+            .join(StudentGroup)
             .where(StudentGroup.course_id == course_id)
         )
         return len(list(result.all()))
@@ -143,13 +145,15 @@ async def _list_membership_pairs(course_id: UUID) -> list[tuple[str, str]]:
     from promptgrimoire.db.engine import get_session
 
     async with get_session() as session:
+        # .select_from(StudentGroupMembership).join(StudentGroup).join(User)
+        # lets SQLAlchemy infer both ON clauses from
+        # StudentGroupMembership's two FKs -- ty cannot type an explicit
+        # Model.field == Model.field onclause (astral-sh/ty#3421).
         result = await session.exec(
             select(StudentGroup.name, User.email)
-            .join(
-                StudentGroupMembership,
-                StudentGroupMembership.student_group_id == StudentGroup.id,  # type: ignore[invalid-argument-type]  -- SQLAlchemy join expression
-            )
-            .join(User, User.id == StudentGroupMembership.user_id)  # type: ignore[invalid-argument-type]  -- SQLAlchemy join expression
+            .select_from(StudentGroupMembership)
+            .join(StudentGroup)
+            .join(User)
             .where(StudentGroup.course_id == course_id)
             .order_by(StudentGroup.name, User.email)
         )

--- a/tests/integration/test_course_service.py
+++ b/tests/integration/test_course_service.py
@@ -248,6 +248,40 @@ class TestEnrollment:
         assert course2.id in course_ids
 
     @pytest.mark.asyncio
+    async def test_list_enrollments_for_course(self) -> None:
+        """Returns all enrollments for a course, ordered by role then user_id."""
+        from promptgrimoire.db.courses import (
+            create_course,
+            enroll_user,
+            list_course_enrollments,
+        )
+        from promptgrimoire.db.users import create_user
+
+        course = await create_course(
+            code="LAWS3333", name="Torts", semester=f"test-{uuid4().hex[:8]}"
+        )
+        student = await create_user(
+            email=f"test-{uuid4().hex[:8]}@example.com",
+            display_name="Student User",
+        )
+        tutor = await create_user(
+            email=f"test-{uuid4().hex[:8]}@example.com",
+            display_name="Tutor User",
+        )
+
+        # Enrol in reverse-alphabetical role order so ORDER BY role, user_id
+        # is what proves the sort, not insertion order.
+        await enroll_user(course_id=course.id, user_id=tutor.id, role="tutor")
+        await enroll_user(course_id=course.id, user_id=student.id, role="student")
+
+        enrollments = await list_course_enrollments(course.id)
+
+        assert len(enrollments) == 2
+        assert [e.role for e in enrollments] == ["student", "tutor"]
+        assert enrollments[0].user_id == student.id
+        assert enrollments[1].user_id == tutor.id
+
+    @pytest.mark.asyncio
     async def test_unenroll_user(self) -> None:
         """User can be removed from course."""
         from promptgrimoire.db.courses import (
@@ -646,3 +680,101 @@ class TestUpdateCourse:
 
         result = await update_course(uuid4(), name="Nope")
         assert result is None
+
+
+class TestListStudentsWithoutWorkspaces:
+    """Tests for list_students_without_workspaces.
+
+    Exercises the raw-SQL row-attribute fix in this function (row.display_name
+    / row.email, not row[0] / row[1] -- see
+    docs/architecture/raw-sql-convention.md) against a real query result, not
+    just a mock.
+    """
+
+    @pytest.mark.asyncio
+    async def test_student_with_no_workspace_is_listed(self) -> None:
+        """A student with zero workspaces in the course is returned."""
+        from promptgrimoire.db.courses import (
+            create_course,
+            enroll_user,
+            list_students_without_workspaces,
+        )
+        from promptgrimoire.db.users import create_user
+
+        course = await create_course(
+            code=f"LSW{uuid4().hex[:6].upper()}",
+            name="No Workspace",
+            semester="2025-S1",
+        )
+        student = await create_user(
+            email=f"no-ws-{uuid4().hex[:8]}@example.com",
+            display_name="No Workspace Student",
+        )
+        await enroll_user(course_id=course.id, user_id=student.id, role="student")
+
+        rows = await list_students_without_workspaces(course.id)
+
+        assert (student.display_name, student.email) in rows
+
+    @pytest.mark.asyncio
+    async def test_student_with_owned_workspace_is_excluded(self) -> None:
+        """A student who owns a course-placed workspace is not returned."""
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.courses import (
+            create_course,
+            enroll_user,
+            list_students_without_workspaces,
+        )
+        from promptgrimoire.db.engine import get_session
+        from promptgrimoire.db.models import Workspace
+        from promptgrimoire.db.users import create_user
+        from promptgrimoire.db.workspaces import create_workspace
+
+        course = await create_course(
+            code=f"LSW{uuid4().hex[:6].upper()}",
+            name="Has Workspace",
+            semester="2025-S1",
+        )
+        student = await create_user(
+            email=f"has-ws-{uuid4().hex[:8]}@example.com",
+            display_name="Has Workspace Student",
+        )
+        await enroll_user(course_id=course.id, user_id=student.id, role="student")
+
+        workspace = await create_workspace()
+        async with get_session() as session:
+            db_workspace = await session.get(Workspace, workspace.id)
+            assert db_workspace is not None
+            db_workspace.course_id = course.id
+            session.add(db_workspace)
+            await session.flush()
+        await grant_permission(workspace.id, student.id, "owner")
+
+        rows = await list_students_without_workspaces(course.id)
+
+        assert (student.display_name, student.email) not in rows
+
+    @pytest.mark.asyncio
+    async def test_staff_role_excluded_even_without_workspace(self) -> None:
+        """Staff roles (e.g. instructor) are excluded regardless of workspace."""
+        from promptgrimoire.db.courses import (
+            create_course,
+            enroll_user,
+            list_students_without_workspaces,
+        )
+        from promptgrimoire.db.users import create_user
+
+        course = await create_course(
+            code=f"LSW{uuid4().hex[:6].upper()}",
+            name="Staff Excluded",
+            semester="2025-S1",
+        )
+        instructor = await create_user(
+            email=f"instructor-{uuid4().hex[:8]}@example.com",
+            display_name="Instructor No Workspace",
+        )
+        await enroll_user(course_id=course.id, user_id=instructor.id, role="instructor")
+
+        rows = await list_students_without_workspaces(course.id)
+
+        assert (instructor.display_name, instructor.email) not in rows

--- a/tests/integration/test_loadtest_queries.py
+++ b/tests/integration/test_loadtest_queries.py
@@ -1,0 +1,541 @@
+"""Integration tests for cli_loadtest.py's raw-SQL migrated queries.
+
+Covers the ADR 0004 requirement that every migrated query keep or gain
+integration coverage that executes against Postgres
+(docs/architecture/raw-sql-convention.md), plus characterisation coverage
+for the DB-touching helpers extracted from _seed_student_workspaces and
+_seed_acl_shares during the ty-bump complexity cleanup (both functions were
+flagged over the complexity-15 threshold and had zero prior test coverage).
+
+Requires a running PostgreSQL instance. Set DEV__TEST_DATABASE_URL.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import pytest
+
+from promptgrimoire.config import get_settings
+
+if TYPE_CHECKING:
+    from promptgrimoire.db.models import User
+
+pytestmark = pytest.mark.skipif(
+    not get_settings().dev.test_database_url,
+    reason="DEV__TEST_DATABASE_URL not configured",
+)
+
+
+async def _make_course_week_activity(*, title: str = "Query Test Activity"):
+    """Create Course -> Week -> Activity with a template workspace.
+
+    Returns (Course, Week, Activity).
+    """
+    from promptgrimoire.db.activities import create_activity
+    from promptgrimoire.db.courses import create_course
+    from promptgrimoire.db.weeks import create_week
+
+    code = f"T{uuid4().hex[:6].upper()}"
+    course = await create_course(
+        code=code, name="LoadtestQueryTest", semester="2026-S1"
+    )
+    week = await create_week(course_id=course.id, week_number=1, title="Week 1")
+    activity = await create_activity(week_id=week.id, title=title)
+    return course, week, activity
+
+
+async def _make_student(email_prefix: str = "loadtest-query") -> User:
+    from promptgrimoire.db.users import find_or_create_user
+
+    user, _created = await find_or_create_user(
+        email=f"{email_prefix}-{uuid4().hex[:8]}@test.local",
+        display_name="Query Test Student",
+    )
+    return user
+
+
+class TestCheckWorkspaceExists:
+    """Migrated from SQLModel .join() -- raw SQL with a JOIN + owner filter."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_workspace(self) -> None:
+        from promptgrimoire.cli_loadtest import _check_workspace_exists
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student()
+
+        assert await _check_workspace_exists(activity.id, student.id) is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_after_owner_workspace_created(self) -> None:
+        from promptgrimoire.cli_loadtest import _check_workspace_exists
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_activity,
+        )
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student()
+
+        workspace = await create_workspace()
+        await place_workspace_in_activity(workspace.id, activity.id)
+        await grant_permission(workspace.id, student.id, "owner")
+
+        assert await _check_workspace_exists(activity.id, student.id) is True
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_owner_permission(self) -> None:
+        """A viewer-only ACL entry must not count as 'workspace exists'."""
+        from promptgrimoire.cli_loadtest import _check_workspace_exists
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_activity,
+        )
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-query-viewer")
+
+        workspace = await create_workspace()
+        await place_workspace_in_activity(workspace.id, activity.id)
+        await grant_permission(workspace.id, student.id, "viewer")
+
+        assert await _check_workspace_exists(activity.id, student.id) is False
+
+
+class TestResolveCourseIdForCode:
+    """Migrated from SQLModel .join() -- raw SQL joining week to activity."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_course_id_via_activity_hierarchy(self) -> None:
+        from promptgrimoire.cli_loadtest import (
+            _course_id_cache,
+            _resolve_course_id_for_code,
+        )
+
+        course, _week, activity = await _make_course_week_activity()
+        code = course.code
+        _course_id_cache.pop(code, None)  # avoid cross-test cache bleed
+
+        course_activities = {code: [(activity, activity.template_workspace_id)]}
+        resolved = await _resolve_course_id_for_code(code, course_activities)
+
+        assert resolved == course.id
+
+    @pytest.mark.asyncio
+    async def test_caches_result_across_calls(self) -> None:
+        from promptgrimoire.cli_loadtest import (
+            _course_id_cache,
+            _resolve_course_id_for_code,
+        )
+
+        course, _week, activity = await _make_course_week_activity()
+        code = course.code
+        _course_id_cache.pop(code, None)
+
+        course_activities = {code: [(activity, activity.template_workspace_id)]}
+        first = await _resolve_course_id_for_code(code, course_activities)
+        # Second call passes an empty mapping: if the result weren't cached,
+        # `acts = course_activities.get(code, [])` would be empty and this
+        # would return None instead of the cached course id.
+        second = await _resolve_course_id_for_code(code, {})
+
+        assert first == course.id
+        assert second == course.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_course_with_no_activities(self) -> None:
+        from promptgrimoire.cli_loadtest import (
+            _course_id_cache,
+            _resolve_course_id_for_code,
+        )
+
+        code = f"NOACT{uuid4().hex[:6].upper()}"
+        _course_id_cache.pop(code, None)
+
+        assert await _resolve_course_id_for_code(code, {}) is None
+
+
+class TestEnsureActivitiesForCourse:
+    """Migrated from SQLModel .in_() -- raw SQL with = ANY(...)."""
+
+    @pytest.mark.asyncio
+    async def test_second_pass_reuses_activity_found_by_raw_sql(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The existing_acts query must find activities created by a prior
+        pass, so a second pass reuses rather than duplicates them."""
+        import promptgrimoire.cli_loadtest as loadtest_mod
+        from promptgrimoire.db.courses import create_course
+        from promptgrimoire.db.engine import get_session
+        from promptgrimoire.db.weeks import create_week
+
+        code = f"T{uuid4().hex[:6].upper()}"
+        course = await create_course(
+            code=code, name="Ensure Activities Test", semester="2026-S1"
+        )
+        week = await create_week(course_id=course.id, week_number=1, title="Week 1")
+        async with get_session() as session:
+            session.add(week)
+            week.is_published = True
+            await session.flush()
+            await session.refresh(week)
+
+        week_map = {1: week}
+        monkeypatch.setitem(
+            loadtest_mod.ACTIVITY_DEFS, code, [(1, "Shared Activity Title")]
+        )
+
+        first_pass = await loadtest_mod._ensure_activities_for_course(code, week_map)
+        assert len(first_pass) == 1
+        created_activity_id = first_pass[0][0].id
+
+        second_pass = await loadtest_mod._ensure_activities_for_course(code, week_map)
+
+        assert len(second_pass) == 1
+        assert second_pass[0][0].id == created_activity_id
+
+
+class TestFetchCandidateWorkspaces:
+    """Migrated from SQLModel .join() x3 -- raw SQL with three JOINs."""
+
+    @pytest.mark.asyncio
+    async def test_excludes_template_and_non_owner_workspaces(self) -> None:
+        from promptgrimoire.cli_loadtest import _fetch_candidate_workspaces
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_activity,
+        )
+
+        course, _week, activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-query-candidate")
+
+        # Owner workspace on a real activity: should be a candidate.
+        student_ws = await create_workspace()
+        await place_workspace_in_activity(student_ws.id, activity.id)
+        await grant_permission(student_ws.id, student.id, "owner")
+
+        # Same activity, viewer-only: must be excluded (not owner).
+        other_ws = await create_workspace()
+        await place_workspace_in_activity(other_ws.id, activity.id)
+        viewer = await _make_student("loadtest-query-candidate-viewer")
+        await grant_permission(other_ws.id, viewer.id, "viewer")
+
+        # The activity's own template workspace has an owner too (from
+        # create_activity's bootstrap) but must never appear as a candidate.
+        candidates = await _fetch_candidate_workspaces({course.code: course})
+
+        candidate_ids = {ws_id for ws_id, _owner, _cid in candidates}
+        assert student_ws.id in candidate_ids
+        assert other_ws.id not in candidate_ids
+        assert activity.template_workspace_id not in candidate_ids
+
+        owner_lookup = {ws_id: owner for ws_id, owner, _cid in candidates}
+        assert owner_lookup[student_ws.id] == student.id
+
+    @pytest.mark.asyncio
+    async def test_no_courses_returns_empty(self) -> None:
+        from promptgrimoire.cli_loadtest import _fetch_candidate_workspaces
+
+        assert await _fetch_candidate_workspaces({}) == []
+
+
+class TestGrantSharesForWorkspace:
+    """Extracted from _seed_acl_shares (complexity 18 -> decomposed)."""
+
+    @pytest.mark.asyncio
+    async def test_grants_one_or_two_shares_excluding_owner(self) -> None:
+        from promptgrimoire.cli_loadtest import _grant_shares_for_workspace
+        from promptgrimoire.db.workspaces import create_workspace
+
+        owner = await _make_student("loadtest-query-owner")
+        peer_a = await _make_student("loadtest-query-peer-a")
+        peer_b = await _make_student("loadtest-query-peer-b")
+        course_id = uuid4()
+
+        workspace = await create_workspace()
+        course_students = {course_id: [owner, peer_a, peer_b]}
+
+        granted = await _grant_shares_for_workspace(
+            workspace.id, owner.id, course_id, course_students
+        )
+
+        assert 1 <= granted <= 2
+
+        grants = await _fetch_acl_grants(workspace.id)
+        assert owner.id not in grants
+        assert len(grants) == granted
+        assert set(grants).issubset({peer_a.id, peer_b.id})
+        assert all(perm in ("editor", "viewer") for perm in grants.values())
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_eligible_students(self) -> None:
+        """Only the owner is enrolled in the course -- nobody to share with."""
+        from promptgrimoire.cli_loadtest import _grant_shares_for_workspace
+        from promptgrimoire.db.workspaces import create_workspace
+
+        owner = await _make_student("loadtest-query-solo-owner")
+        course_id = uuid4()
+        workspace = await create_workspace()
+        course_students = {course_id: [owner]}
+
+        granted = await _grant_shares_for_workspace(
+            workspace.id, owner.id, course_id, course_students
+        )
+
+        assert granted == 0
+        assert await _fetch_acl_grants(workspace.id) == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_course_has_no_students_mapped(self) -> None:
+        from promptgrimoire.cli_loadtest import _grant_shares_for_workspace
+        from promptgrimoire.db.workspaces import create_workspace
+
+        owner_id = uuid4()
+        workspace = await create_workspace()
+
+        granted = await _grant_shares_for_workspace(workspace.id, owner_id, uuid4(), {})
+
+        assert granted == 0
+
+
+async def _fetch_acl_grants(workspace_id: UUID) -> dict[UUID, str]:
+    """Read back ACL grants for a workspace via the same raw-SQL idiom."""
+    from sqlalchemy import tstring
+
+    from promptgrimoire.db.engine import get_session
+
+    async with get_session() as session:
+        rows = await session.execute(
+            tstring(
+                t"""
+                SELECT user_id, permission
+                FROM acl_entry
+                WHERE workspace_id = {workspace_id}
+                """
+            )
+        )
+        return {row.user_id: row.permission for row in rows}
+
+
+class TestBuildTemplateDocCache:
+    """Extracted from _seed_student_workspaces (complexity 27 -> decomposed)."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_once_per_unique_template_id(self) -> None:
+        from promptgrimoire.cli_loadtest import _build_template_doc_cache
+        from promptgrimoire.db.workspace_documents import add_document
+
+        _course, _week, activity = await _make_course_week_activity()
+        tmpl_id = activity.template_workspace_id
+        await add_document(
+            workspace_id=tmpl_id,
+            type="source",
+            content="<p>hello</p>",
+            source_type="html",
+            title="Doc 1",
+        )
+
+        # Same template id appears twice across two "activities" -- the
+        # cache must still hold exactly one fetch's worth of documents.
+        course_activities = {"X": [(activity, tmpl_id), (activity, tmpl_id)]}
+
+        cache = await _build_template_doc_cache(course_activities)
+
+        assert tmpl_id in cache
+        assert len(cache[tmpl_id]) == 1
+        assert cache[tmpl_id][0].title == "Doc 1"
+
+    @pytest.mark.asyncio
+    async def test_empty_course_activities_produces_empty_cache(self) -> None:
+        from promptgrimoire.cli_loadtest import _build_template_doc_cache
+
+        assert await _build_template_doc_cache({}) == {}
+
+
+class TestCreateActivityWorkspacesForStudent:
+    """Extracted from _seed_student_workspaces (complexity 27 -> decomposed)."""
+
+    @pytest.mark.asyncio
+    async def test_creates_workspace_when_probability_roll_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+        from promptgrimoire.db.workspace_documents import add_document
+
+        _course, _week, activity = await _make_course_week_activity()
+        tmpl_id = activity.template_workspace_id
+        await add_document(
+            workspace_id=tmpl_id,
+            type="source",
+            content="<p>x</p>",
+            source_type="html",
+            title="Template Doc",
+        )
+        student = await _make_student("loadtest-query-actor")
+
+        # Force the 70%-chance roll to always pass (random() <= threshold).
+        monkeypatch.setattr(loadtest_mod.random, "random", lambda: 0.0)
+
+        course_activities = {"X": [(activity, tmpl_id)]}
+        template_doc_cache = await loadtest_mod._build_template_doc_cache(
+            course_activities
+        )
+
+        (
+            ws_count,
+            doc_count,
+            shared_count,
+        ) = await loadtest_mod._create_activity_workspaces_for_student(
+            student, ["X"], course_activities, template_doc_cache
+        )
+
+        assert ws_count == 1
+        assert doc_count == 1
+        assert shared_count in (0, 1)
+        assert await loadtest_mod._check_workspace_exists(activity.id, student.id)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_probability_roll_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-query-actor-skip")
+
+        # Force the roll to always fail (random() > threshold).
+        monkeypatch.setattr(loadtest_mod.random, "random", lambda: 1.0)
+
+        result = await loadtest_mod._create_activity_workspaces_for_student(
+            student, ["X"], {"X": [(activity, activity.template_workspace_id)]}, {}
+        )
+
+        assert result == (0, 0, 0)
+        assert not await loadtest_mod._check_workspace_exists(activity.id, student.id)
+
+    @pytest.mark.asyncio
+    async def test_skips_activity_the_student_already_has_a_workspace_for(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_activity,
+        )
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-query-actor-exists")
+
+        existing_ws = await create_workspace()
+        await place_workspace_in_activity(existing_ws.id, activity.id)
+        await grant_permission(existing_ws.id, student.id, "owner")
+
+        # Force the roll to pass so idempotency, not probability, is what's
+        # under test here.
+        monkeypatch.setattr(loadtest_mod.random, "random", lambda: 0.0)
+
+        result = await loadtest_mod._create_activity_workspaces_for_student(
+            student, ["X"], {"X": [(activity, activity.template_workspace_id)]}, {}
+        )
+
+        assert result == (0, 0, 0)
+
+
+class TestPrintSummary:
+    """Migrated from SQLModel .like()/.in_() -- raw SQL with LIKE / = ANY(...)."""
+
+    @pytest.mark.asyncio
+    async def test_reports_accurate_scoped_enrollment_and_phase_counts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+        from promptgrimoire.db.courses import enroll_user
+
+        course, _week, _activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-summary")
+        await enroll_user(course_id=course.id, user_id=student.id, role="student")
+
+        captured: list[str] = []
+        monkeypatch.setattr(loadtest_mod.console, "print", captured.append)
+
+        counts = loadtest_mod.LoadTestCounts(
+            activity_ws_count=1,
+            loose_ws_count=2,
+            total_doc_count=3,
+            share_count=4,
+            shared_with_class_count=5,
+        )
+        await loadtest_mod._print_summary(
+            courses={course.code: course},
+            course_activities={},
+            counts=counts,
+        )
+
+        rendered = "\n".join(str(c) for c in captured)
+        # Enrollment count is scoped to this one freshly-created course, so
+        # it is exact even under parallel test execution.
+        assert "Enrollments: 1" in rendered
+        assert "Workspaces (activity): 1" in rendered
+        assert "Workspaces (loose): 2" in rendered
+        assert "Documents: 3" in rendered
+        assert "ACL shares: 4" in rendered
+        assert "Workspaces with shared_with_class: 5" in rendered
+
+    @pytest.mark.asyncio
+    async def test_zero_enrollments_for_course_with_no_students(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+
+        course, _week, _activity = await _make_course_week_activity()
+
+        captured: list[str] = []
+        monkeypatch.setattr(loadtest_mod.console, "print", captured.append)
+
+        await loadtest_mod._print_summary(
+            courses={course.code: course},
+            course_activities={},
+            counts=loadtest_mod.LoadTestCounts(
+                activity_ws_count=0,
+                loose_ws_count=0,
+                total_doc_count=0,
+                share_count=0,
+                shared_with_class_count=0,
+            ),
+        )
+
+        rendered = "\n".join(str(c) for c in captured)
+        assert "Enrollments: 0" in rendered
+
+
+class TestValidateEnsureStudentWorkspace:
+    """Migrated from SQLModel .join() -- raw SQL, same shape as
+    _check_workspace_exists but selecting the workspace id itself."""
+
+    @pytest.mark.asyncio
+    async def test_finds_existing_owner_workspace_via_raw_sql(self) -> None:
+        from promptgrimoire.cli_loadtest import _validate_ensure_student_workspace
+        from promptgrimoire.db.acl import grant_permission
+        from promptgrimoire.db.workspaces import (
+            create_workspace,
+            place_workspace_in_activity,
+        )
+
+        _course, _week, activity = await _make_course_week_activity()
+        student = await _make_student("loadtest-query-validate")
+
+        workspace = await create_workspace()
+        await place_workspace_in_activity(workspace.id, activity.id)
+        await grant_permission(workspace.id, student.id, "owner")
+
+        resolved = await _validate_ensure_student_workspace(
+            activity, activity.template_workspace_id, student
+        )
+
+        assert resolved == workspace.id

--- a/tests/integration/test_tag_management_crdt_sync.py
+++ b/tests/integration/test_tag_management_crdt_sync.py
@@ -132,6 +132,7 @@ class TestTagColourEditUpdatesCrdt:
                 return t if t is not None and t.color == "#ff0000" else None
 
             updated = await wait_for(_colour_saved, timeout=5.0)
+            assert updated is not None
             assert updated.color == "#ff0000", (
                 f"tag colour not updated: expected #ff0000, got {updated.color}"
             )
@@ -176,6 +177,7 @@ class TestTagNameEditUpdatesCrdt:
                 return t if t is not None and t.name == "NewName" else None
 
             updated = await wait_for(_name_saved, timeout=5.0)
+            assert updated is not None
             assert updated.name == "NewName", (
                 f"tag name not updated: expected 'NewName', got {updated.name!r}"
             )
@@ -228,6 +230,7 @@ class TestGroupColourEditUpdatesCrdt:
                 return g if g is not None and g.color == "#00ff00" else None
 
             updated = await wait_for(_group_colour_saved, timeout=5.0)
+            assert updated is not None
             assert updated.color == "#00ff00", (
                 f"group colour not updated: expected #00ff00, got {updated.color}"
             )

--- a/tests/integration/test_user_listing.py
+++ b/tests/integration/test_user_listing.py
@@ -1,0 +1,84 @@
+"""Tests for list_users/list_all_users, used by the admin CLI user listing.
+
+These tests require a running PostgreSQL instance. Set DEV__TEST_DATABASE_URL.
+
+The user table is shared across the test suite, so assertions filter the
+returned list down to users created within each test (matched via a unique
+tag embedded in the email) rather than asserting on the full table.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from promptgrimoire.config import get_settings
+
+pytestmark = pytest.mark.skipif(
+    not get_settings().dev.test_database_url,
+    reason="DEV__TEST_DATABASE_URL not configured",
+)
+
+
+class TestListUsers:
+    """Tests for list_users() (active-only by default) and list_all_users()."""
+
+    @pytest.mark.asyncio
+    async def test_excludes_users_who_never_logged_in_by_default(self) -> None:
+        """list_users() without include_inactive omits users with no last_login."""
+        from promptgrimoire.db.users import create_user, list_users, update_last_login
+
+        tag = uuid4().hex[:8]
+        never_logged_in = await create_user(
+            email=f"aaa-{tag}@example.com", display_name="Never Logged In"
+        )
+        logged_in = await create_user(
+            email=f"bbb-{tag}@example.com", display_name="Logged In"
+        )
+        await update_last_login(logged_in.id)
+
+        users = await list_users()
+        matched_ids = [u.id for u in users if tag in u.email]
+
+        assert matched_ids == [logged_in.id]
+        assert never_logged_in.id not in matched_ids
+
+    @pytest.mark.asyncio
+    async def test_include_inactive_returns_both_ordered_by_email(self) -> None:
+        """list_users(include_inactive=True) includes never-logged-in users too."""
+        from promptgrimoire.db.users import create_user, list_users, update_last_login
+
+        tag = uuid4().hex[:8]
+        # Created in reverse-alphabetical order so ORDER BY email is what
+        # proves the sort, not insertion order.
+        logged_in = await create_user(
+            email=f"zzz-{tag}@example.com", display_name="Logged In"
+        )
+        await update_last_login(logged_in.id)
+        never_logged_in = await create_user(
+            email=f"aaa-{tag}@example.com", display_name="Never Logged In"
+        )
+
+        users = await list_users(include_inactive=True)
+        matched_ids = [u.id for u in users if tag in u.email]
+
+        assert matched_ids == [never_logged_in.id, logged_in.id]
+
+    @pytest.mark.asyncio
+    async def test_list_all_users_ordered_by_email(self) -> None:
+        """list_all_users() returns every user, ordered by email ascending."""
+        from promptgrimoire.db.users import create_user, list_all_users
+
+        tag = uuid4().hex[:8]
+        # Created in reverse-alphabetical order so ORDER BY email is what
+        # proves the sort, not insertion order.
+        second = await create_user(
+            email=f"zzz-{tag}@example.com", display_name="Second"
+        )
+        first = await create_user(email=f"aaa-{tag}@example.com", display_name="First")
+
+        users = await list_all_users()
+        matched_ids = [u.id for u in users if tag in u.email]
+
+        assert matched_ids == [first.id, second.id]

--- a/tests/integration/test_wargame_schema.py
+++ b/tests/integration/test_wargame_schema.py
@@ -476,7 +476,7 @@ class TestWargameMessageTable:
             result = await session.exec(
                 select(WargameMessage)
                 .where(WargameMessage.team_id == team_id)
-                .order_by(WargameMessage.sequence_no)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+                .order_by("sequence_no")
             )
             messages = list(result.all())
 
@@ -595,7 +595,7 @@ class TestWargameMessageTable:
             result = await session.exec(
                 select(WargameMessage)
                 .where(WargameMessage.team_id == team_id)
-                .order_by(WargameMessage.sequence_no)  # type: ignore[arg-type]  -- SQLModel order_by() stubs don't accept Column expressions
+                .order_by("sequence_no")
             )
             messages = list(result.all())
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -201,6 +201,7 @@ def make_workspace_document():
 
     def _make(
         workspace_id: UUID | None = None,
+        *,
         type: str = "source",
         content: str = "",
         source_type: str = "text",

--- a/tests/unit/export/test_empty_content_guard.py
+++ b/tests/unit/export/test_empty_content_guard.py
@@ -66,8 +66,8 @@ def _extract_body(html: str) -> str:
     tree = LexborHTMLParser(html)
     body = tree.body
     if body is not None:
-        # selectolax .html stub returns str|None but body check above
-        return body.html  # type: ignore[no-any-return]  # selectolax stub
+        # selectolax .html is str | None; fall back to the input on None
+        return body.html or html
     return html
 
 

--- a/tests/unit/export/test_highlight_spans.py
+++ b/tests/unit/export/test_highlight_spans.py
@@ -30,9 +30,11 @@ from promptgrimoire.input_pipeline.html_input import extract_text_from_html
 def _find_spans(html: str) -> list[dict[str, str]]:
     """Extract all data-hl spans from HTML as dicts of their attributes."""
     tree = LexborHTMLParser(html)
-    spans = []
+    spans: list[dict[str, str]] = []
     for node in tree.css("span[data-hl]"):
-        attrs = dict(node.attributes)
+        # Valueless attributes come back as None; normalise to "" so
+        # callers can use str operations without per-site guards.
+        attrs = {k: v if v is not None else "" for k, v in node.attributes.items()}
         attrs["_text"] = node.text() or ""
         spans.append(attrs)
     return spans
@@ -41,6 +43,7 @@ def _find_spans(html: str) -> list[dict[str, str]]:
 def _make_hl(
     start: int,
     end: int,
+    *,
     tag: str = "jurisdiction",
     author: str = "",
     comments: list | None = None,

--- a/tests/unit/export/test_latex_render.py
+++ b/tests/unit/export/test_latex_render.py
@@ -149,3 +149,72 @@ class TestRenderLatex:
         name = "test_tag"
         result = render_latex(t"\\definecolor{{tag-{name}}}{{HTML}}{{FF0000}}")
         assert result == "\\definecolor{tag-test\\_tag}{HTML}{FF0000}"
+
+
+class TestRenderLatexConversions:
+    """Characterisation tests for conversion specifiers (!r, !s, !a) and
+    format specs -- these branches were previously untested and are the
+    source of most of render_latex's cognitive complexity (a nested
+    if/elif chain), so they must be pinned down before refactoring.
+    """
+
+    def test_repr_conversion_applied_before_escaping(self) -> None:
+        """!r applies repr() to the value, then the LaTeX-special result
+        (the quotes from repr are not special, the & is) is escaped."""
+        val = "a&b"
+        result = render_latex(t"{val!r}")
+        assert result == "'a\\&b'"
+
+    def test_str_conversion_applied(self) -> None:
+        """!s applies str() to the value before escaping."""
+
+        class Wrapper:
+            def __str__(self) -> str:
+                return "wrapped#value"
+
+        result = render_latex(t"{Wrapper()!s}")
+        assert result == "wrapped\\#value"
+
+    def test_ascii_conversion_applied(self) -> None:
+        """!a applies ascii() (backslash-escaping non-ASCII) before LaTeX
+        escaping, so the backslashes ascii() introduces are themselves
+        escaped to \\textbackslash{}."""
+        val = "café"
+        result = render_latex(t"{val!a}")
+        assert result == "'caf\\textbackslash{}xe9'"
+
+    def test_no_conversion_leaves_value_untouched(self) -> None:
+        """Absence of a conversion specifier applies none of !r/!s/!a."""
+        result = render_latex(t"{42}")
+        assert result == "42"
+
+    def test_format_spec_applied(self) -> None:
+        """A format spec (e.g. .2f) is applied via format() before escaping."""
+        result = render_latex(t"{3.14159:.2f}")
+        assert result == "3.14"
+
+    def test_format_spec_combined_with_conversion(self) -> None:
+        """Conversion runs first, then the format spec is applied to the
+        converted (string) value -- matching f-string evaluation order."""
+        result = render_latex(t"{42!r:>6}")
+        assert result == "    42"
+
+    def test_noescape_without_format_spec_stays_unescaped(self) -> None:
+        """A NoEscape value with no format spec passes through verbatim."""
+        val = NoEscape(r"\textbf{x}")
+        result = render_latex(t"{val}")
+        assert result == "\\textbf{x}"
+
+    def test_noescape_with_format_spec_loses_trust_marker(self) -> None:
+        """Documented gotcha: str.__format__ on a str subclass always
+        returns a plain str (verified directly against builtins, not
+        against this module), so applying a format spec to a NoEscape
+        value strips the NoEscape marker and the padded result gets
+        escaped like untrusted text. This is current behaviour, not
+        necessarily desired behaviour -- pinned here so a refactor
+        cannot silently change it either way.
+        """
+        val = NoEscape(r"\textbf{x}")
+        assert type(format(val, ">20")) is str
+        result = render_latex(t"{val:>20}")
+        assert result == "          \\textbackslash{}textbf\\{x\\}"

--- a/tests/unit/incident/test_pglog_parser.py
+++ b/tests/unit/incident/test_pglog_parser.py
@@ -156,6 +156,7 @@ class TestTextEdgeCases:
 
 
 def _make_pg_json_line(
+    *,
     timestamp: str = "2026-03-16 04:32:52.000 GMT",
     pid: int = 1234,
     error_severity: str = "ERROR",

--- a/tests/unit/input_pipeline/test_insert_markers_fixtures.py
+++ b/tests/unit/input_pipeline/test_insert_markers_fixtures.py
@@ -85,7 +85,7 @@ def _extract_body(html: str) -> str:
     tree = LexborHTMLParser(html)
     body = tree.body
     if body is not None:
-        return body.html  # type: ignore[no-any-return]  # selectolax .html stub returns str|None but body existence is checked above
+        return body.html or html
     return html
 
 

--- a/tests/unit/input_pipeline/test_paragraph_map.py
+++ b/tests/unit/input_pipeline/test_paragraph_map.py
@@ -10,6 +10,7 @@ Covers acceptance criteria from paragraph-numbering-191 Phase 2:
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from selectolax.lexbor import LexborHTMLParser
 
@@ -70,13 +71,13 @@ def _extract_text(html: str) -> str:
         return ""
     chars: list[str] = []
 
-    def _walk(node: object) -> None:
-        tag = node.tag  # type: ignore[attr-defined]
+    def _walk(node: Any) -> None:
+        tag = node.tag
         if tag == "-text":
-            text = node.text_content  # type: ignore[attr-defined]
+            text = node.text_content
             if not text:
                 return
-            parent = node.parent  # type: ignore[attr-defined]
+            parent = node.parent
             if (
                 parent is not None
                 and parent.tag in _BLOCK_TAGS
@@ -91,7 +92,7 @@ def _extract_text(html: str) -> str:
         if tag == "br":
             chars.append("\n")
             return
-        child = node.child  # type: ignore[attr-defined]
+        child = node.child
         while child is not None:
             _walk(child)
             child = child.next

--- a/tests/unit/pages/test_annotation_tags.py
+++ b/tests/unit/pages/test_annotation_tags.py
@@ -31,7 +31,7 @@ class TestTagInfo:
         """TagInfo instances are immutable (frozen dataclass)."""
         ti = TagInfo(name="Test", colour="#000000", raw_key="key")
         try:
-            ti.name = "Changed"  # type: ignore[misc]  -- testing frozen
+            setattr(ti, "name", "Changed")  # noqa: B010  -- testing frozen
             raise AssertionError("Expected FrozenInstanceError")
         except AttributeError:
             pass

--- a/tests/unit/pages/test_annotation_warp.py
+++ b/tests/unit/pages/test_annotation_warp.py
@@ -12,8 +12,12 @@ Traceability:
 from __future__ import annotations
 
 import inspect
+from uuid import UUID, uuid4
 
-from promptgrimoire.pages.annotation.highlights import _warp_to_highlight
+from promptgrimoire.pages.annotation.highlights import (
+    _resolve_warp_target_doc_id,
+    _warp_to_highlight,
+)
 from promptgrimoire.pages.annotation.organise import (
     _build_highlight_card_html,
     render_organise_tab,
@@ -47,6 +51,47 @@ class TestWarpToHighlightSignature:
             p for p in sig.parameters.values() if p.default is inspect.Parameter.empty
         ]
         assert len(required) == 3
+
+
+class TestResolveWarpTargetDocId:
+    """Pure logic extracted from _warp_to_highlight's tab-resolution branch."""
+
+    def test_no_document_id_returns_first_tab(self) -> None:
+        """With no document_id hint, the first tab in the mapping wins."""
+        first = uuid4()
+        document_tabs = {first: object(), uuid4(): object()}
+        assert _resolve_warp_target_doc_id(None, document_tabs) == str(first)
+
+    def test_valid_known_document_id_is_used_verbatim(self) -> None:
+        """A document_id that matches a known tab is returned unchanged."""
+        known = uuid4()
+        document_tabs = {known: object(), uuid4(): object()}
+        assert _resolve_warp_target_doc_id(str(known), document_tabs) == str(known)
+
+    def test_valid_but_unknown_document_id_falls_back_to_first_tab(self) -> None:
+        """A well-formed UUID absent from document_tabs falls back to the first tab."""
+        first = uuid4()
+        document_tabs = {first: object()}
+        assert _resolve_warp_target_doc_id(str(uuid4()), document_tabs) == str(first)
+
+    def test_malformed_document_id_falls_back_to_first_tab(self) -> None:
+        """A non-UUID document_id string falls back to the first tab."""
+        first = uuid4()
+        document_tabs = {first: object()}
+        assert _resolve_warp_target_doc_id("not-a-uuid", document_tabs) == str(first)
+
+    def test_empty_string_document_id_falls_back_to_first_tab(self) -> None:
+        """An empty document_id is falsy, so it falls back like None."""
+        first = uuid4()
+        document_tabs = {first: object()}
+        assert _resolve_warp_target_doc_id("", document_tabs) == str(first)
+
+    def test_return_type_is_str(self) -> None:
+        """The resolved id is always a str, even though keys are UUID."""
+        first = uuid4()
+        result = _resolve_warp_target_doc_id(None, {first: object()})
+        assert isinstance(result, str)
+        assert UUID(result) == first
 
 
 class TestOrganiseLocateParameter:

--- a/tests/unit/pages/test_navigator_title_edit.py
+++ b/tests/unit/pages/test_navigator_title_edit.py
@@ -14,8 +14,12 @@ from re-reading the code under test.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from nicegui.elements.input import Input
 
 
 async def test_none_value_persists_as_none() -> None:
@@ -34,7 +38,7 @@ async def test_none_value_persists_as_none() -> None:
     ) as mock_update:
         await _persist_title_change(
             workspace_id=workspace_id,
-            title_input=title_input,  # type: ignore[arg-type]  -- structural stand-in for Input
+            title_input=cast("Input", title_input),
             fallback_title="Untitled Workspace",
             original_title="Untitled Workspace",
             page_state=None,
@@ -59,7 +63,7 @@ async def test_whitespace_only_value_persists_as_none() -> None:
     ) as mock_update:
         await _persist_title_change(
             workspace_id=workspace_id,
-            title_input=title_input,  # type: ignore[arg-type]  -- structural stand-in for Input
+            title_input=cast("Input", title_input),
             fallback_title="Untitled Workspace",
             original_title="Untitled Workspace",
             page_state=None,
@@ -85,7 +89,7 @@ async def test_real_title_is_stripped_and_persisted() -> None:
     ) as mock_update:
         await _persist_title_change(
             workspace_id=workspace_id,
-            title_input=title_input,  # type: ignore[arg-type]  -- structural stand-in for Input
+            title_input=cast("Input", title_input),
             fallback_title="Untitled Workspace",
             original_title="Untitled Workspace",
             page_state=None,

--- a/tests/unit/pages/test_pdf_export_refactor.py
+++ b/tests/unit/pages/test_pdf_export_refactor.py
@@ -70,11 +70,31 @@ from promptgrimoire.pages.annotation.header import (  # noqa: E402
     _wrap_refresh_with_stale_download_clear,
 )
 from promptgrimoire.pages.annotation.pdf_export import (  # noqa: E402
+    _build_export_documents,
+    _ExportBuildContext,
     _handle_pdf_export,
     _show_download_button,
     _start_export_polling,
     check_existing_export,
 )
+
+
+# ---------------------------------------------------------------------------
+# Stub for WorkspaceDocument -- avoids importing SQLModel at test time
+# ---------------------------------------------------------------------------
+@dataclass
+class _StubDocument:
+    """Minimal stub matching the WorkspaceDocument fields read by export building."""
+
+    id: UUID = field(default_factory=uuid4)
+    title: str | None = None
+    content: str = "<p>content</p>"
+    paragraph_map: dict[str, int | None] | None = None
+
+
+def _doc(**kwargs: Any) -> Any:
+    """Create a _StubDocument cast to Any for type-checker compat."""
+    return _StubDocument(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -584,3 +604,138 @@ class TestLockRemoval:
 
         source = inspect.getsource(mod)
         assert "asyncio.Lock" not in source
+
+
+# ---------------------------------------------------------------------------
+# _build_export_documents -- pure per-document payload building, extracted
+# from _handle_pdf_export to reduce cognitive complexity.
+# ---------------------------------------------------------------------------
+def _ctx(**overrides: Any) -> _ExportBuildContext:
+    """Build an _ExportBuildContext with sensible defaults for testing."""
+    defaults: dict[str, Any] = {
+        "crdt_doc": MagicMock(),
+        "tag_name_map": {},
+        "is_anonymous": False,
+        "user_id": str(uuid4()),
+        "viewer_is_privileged": False,
+        "privileged_user_ids": frozenset(),
+    }
+    defaults.update(overrides)
+    return _ExportBuildContext(**defaults)
+
+
+class TestBuildExportDocuments:
+    """Unit coverage for the pure per-document export payload builder."""
+
+    def test_builds_entry_with_valid_highlights(self) -> None:
+        """A highlight whose tag is known survives into the entry, untouched."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = [
+            {"tag": "tag-1", "start_char": 0, "end_char": 5}
+        ]
+        doc = _doc(title="My Doc")
+
+        documents, total_dangling = _build_export_documents(
+            [doc], _ctx(crdt_doc=crdt, tag_name_map={"tag-1": "Jurisdiction"})
+        )
+
+        assert total_dangling == 0
+        assert len(documents) == 1
+        assert documents[0]["title"] == "My Doc"
+        assert documents[0]["html_content"] == doc.content
+        assert documents[0]["highlights"] == [
+            {
+                "tag": "tag-1",
+                "start_char": 0,
+                "end_char": 5,
+                "tag_name": "Jurisdiction",
+            }
+        ]
+
+    def test_dangling_tag_is_dropped_and_counted(self) -> None:
+        """A highlight referencing a deleted tag is excluded and counted."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = [
+            {"tag": "deleted-tag", "start_char": 0, "end_char": 5}
+        ]
+        doc = _doc()
+
+        documents, total_dangling = _build_export_documents(
+            [doc], _ctx(crdt_doc=crdt, tag_name_map={"tag-1": "Jurisdiction"})
+        )
+
+        assert total_dangling == 1
+        assert documents[0]["highlights"] == []
+
+    def test_dangling_count_sums_across_documents(self) -> None:
+        """Dangling counts from multiple documents are summed."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.side_effect = [
+            [{"tag": "gone-1", "start_char": 0, "end_char": 1}],
+            [{"tag": "gone-2", "start_char": 0, "end_char": 1}],
+        ]
+        docs = [_doc(), _doc()]
+
+        _documents, total_dangling = _build_export_documents(
+            docs, _ctx(crdt_doc=crdt, tag_name_map={})
+        )
+
+        assert total_dangling == 2
+
+    def test_untitled_document_falls_back_to_positional_title(self) -> None:
+        """A document with no title gets 'Source N' based on its position."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = []
+        docs = [_doc(title=None), _doc(title=None)]
+
+        documents, _total_dangling = _build_export_documents(docs, _ctx(crdt_doc=crdt))
+
+        assert documents[0]["title"] == "Source 1"
+        assert documents[1]["title"] == "Source 2"
+
+    def test_paragraph_map_keys_converted_to_int(self) -> None:
+        """String paragraph_map keys (as stored) become int keys in the payload."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = []
+        doc = _doc(paragraph_map={"0": 1, "12": 2})
+
+        documents, _total_dangling = _build_export_documents([doc], _ctx(crdt_doc=crdt))
+
+        assert documents[0]["word_to_legal_para"] == {0: 1, 12: 2}
+
+    def test_empty_paragraph_map_becomes_none(self) -> None:
+        """A falsy paragraph_map (None or {}) becomes None in the payload."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = []
+        doc = _doc(paragraph_map=None)
+
+        documents, _total_dangling = _build_export_documents([doc], _ctx(crdt_doc=crdt))
+
+        assert documents[0]["word_to_legal_para"] is None
+
+    def test_anonymises_highlights_when_anonymous(self) -> None:
+        """When is_anonymous is set, highlights are routed through anonymisation."""
+        crdt = MagicMock()
+        crdt.get_highlights_for_document.return_value = [
+            {"tag": "tag-1", "author": "Real Name", "user_id": "u1"}
+        ]
+        doc = _doc()
+
+        with patch(
+            "promptgrimoire.pages.annotation.pdf_export.anonymise_highlights"
+        ) as mock_anon:
+            mock_anon.return_value = [
+                {"tag": "tag-1", "author": "Anonymous 1", "user_id": "u1"}
+            ]
+            documents, _total_dangling = _build_export_documents(
+                [doc],
+                _ctx(
+                    crdt_doc=crdt,
+                    tag_name_map={"tag-1": "Jurisdiction"},
+                    is_anonymous=True,
+                    user_id="u1",
+                ),
+            )
+
+        mock_anon.assert_called_once()
+        assert documents[0]["highlights"][0]["author"] == "Anonymous 1"

--- a/tests/unit/pages/test_tag_management.py
+++ b/tests/unit/pages/test_tag_management.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from unittest.mock import AsyncMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -104,3 +104,85 @@ class TestBuildGroupCallbacks:
         )
         render_tag_list.assert_not_awaited()
         mock_logger.exception.assert_not_called()
+
+
+class TestReorderedGroupForMove:
+    """Pure helper extracted from ``_move_tag`` (cognitive-complexity split).
+
+    Computes the new tag ordering for a move-up/move-down button click
+    without touching the DB or CRDT -- ``_move_tag`` applies the result.
+    """
+
+    def test_move_up_within_group(self) -> None:
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        a, b, c = uuid4(), uuid4(), uuid4()
+        tag_id_lists = {None: [a, b, c]}
+
+        result = _reordered_group_for_move(b, tag_id_lists, -1)
+
+        assert result == [b, a, c]
+
+    def test_move_down_within_group(self) -> None:
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        a, b, c = uuid4(), uuid4(), uuid4()
+        tag_id_lists = {None: [a, b, c]}
+
+        result = _reordered_group_for_move(b, tag_id_lists, 1)
+
+        assert result == [a, c, b]
+
+    def test_move_up_at_top_is_noop(self) -> None:
+        """Moving the first tag up would go out of bounds -- returns None."""
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        a, b = uuid4(), uuid4()
+        tag_id_lists = {None: [a, b]}
+
+        assert _reordered_group_for_move(a, tag_id_lists, -1) is None
+
+    def test_move_down_at_bottom_is_noop(self) -> None:
+        """Moving the last tag down would go out of bounds -- returns None."""
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        a, b = uuid4(), uuid4()
+        tag_id_lists = {None: [a, b]}
+
+        assert _reordered_group_for_move(b, tag_id_lists, 1) is None
+
+    def test_tag_not_found_returns_none(self) -> None:
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        a, b = uuid4(), uuid4()
+        tag_id_lists = {None: [a]}
+
+        assert _reordered_group_for_move(b, tag_id_lists, 1) is None
+
+    def test_finds_tag_in_its_own_group_not_the_first(self) -> None:
+        """With multiple groups, the tag's own group is used, not group 0."""
+        from promptgrimoire.pages.annotation.tag_management import (
+            _reordered_group_for_move,
+        )
+
+        group1_id, group2_id = uuid4(), uuid4()
+        a, b = uuid4(), uuid4()
+        c, d = uuid4(), uuid4()
+        tag_id_lists: dict[UUID | None, list[UUID]] = {
+            group1_id: [a, b],
+            group2_id: [c, d],
+        }
+
+        result = _reordered_group_for_move(d, tag_id_lists, -1)
+
+        assert result == [d, c]

--- a/tests/unit/pages/test_tag_management_save.py
+++ b/tests/unit/pages/test_tag_management_save.py
@@ -160,14 +160,13 @@ class TestCreateTagOrNotify:
     @pytest.mark.asyncio
     async def test_duplicate_name_shows_warning_not_generic_failure(self) -> None:
         """DuplicateNameError should show warning UI and avoid exception logging."""
-        from types import SimpleNamespace
-
         from promptgrimoire.db.tags import DuplicateNameError
+        from promptgrimoire.pages.annotation import PageState
         from promptgrimoire.pages.annotation.tag_management_save import (
             _create_tag_or_notify,
         )
 
-        state = SimpleNamespace(workspace_id=uuid4(), crdt_doc=None)
+        state = PageState(workspace_id=uuid4())
         create_tag = AsyncMock(
             side_effect=DuplicateNameError(
                 "A tag named 'Evidence' already exists in this workspace"
@@ -182,7 +181,7 @@ class TestCreateTagOrNotify:
         ):
             result = await _create_tag_or_notify(
                 create_tag,
-                state,  # type: ignore[arg-type]  # SimpleNamespace stub for PageState
+                state,
                 "Evidence",
                 "#1f77b4",
                 None,

--- a/tests/unit/pages/test_text_selection_validation.py
+++ b/tests/unit/pages/test_text_selection_validation.py
@@ -1,0 +1,70 @@
+"""Unit tests for the pure selection-event validation logic in text_selection.py.
+
+_validate_selection_args was extracted from the text_selected event handler
+to bring text_selection_demo_page's cognitive complexity under the project
+threshold. It is pure (no NiceGUI/UI side effects), so it is unit-testable
+in isolation.
+"""
+
+from __future__ import annotations
+
+from promptgrimoire.pages.text_selection import (
+    MAX_DISPLAY_LENGTH,
+    _validate_selection_args,
+)
+
+
+class TestValidateSelectionArgs:
+    """Tests for _validate_selection_args."""
+
+    def test_valid_short_selection_returns_quoted_display(self) -> None:
+        """A short valid selection returns the parsed tuple with a quoted display."""
+        result = _validate_selection_args("hello", 0, 5)
+        assert result == ("hello", 0, 5, '"hello"')
+
+    def test_long_text_is_truncated_in_display(self) -> None:
+        """Text longer than MAX_DISPLAY_LENGTH is truncated with an ellipsis."""
+        text = "x" * (MAX_DISPLAY_LENGTH + 10)
+        result = _validate_selection_args(text, 0, len(text))
+        assert result is not None
+        _text, _start, _end, display = result
+        assert display == f'"{text[:MAX_DISPLAY_LENGTH]}..."'
+
+    def test_text_at_exact_max_length_is_not_truncated(self) -> None:
+        """Text exactly MAX_DISPLAY_LENGTH long is shown in full."""
+        text = "x" * MAX_DISPLAY_LENGTH
+        result = _validate_selection_args(text, 0, len(text))
+        assert result is not None
+        assert result[3] == f'"{text}"'
+
+    def test_non_string_text_is_rejected(self) -> None:
+        """A non-str text argument (unexpected client payload) is rejected."""
+        assert _validate_selection_args(123, 0, 3) is None
+
+    def test_non_int_start_is_rejected(self) -> None:
+        """A non-int start argument is rejected."""
+        assert _validate_selection_args("hi", "0", 2) is None
+
+    def test_non_int_end_is_rejected(self) -> None:
+        """A non-int end argument is rejected."""
+        assert _validate_selection_args("hi", 0, "2") is None
+
+    def test_negative_start_is_rejected(self) -> None:
+        """A negative start offset is rejected."""
+        assert _validate_selection_args("hi", -1, 2) is None
+
+    def test_negative_end_is_rejected(self) -> None:
+        """A negative end offset is rejected."""
+        assert _validate_selection_args("hi", 0, -1) is None
+
+    def test_start_after_end_is_rejected(self) -> None:
+        """An inverted range (start > end) is rejected."""
+        assert _validate_selection_args("hi", 5, 2) is None
+
+    def test_empty_text_is_rejected(self) -> None:
+        """Empty selected text is rejected even with a valid range."""
+        assert _validate_selection_args("", 0, 0) is None
+
+    def test_start_equals_end_is_accepted(self) -> None:
+        """A zero-width but non-inverted range (start == end) is accepted."""
+        assert _validate_selection_args("a", 3, 3) == ("a", 3, 3, '"a"')

--- a/tests/unit/scripts/test_analyse_fixture.py
+++ b/tests/unit/scripts/test_analyse_fixture.py
@@ -1,0 +1,52 @@
+"""Tests for scripts/analyse_fixture.py fixture resolution.
+
+Covers ``_load_fixture``'s three resolution strategies -- direct path, exact
+name match, and unique substring match -- after decomposing it into smaller
+helpers (see ``docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md``).
+"""
+
+from __future__ import annotations
+
+import gzip
+from typing import TYPE_CHECKING
+
+from scripts import analyse_fixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_load_fixture_resolves_path_name_and_substring(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Synthetic input -> (display_name, html_content) shape for each path."""
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    monkeypatch.setattr(analyse_fixture, "FIXTURES_DIR", fixtures_dir)
+
+    plain = fixtures_dir / "alpha_debug.html"
+    plain.write_text("<p>alpha content</p>", encoding="utf-8")
+
+    gz_path = fixtures_dir / "beta_debug.html.gz"
+    with gzip.open(gz_path, "wt", encoding="utf-8") as f:
+        f.write("<p>beta content</p>")
+
+    # Exact name match, plain HTML.
+    name, html = analyse_fixture._load_fixture("alpha_debug")
+    assert (name, html) == ("alpha_debug", "<p>alpha content</p>")
+
+    # Exact name match, gzip-compressed -- transparent decompression.
+    name, html = analyse_fixture._load_fixture("beta_debug")
+    assert (name, html) == ("beta_debug", "<p>beta content</p>")
+
+    # Unique substring match.
+    name, html = analyse_fixture._load_fixture("alpha")
+    assert (name, html) == ("alpha_debug", "<p>alpha content</p>")
+
+    # Direct filesystem path, outside FIXTURES_DIR entirely.
+    direct = tmp_path / "elsewhere.html"
+    direct.write_text("<p>direct content</p>", encoding="utf-8")
+    name, html = analyse_fixture._load_fixture(str(direct))
+    assert (name, html) == ("elsewhere", "<p>direct content</p>")

--- a/tests/unit/scripts/test_jsonl_to_md.py
+++ b/tests/unit/scripts/test_jsonl_to_md.py
@@ -1,0 +1,61 @@
+"""Tests for scripts/jsonl_to_md.py transcript conversion.
+
+Covers ``convert_jsonl_to_md`` after decomposing it into ``_parse_jsonl_line``
+and ``_record_to_markdown_section`` (see
+``docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.jsonl_to_md import convert_jsonl_to_md
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_convert_jsonl_to_md_synthetic_transcript(tmp_path: Path) -> None:
+    """Synthetic input -> markdown shape: heading, roles, and skip rules."""
+    records = [
+        # Blank line and malformed JSON are both skipped, not errors.
+        "",
+        "{not valid json",
+        # Non-message record type is skipped.
+        json.dumps({"type": "progress", "message": {"role": "user"}}),
+        # Simple string-content user turn.
+        json.dumps(
+            {"type": "user", "message": {"role": "user", "content": "hello there"}}
+        ),
+        # List-content assistant turn with a text block and a tool_use block.
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "checking the file"},
+                        {
+                            "type": "tool_use",
+                            "name": "Read",
+                            "input": {"file_path": "foo.py"},
+                        },
+                    ],
+                },
+            }
+        ),
+        # Content that renders to empty text is skipped.
+        json.dumps({"type": "user", "message": {"role": "user", "content": "   "}}),
+    ]
+    jsonl_path = tmp_path / "transcript.jsonl"
+    jsonl_path.write_text("\n".join(records) + "\n", encoding="utf-8")
+
+    md = convert_jsonl_to_md(jsonl_path)
+
+    assert md.startswith("# Conversation: transcript\n")
+    assert "## User\n\nhello there\n" in md
+    assert "## Assistant\n\nchecking the file" in md
+    assert "**Tool: Read** `foo.py`" in md
+    assert md.count("## User") == 1
+    assert md.count("## Assistant") == 1

--- a/tests/unit/scripts/test_profile_workspace.py
+++ b/tests/unit/scripts/test_profile_workspace.py
@@ -1,0 +1,30 @@
+"""Tests for scripts/profile_workspace.py's pure statistics helper.
+
+``_compute_stats`` is the one function in this Playwright-driven profiling
+script that has no browser/server dependency, so it's the only part
+covered here. It backs the ``_MIN_VALUES_FOR_STDEV`` threshold introduced
+when naming the PLR2004 magic value (see
+``docs/design-plans/2026-04-23-ty-sa-typing-cleanup.md``).
+"""
+
+from __future__ import annotations
+
+from scripts.profile_workspace import _compute_stats
+
+
+def test_compute_stats_omits_stdev_below_threshold() -> None:
+    """A single value has no stdev; two or more values do."""
+    single = _compute_stats([42.0])
+    assert single["count"] == 1
+    assert single["mean"] == 42.0
+    assert "stdev" not in single
+
+    pair = _compute_stats([10.0, 20.0])
+    assert pair["count"] == 2
+    assert pair["mean"] == 15.0
+    assert pair["stdev"] == 7.1
+
+
+def test_compute_stats_empty_input() -> None:
+    """Empty input yields an empty stats dict, not an error."""
+    assert _compute_stats([]) == {}

--- a/tests/unit/test_cli_e2e_runner.py
+++ b/tests/unit/test_cli_e2e_runner.py
@@ -514,7 +514,7 @@ def test_run_serial_playwright_e2e_selects_only_playwright_path(
     patch_serial_playwright_infra: None,  # noqa: ARG001 - fixture side effects
 ) -> None:
     """Serial Playwright lane uses `tests/e2e` path boundary, never NiceGUI marker."""
-    from promptgrimoire.cli.e2e import _run_serial_playwright_e2e
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, _run_serial_playwright_e2e
 
     captured: dict[str, Any] = {}
 
@@ -536,7 +536,7 @@ def test_run_serial_playwright_e2e_selects_only_playwright_path(
     try:
         exit_code = _run_serial_playwright_e2e(
             ["-k", "test_annotation_nav_home_navigates_to_navigator"],
-            use_pyspy=False,
+            PlaywrightRunOptions(use_pyspy=False),
         )
     finally:
         os.environ.pop("E2E_BASE_URL", None)
@@ -554,7 +554,7 @@ def test_shared_playwright_marks_concurrent_workers(
     patch_serial_playwright_infra: None,  # noqa: ARG001 - fixture side effects
 ) -> None:
     """Concurrent workers must not run the destructive global cleanup fixture."""
-    from promptgrimoire.cli.e2e import _run_shared_playwright_e2e
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, _run_shared_playwright_e2e
 
     observed: list[str | None] = []
 
@@ -564,7 +564,9 @@ def test_shared_playwright_marks_concurrent_workers(
 
     monkeypatch.setattr("promptgrimoire.cli.e2e._run_pytest", _fake_run_pytest)
 
-    _run_shared_playwright_e2e([], use_pyspy=False, worker_count=4)
+    _run_shared_playwright_e2e(
+        [], PlaywrightRunOptions(use_pyspy=False, worker_count=4)
+    )
 
     assert observed == ["1"]
     assert "E2E_SHARED_SERVER" not in os.environ
@@ -574,7 +576,7 @@ def test_parallel_playwright_reserves_cpu_for_shared_services(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Four available CPUs yield two clients, leaving capacity for shared I/O."""
-    from promptgrimoire.cli.e2e import run_playwright_lane
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, run_playwright_lane
 
     captured: dict[str, int] = {}
 
@@ -589,16 +591,12 @@ def test_parallel_playwright_reserves_cpu_for_shared_services(
 
     def _capture_worker_count(
         _args: list[str],
-        *,
-        use_pyspy: bool,
-        worker_count: int,
-        fail_fast: bool,
-        browser: str | None,
+        options: PlaywrightRunOptions,
     ) -> int:
-        assert use_pyspy is False
-        assert fail_fast is False
-        assert browser == "chromium"
-        captured["worker_count"] = worker_count
+        assert options.use_pyspy is False
+        assert options.fail_fast is False
+        assert options.browser == "chromium"
+        captured["worker_count"] = options.worker_count
         return 0
 
     monkeypatch.setattr(
@@ -860,7 +858,7 @@ def test_run_slow_lanes_runs_all_lanes_then_latexmk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Slow lane runs all standard lanes first, then latexmk-specific lanes."""
-    from promptgrimoire.cli.e2e import run_slow_lanes
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, run_slow_lanes
     from promptgrimoire.cli.e2e._lanes import LaneResult
 
     captured: dict[str, object] = {}
@@ -871,17 +869,13 @@ def test_run_slow_lanes_runs_all_lanes_then_latexmk(
 
     def _fake_playwright(
         extra_args: list[str],
-        *,
-        use_pyspy: bool,
-        marker_expr: str,
-        test_timeout: int | None = None,
-        log_file: Path | None = None,
+        options: PlaywrightRunOptions,
     ) -> int:
         captured["playwright_args"] = extra_args
-        captured["playwright_use_pyspy"] = use_pyspy
-        captured["playwright_test_timeout"] = test_timeout
-        captured["playwright_marker_expr"] = marker_expr
-        captured["playwright_log_file"] = log_file
+        captured["playwright_use_pyspy"] = options.use_pyspy
+        captured["playwright_test_timeout"] = options.test_timeout
+        captured["playwright_marker_expr"] = options.marker_expr
+        captured["playwright_log_file"] = options.log_file
         captured["e2e_skip_latexmk"] = os.environ["E2E_SKIP_LATEXMK"]
         return 0
 
@@ -1221,7 +1215,7 @@ def test_serial_playwright_includes_browser_flag(
     patch_serial_playwright_infra: None,  # noqa: ARG001 - fixture side effects
 ) -> None:
     """Serial mode inserts --browser into default_args when specified."""
-    from promptgrimoire.cli.e2e import _run_serial_playwright_e2e
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, _run_serial_playwright_e2e
 
     captured: dict[str, Any] = {}
 
@@ -1239,7 +1233,9 @@ def test_serial_playwright_includes_browser_flag(
     monkeypatch.setattr("promptgrimoire.cli.e2e._run_pytest", _fake_run_pytest)
 
     try:
-        _run_serial_playwright_e2e([], use_pyspy=False, browser="firefox")
+        _run_serial_playwright_e2e(
+            [], PlaywrightRunOptions(use_pyspy=False, browser="firefox")
+        )
     finally:
         os.environ.pop("E2E_BASE_URL", None)
 
@@ -1253,7 +1249,7 @@ def test_serial_playwright_omits_browser_flag_by_default(
     patch_serial_playwright_infra: None,  # noqa: ARG001 - fixture side effects
 ) -> None:
     """Serial mode without browser param produces no --browser flag."""
-    from promptgrimoire.cli.e2e import _run_serial_playwright_e2e
+    from promptgrimoire.cli.e2e import PlaywrightRunOptions, _run_serial_playwright_e2e
 
     captured: dict[str, Any] = {}
 
@@ -1271,7 +1267,7 @@ def test_serial_playwright_omits_browser_flag_by_default(
     monkeypatch.setattr("promptgrimoire.cli.e2e._run_pytest", _fake_run_pytest)
 
     try:
-        _run_serial_playwright_e2e([], use_pyspy=False)
+        _run_serial_playwright_e2e([], PlaywrightRunOptions(use_pyspy=False))
     finally:
         os.environ.pop("E2E_BASE_URL", None)
 

--- a/tests/unit/test_cli_parallel.py
+++ b/tests/unit/test_cli_parallel.py
@@ -308,6 +308,7 @@ async def test_finalise_parallel_results_keeps_initial_failure_red(
     """A passing diagnostic retry never rescues the initial failure."""
     from promptgrimoire.cli.e2e import _parallel
     from promptgrimoire.cli.e2e._lanes import PLAYWRIGHT_LANE, WorkerResult
+    from promptgrimoire.cli.e2e._parallel import LaneRunContext, SourceDatabase
 
     run_dir = tmp_path / "run"
     run_dir.mkdir()
@@ -333,15 +334,16 @@ async def test_finalise_parallel_results_keeps_initial_failure_red(
         _parallel, "_merge_junit_xml", lambda _run_dir: _run_dir / "combined.xml"
     )
 
+    ctx = LaneRunContext(lane=PLAYWRIGHT_LANE, worker=_unused_worker, user_args=[])
+    source_db = SourceDatabase(
+        url="postgresql+asyncpg://user:pass@localhost/test_db", name="test_db"
+    )
     all_passed, had_flaky = await _parallel._finalise_parallel_results(
-        PLAYWRIGHT_LANE,
-        _unused_worker,
+        ctx,
         [failed_result],
         0.0,
-        "postgresql+asyncpg://user:pass@localhost/test_db",
-        "test_db",
+        source_db,
         run_dir,
-        [],
     )
 
     assert all_passed is False
@@ -356,6 +358,7 @@ async def test_finalise_parallel_results_keeps_cancelled_workers_as_failure(
     """Cancelled workers are not retried and keep the lane in a failing state."""
     from promptgrimoire.cli.e2e import _parallel
     from promptgrimoire.cli.e2e._lanes import PLAYWRIGHT_LANE, WorkerResult
+    from promptgrimoire.cli.e2e._parallel import LaneRunContext, SourceDatabase
 
     run_dir = tmp_path / "run"
     run_dir.mkdir()
@@ -387,15 +390,16 @@ async def test_finalise_parallel_results_keeps_cancelled_workers_as_failure(
         _parallel, "_merge_junit_xml", lambda _run_dir: _run_dir / "combined.xml"
     )
 
+    ctx = LaneRunContext(lane=PLAYWRIGHT_LANE, worker=_unused_worker, user_args=[])
+    source_db = SourceDatabase(
+        url="postgresql+asyncpg://user:pass@localhost/test_db", name="test_db"
+    )
     all_passed, had_flaky = await _parallel._finalise_parallel_results(
-        PLAYWRIGHT_LANE,
-        _unused_worker,
+        ctx,
         [failed_result, cancelled_result],
         0.0,
-        "postgresql+asyncpg://user:pass@localhost/test_db",
-        "test_db",
+        source_db,
         run_dir,
-        [],
     )
 
     assert all_passed is False
@@ -410,6 +414,7 @@ async def test_finalise_parallel_results_forwards_browser_to_retry(
     """browser= must reach _retry_parallel_failures."""
     from promptgrimoire.cli.e2e import _parallel
     from promptgrimoire.cli.e2e._lanes import PLAYWRIGHT_LANE, WorkerResult
+    from promptgrimoire.cli.e2e._parallel import LaneRunContext, SourceDatabase
 
     run_dir = tmp_path / "run"
     run_dir.mkdir()
@@ -423,17 +428,12 @@ async def test_finalise_parallel_results_forwards_browser_to_retry(
     captured_browser: list[str | None] = []
 
     async def _spy_retry(
-        _lane: object,
-        _worker: object,
+        ctx: LaneRunContext,
         _failed: object,
-        _db_url: object,
         _src_db: object,
         _run_dir: object,
-        _user_args: object,
-        *,
-        browser: str | None = None,
     ) -> tuple[list[Path], list[Path]]:
-        captured_browser.append(browser)
+        captured_browser.append(ctx.browser)
         return [], [failed_result.file]
 
     async def _unused_worker(
@@ -454,16 +454,18 @@ async def test_finalise_parallel_results_forwards_browser_to_retry(
         lambda _run_dir: _run_dir / "combined.xml",
     )
 
+    ctx = LaneRunContext(
+        lane=PLAYWRIGHT_LANE, worker=_unused_worker, user_args=[], browser="firefox"
+    )
+    source_db = SourceDatabase(
+        url="postgresql+asyncpg://user:pass@localhost/test_db", name="test_db"
+    )
     await _parallel._finalise_parallel_results(
-        PLAYWRIGHT_LANE,
-        _unused_worker,
+        ctx,
         [failed_result],
         0.0,
-        "postgresql+asyncpg://user:pass@localhost/test_db",
-        "test_db",
+        source_db,
         run_dir,
-        [],
-        browser="firefox",
     )
 
     assert captured_browser == ["firefox"], (

--- a/tests/unit/test_cli_testing.py
+++ b/tests/unit/test_cli_testing.py
@@ -403,65 +403,62 @@ class TestDispatchProgressLine:
     """_dispatch_progress_line routes lines through collecting/running/summary."""
 
     def test_summary_phase_passthrough(self, capsys) -> None:
+        from typing import cast
         from unittest.mock import MagicMock
 
-        from rich.progress import TaskID
+        from rich.progress import Progress, TaskID
 
-        from promptgrimoire.cli.testing import _dispatch_progress_line
+        from promptgrimoire.cli.testing import _dispatch_progress_line, _ProgressState
 
-        progress = MagicMock()
-        phase, _count, _done = _dispatch_progress_line(
+        progress = cast("Progress", MagicMock())
+        state = _dispatch_progress_line(
             "summary line",
             "summary line\n",
-            "summary",
-            None,
-            0,
+            _ProgressState("summary", None, 0),
             progress,
             TaskID(0),
         )
-        assert phase == "summary"
+        assert state.phase == "summary"
         out = capsys.readouterr().out
         assert "summary line" in out
 
     def test_collecting_to_running_transition(self) -> None:
+        from typing import cast
         from unittest.mock import MagicMock
 
-        from rich.progress import TaskID
+        from rich.progress import Progress, TaskID
 
-        from promptgrimoire.cli.testing import _dispatch_progress_line
+        from promptgrimoire.cli.testing import _dispatch_progress_line, _ProgressState
 
-        progress = MagicMock()
-        phase, count, _done = _dispatch_progress_line(
+        progress = cast("Progress", MagicMock())
+        state = _dispatch_progress_line(
             "collected 42 items",
             "collected 42 items\n",
-            "collecting",
-            None,
-            0,
+            _ProgressState("collecting", None, 0),
             progress,
             TaskID(0),
         )
-        assert phase == "running"
-        assert count == 42
+        assert state.phase == "running"
+        assert state.count == 42
 
     def test_running_to_summary_transition(self) -> None:
+        from typing import cast
         from unittest.mock import MagicMock
 
-        from rich.progress import TaskID
+        from rich.progress import Progress, TaskID
 
-        from promptgrimoire.cli.testing import _dispatch_progress_line
+        from promptgrimoire.cli.testing import _dispatch_progress_line, _ProgressState
 
-        progress = MagicMock()
-        phase, _count, _done = _dispatch_progress_line(
+        progress = cast("Progress", MagicMock())
+        state = _dispatch_progress_line(
             "=" * 20,
             "=" * 20 + "\n",
-            "running",
-            10,
-            5,
+            _ProgressState("running", 10, 5),
             progress,
             TaskID(0),
         )
-        assert phase == "summary"
-        progress.stop.assert_called_once()
+        assert state.phase == "summary"
+        cast("MagicMock", progress).stop.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_guide.py
+++ b/tests/unit/test_docs_guide.py
@@ -20,6 +20,7 @@ import pytest
 from promptgrimoire.docs.guide import Guide
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from pathlib import Path
 
 _CAPTURE_PATCH = "promptgrimoire.docs.guide.capture_screenshot"
@@ -35,7 +36,7 @@ class TestGuideContextManager:
     """Tests for the Guide context manager."""
 
     @pytest.fixture(autouse=True)
-    def _mock_thumbnail(self) -> None:  # type: ignore[override]
+    def _mock_thumbnail(self) -> Generator[None]:
         """Auto-mock generate_thumbnail for all tests."""
         with patch(_THUMBNAIL_PATCH):
             yield

--- a/tests/unit/test_e2e_anti_patterns.py
+++ b/tests/unit/test_e2e_anti_patterns.py
@@ -96,7 +96,10 @@ def _collect_violations_from_files(
             desc = checker(node)
             if desc is None or not hasattr(node, "lineno"):
                 continue
-            lineno: int = node.lineno  # type: ignore[union-attr]
+            # ast.walk() yields the base ast.AST type, which has no lineno
+            # attribute -- hasattr() above confirms it exists at runtime for
+            # this node, so getattr() (typed Any) reads it precisely.
+            lineno: int = getattr(node, "lineno")  # noqa: B009
             if not _has_noqa(source_lines, lineno, noqa_code):
                 rel = py_file.relative_to(_REPO_ROOT)
                 violations.append(f"{rel}:{lineno} - {desc}")
@@ -614,7 +617,11 @@ def test_no_unguarded_network_calls_in_unit_tests() -> None:
                     continue
                 if not hasattr(child, "lineno"):
                     continue
-                lineno: int = child.lineno  # type: ignore[assignment]  # AST node has int lineno at runtime
+                # ast.walk() yields the base ast.AST type, which has no
+                # lineno attribute -- hasattr() above confirms it exists at
+                # runtime for this node, so getattr() (typed Any) reads it
+                # precisely.
+                lineno: int = getattr(child, "lineno")  # noqa: B009
                 if _has_noqa(source_lines, lineno, "PG006"):
                     continue
                 rel = py_file.relative_to(_REPO_ROOT)

--- a/tests/unit/test_engine_nullpool.py
+++ b/tests/unit/test_engine_nullpool.py
@@ -8,7 +8,7 @@ Verifies:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 from sqlalchemy.pool import NullPool
@@ -19,12 +19,21 @@ if TYPE_CHECKING:
     import pytest
 
 
+def _dummy_creator() -> Any:
+    """Stand in for a DBAPI connection factory.
+
+    Never actually invoked: these tests only inspect ``NullPool``'s type
+    and status output, never call ``.connect()`` on it.
+    """
+    return None
+
+
 class TestPoolStatusWithNullPool:
     """infra-split.AC2.3: _pool_status() does not error with NullPool."""
 
     def test_pool_status_nullpool_returns_question_marks(self) -> None:
         """NullPool lacks size/checkedin/etc — _pool_status returns '?' values."""
-        pool = NullPool(creator=lambda: None)
+        pool = NullPool(creator=_dummy_creator)
         result = _pool_status(pool)
         assert "size=?" in result
         assert "checked_in=?" in result
@@ -46,7 +55,7 @@ class TestInitDbPoolSelection:
         captured_kwargs: dict[str, object] = {}
 
         mock_engine = AsyncMock()
-        mock_engine.sync_engine.pool = NullPool(creator=lambda: None)
+        mock_engine.sync_engine.pool = NullPool(creator=_dummy_creator)
 
         def fake_create_async_engine(_url: str, **kwargs: object) -> AsyncMock:
             captured_kwargs.update(kwargs)

--- a/tests/unit/test_enrol_upload_handler.py
+++ b/tests/unit/test_enrol_upload_handler.py
@@ -35,6 +35,7 @@ def _make_upload_event(data: bytes = b"fake xlsx") -> MagicMock:
 
 
 def _make_enrolment_report(
+    *,
     entries_processed: int = 2,
     users_created: int = 1,
     users_existing: int = 1,

--- a/tests/unit/test_epoch_enrichment.py
+++ b/tests/unit/test_epoch_enrichment.py
@@ -76,6 +76,7 @@ def _insert_journal(
 def _insert_github(
     conn: sqlite3.Connection,
     ts_utc: str,
+    *,
     pr_number: int,
     title: str,
     author: str,

--- a/tests/unit/test_github_fetcher.py
+++ b/tests/unit/test_github_fetcher.py
@@ -89,6 +89,7 @@ class TestFetchGithubPrs:
         title: str,
         merged_at: str | None,
         updated_at: str,
+        *,
         user: str = "alice",
         merge_commit_sha: str = "abc123",
         html_url: str = "https://github.com/org/repo/pull/1",

--- a/tests/unit/test_grimoire_test_partition.py
+++ b/tests/unit/test_grimoire_test_partition.py
@@ -1,0 +1,45 @@
+"""Per-lane partitioning of `grimoire test run` arguments.
+
+Regression guard for the mixed-lane silent-drop bug: the old first-match-wins
+classifier routed a mixed invocation down one lane and that lane's runner
+silently discarded the foreign paths (false-green, hit independently by two
+agents on 2026-08-17). Paths must be classified individually, and option
+values (`-k foo`) must stay with the flags rather than being mistaken for
+paths.
+"""
+
+from promptgrimoire.cli.testing import _partition_test_args
+
+
+class TestPartitionTestArgs:
+    def test_mixed_invocation_splits_per_lane(self) -> None:
+        lanes, flags = _partition_test_args(
+            [
+                "tests/integration/test_a.py",
+                "tests/integration/test_page_load_query_count.py",
+                "tests/e2e/test_b.py",
+                "-x",
+            ]
+        )
+        assert lanes["unit"] == ["tests/integration/test_a.py"]
+        assert lanes["nicegui"] == ["tests/integration/test_page_load_query_count.py"]
+        assert lanes["e2e"] == ["tests/e2e/test_b.py"]
+        assert flags == ["-x"]
+
+    def test_option_values_stay_with_flags_in_order(self) -> None:
+        _, flags = _partition_test_args(["-k", "foo", "-m", "blns"])
+        assert flags == ["-k", "foo", "-m", "blns"]
+
+    def test_node_ids_and_directories_are_paths(self) -> None:
+        lanes, _ = _partition_test_args(
+            ["tests/unit/test_x.py::TestC::test_m", "tests/integration/"]
+        )
+        assert lanes["unit"] == [
+            "tests/unit/test_x.py::TestC::test_m",
+            "tests/integration/",
+        ]
+
+    def test_bare_invocation_yields_empty_lanes(self) -> None:
+        lanes, flags = _partition_test_args([])
+        assert lanes == {"e2e": [], "nicegui": [], "unit": []}
+        assert flags == []

--- a/tests/unit/test_help_config.py
+++ b/tests/unit/test_help_config.py
@@ -8,6 +8,8 @@ Verifies:
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 from pydantic import ValidationError
 
@@ -133,4 +135,4 @@ class TestHelpConfigAlgoliaValidation:
     def test_invalid_backend_raises_validation_error(self) -> None:
         """Invalid help_backend value raises ValidationError."""
         with pytest.raises(ValidationError, match="help_backend"):
-            HelpConfig(help_backend="invalid")  # type: ignore[arg-type]
+            HelpConfig(help_backend=cast("Any", "invalid"))

--- a/tests/unit/test_html_normaliser.py
+++ b/tests/unit/test_html_normaliser.py
@@ -1,6 +1,9 @@
 """Tests for HTML normaliser that wraps styled <p> tags for Pandoc."""
 
-from promptgrimoire.export.html_normaliser import normalise_styled_paragraphs
+from promptgrimoire.export.html_normaliser import (
+    normalise_styled_paragraphs,
+    strip_scripts_and_styles,
+)
 
 
 class TestNormaliseStyledParagraphs:
@@ -139,3 +142,73 @@ class TestNormaliseStyledParagraphs:
         assert 'lang="en-AU"' in result
         # Content should be preserved
         assert "(a) the injured person; or" in result
+
+
+class TestStripScriptsAndStyles:
+    """Characterisation tests for strip_scripts_and_styles, written before
+    decomposing it -- it previously had no dedicated coverage of the
+    script/style/noscript removal, tail-text preservation, or event-handler
+    stripping branches that drive most of its cognitive complexity.
+    """
+
+    def test_removes_script_and_content(self):
+        html = "<div><p>keep</p><script>alert(1)</script></div>"
+        result = strip_scripts_and_styles(html)
+        assert "<script" not in result
+        assert "alert" not in result
+        assert "<p>keep</p>" in result
+
+    def test_removes_style_and_content(self):
+        html = "<div><style>.x{color:red}</style><p>keep</p></div>"
+        result = strip_scripts_and_styles(html)
+        assert "<style" not in result
+        assert "color:red" not in result
+        assert "<p>keep</p>" in result
+
+    def test_removes_noscript_and_content(self):
+        html = "<div><noscript>fallback text</noscript><p>keep</p></div>"
+        result = strip_scripts_and_styles(html)
+        assert "<noscript" not in result
+        assert "fallback text" not in result
+        assert "<p>keep</p>" in result
+
+    def test_tail_text_preserved_with_no_previous_sibling(self):
+        """Text after the removed element, with no preceding sibling,
+        is reattached to the parent's own text (parent.text branch)."""
+        html = "<div><script>alert(1)</script>after</div>"
+        result = strip_scripts_and_styles(html)
+        assert result == "<div>after</div>"
+
+    def test_tail_text_preserved_with_previous_sibling(self):
+        """Text after the removed element, with a preceding sibling,
+        is reattached to that sibling's tail (prev.tail branch)."""
+        html = "<div><p>before</p><script>alert(1)</script>after</div>"
+        result = strip_scripts_and_styles(html)
+        assert result == "<div><p>before</p>after</div>"
+
+    def test_removes_inline_event_handlers_case_insensitively(self):
+        html = '<button onclick="doThing()" ONLOAD="x()" class="btn">Click</button>'
+        result = strip_scripts_and_styles(html)
+        assert "onclick" not in result.lower()
+        assert "onload" not in result.lower()
+        assert 'class="btn"' in result
+
+    def test_preserves_non_event_attributes(self):
+        html = '<a href="https://example.com" title="ok">link</a>'
+        result = strip_scripts_and_styles(html)
+        assert 'href="https://example.com"' in result
+        assert 'title="ok"' in result
+
+    def test_empty_string_passthrough(self):
+        assert strip_scripts_and_styles("") == ""
+
+    def test_whitespace_only_passthrough(self):
+        assert strip_scripts_and_styles("   ") == "   "
+
+    def test_parse_failure_falls_back_to_regex(self):
+        """A document lxml cannot parse at all (e.g. a lone HTML comment,
+        which lxml.html.fromstring rejects with 'Document is empty') falls
+        back to the regex-based stripper rather than raising."""
+        html = "<!-- just a comment -->"
+        result = strip_scripts_and_styles(html)
+        assert result == html

--- a/tests/unit/test_loadtest_pure_helpers.py
+++ b/tests/unit/test_loadtest_pure_helpers.py
@@ -1,0 +1,111 @@
+"""Unit tests for pure (non-DB) helpers extracted from cli_loadtest.py.
+
+_build_course_students_map and _report_seeding_progress were pulled out of
+_seed_acl_shares and _seed_student_workspaces during the ty-bump complexity
+cleanup (both functions were flagged over the complexity-15 threshold).
+Neither touches the database, so these are ordinary unit tests rather than
+the DB-backed integration tests the other extracted helpers need.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from promptgrimoire.cli_loadtest import (
+    _build_course_students_map,
+    _report_seeding_progress,
+)
+from promptgrimoire.db.models import Course, User
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _make_user(name: str) -> User:
+    """An unsaved User instance -- construction only, no DB I/O."""
+    return User(id=uuid4(), email=f"{name}@test.local", display_name=name)
+
+
+def _make_course(code: str) -> Course:
+    """An unsaved Course instance -- construction only, no DB I/O."""
+    return Course(id=uuid4(), code=code, name=code, semester="2026-S1")
+
+
+class TestBuildCourseStudentsMap:
+    """Maps course_id -> enrolled student Users from the raw enrollment data."""
+
+    def test_groups_students_by_every_enrolled_course(self) -> None:
+        alice, bob = _make_user("alice"), _make_user("bob")
+        course_a, course_b = _make_course("A"), _make_course("B")
+
+        result = _build_course_students_map(
+            all_students={"alice@test.local": alice, "bob@test.local": bob},
+            student_courses={
+                "alice@test.local": ["A", "B"],
+                "bob@test.local": ["A"],
+            },
+            courses={"A": course_a, "B": course_b},
+        )
+
+        assert result[course_a.id] == [alice, bob]
+        assert result[course_b.id] == [alice]
+
+    def test_course_code_not_in_courses_mapping_is_skipped(self) -> None:
+        """A stale/unknown course code must not raise or appear in the result."""
+        alice = _make_user("alice")
+
+        result = _build_course_students_map(
+            all_students={"alice@test.local": alice},
+            student_courses={"alice@test.local": ["UNKNOWN"]},
+            courses={},
+        )
+
+        assert result == {}
+
+    def test_no_students_produces_empty_map(self) -> None:
+        result = _build_course_students_map(
+            all_students={}, student_courses={}, courses={}
+        )
+
+        assert result == {}
+
+
+class TestReportSeedingProgress:
+    """Prints a progress line on every 100th student and the final student."""
+
+    def test_prints_on_hundredth_student(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+
+        captured: list[str] = []
+        monkeypatch.setattr(loadtest_mod.console, "print", captured.append)
+
+        _report_seeding_progress(99, 250, activity_ws_count=10, loose_ws_count=5)
+
+        assert len(captured) == 1
+        assert "100/250" in captured[0]
+        assert "10 activity ws" in captured[0]
+        assert "5 loose ws" in captured[0]
+
+    def test_prints_on_final_student_even_off_the_hundred_boundary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+
+        captured: list[str] = []
+        monkeypatch.setattr(loadtest_mod.console, "print", captured.append)
+
+        _report_seeding_progress(42, 43, activity_ws_count=3, loose_ws_count=1)
+
+        assert len(captured) == 1
+        assert "43/43" in captured[0]
+
+    def test_silent_between_boundaries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import promptgrimoire.cli_loadtest as loadtest_mod
+
+        captured: list[str] = []
+        monkeypatch.setattr(loadtest_mod.console, "print", captured.append)
+
+        _report_seeding_progress(5, 250, activity_ws_count=1, loose_ws_count=0)
+
+        assert captured == []

--- a/tests/unit/test_manage_users.py
+++ b/tests/unit/test_manage_users.py
@@ -509,6 +509,7 @@ def _mock_xlsx_file() -> MagicMock:
 
 
 def _make_enrolment_report(
+    *,
     entries_processed: int = 3,
     users_created: int = 2,
     users_existing: int = 1,

--- a/tests/unit/test_markdown_sync_event.py
+++ b/tests/unit/test_markdown_sync_event.py
@@ -48,7 +48,10 @@ def _capture_on_yjs_handler(
 
     Returns (handler, mock_ui_on) so the test can invoke the handler directly.
     """
-    from promptgrimoire.pages.annotation.respond import _setup_yjs_event_handler
+    from promptgrimoire.pages.annotation.respond import (
+        ClientContext,
+        _setup_yjs_event_handler,
+    )
 
     if state is None:
         state = MagicMock()
@@ -59,10 +62,12 @@ def _capture_on_yjs_handler(
     with patch("promptgrimoire.pages.annotation.respond.ui") as mock_ui:
         _setup_yjs_event_handler(
             crdt_doc=crdt_doc,
-            workspace_key="test-ws",
-            workspace_id=MagicMock(),
-            client_id="test-client-id-1234",
-            on_yjs_update_broadcast=mock_broadcast,
+            client_ctx=ClientContext(
+                workspace_key="test-ws",
+                workspace_id=MagicMock(),
+                client_id="test-client-id-1234",
+                on_yjs_update_broadcast=mock_broadcast,
+            ),
             state=state,
         )
         # ui.on("respond_yjs_update", handler) was called

--- a/tests/unit/test_report_render.py
+++ b/tests/unit/test_report_render.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from scripts.incident.analysis import _fmt_gap_duration, _md_table, render_review_report
+from scripts.incident.analysis import (
+    ReportData,
+    _fmt_gap_duration,
+    _md_table,
+    render_review_report,
+)
 
 
 class TestMdTable:
@@ -43,11 +48,13 @@ class TestExplanatoryProse:
     def test_report_header_prose(self) -> None:
         """Introductory prose about epochs and normalisation appears after header."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
         assert "epochs" in report.lower()
         assert "SRE" in report
@@ -55,11 +62,13 @@ class TestExplanatoryProse:
     def test_timeline_prose(self) -> None:
         """Epoch Timeline section includes explanatory prose."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
         assert "deploy" in report
         assert "crash" in report.lower()
@@ -67,11 +76,13 @@ class TestExplanatoryProse:
     def test_trend_prose(self) -> None:
         """Trend Analysis section includes metric explanation prose."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
         assert "5xx Ratio" in report
         assert "Error Ratio" in report
@@ -235,11 +246,13 @@ class TestRenderReviewReport:
     def test_all_sections_present(self) -> None:
         """AC6.1: All expected section headers appear in the report."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
 
         assert "Source Inventory" in report
@@ -251,11 +264,13 @@ class TestRenderReviewReport:
     def test_data_included(self) -> None:
         """Report includes key data from the provided mock data."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
 
         # Epoch commit hash
@@ -276,12 +291,14 @@ class TestRenderReviewReport:
     def test_static_counts_omitted_when_none(self) -> None:
         """AC6.2: static_counts=None produces no Static DB Counts section."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
-            static_counts=None,
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+                static_counts=None,
+            )
         )
 
         assert "Static DB Counts" not in report
@@ -290,12 +307,14 @@ class TestRenderReviewReport:
         """Static DB Counts section appears when data is provided."""
         counts = {"users": 42, "workspaces": 100}
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
-            static_counts=counts,
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+                static_counts=counts,
+            )
         )
 
         assert "Static DB Counts" in report
@@ -305,11 +324,13 @@ class TestRenderReviewReport:
     def test_empty_epochs(self) -> None:
         """Handles empty epochs list without error."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=[],
-            epoch_analyses=[],
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=[],
+                epoch_analyses=[],
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "Epoch Timeline" in report
@@ -323,11 +344,13 @@ class TestRenderReviewReport:
         analyses[0]["haproxy"]["p99_ms"] = None
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "N/A" in report
@@ -338,11 +361,13 @@ class TestRenderReviewReport:
         epochs[0]["is_crash_bounce"] = True
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=epochs,
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=epochs,
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         # Should have some crash bounce indicator
@@ -351,11 +376,13 @@ class TestRenderReviewReport:
     def test_trend_ratio_formatting(self) -> None:
         """Trend ratios are formatted as percentages with pp deltas."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=_mock_trends(),
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=_mock_trends(),
+            )
         )
 
         # Ratios should be displayed as percentages
@@ -373,11 +400,13 @@ class TestNosrvRendering:
         analyses[0]["haproxy"]["nosrv_first_60s"] = 72
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "NOSRV" in report
@@ -387,11 +416,13 @@ class TestNosrvRendering:
     def test_nosrv_omitted_when_zero(self) -> None:
         """AC1.3: Zero NOSRV events omit the NOSRV per-epoch line."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "Restart 503s (NOSRV)" not in report
@@ -408,11 +439,13 @@ class TestErrorLandscapeRendering:
         }
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "Appeared" in report
@@ -430,11 +463,13 @@ class TestErrorLandscapeRendering:
         }
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "No errors" in report
@@ -444,11 +479,13 @@ class TestMethodology:
     def test_key_terms_present(self) -> None:
         """AC5.1: Methodology contains key terms."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
         lower = report.lower()
         assert "epoch" in lower
@@ -462,11 +499,13 @@ class TestMethodology:
     def test_citations_present(self) -> None:
         """AC5.2: SRE Workbook and playbook cited."""
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
         assert "SRE Workbook" in report
         assert "incident-analysis-playbook" in report
@@ -496,11 +535,13 @@ class TestPoolConfigRendering:
         analyses[0]["pool_config"] = {"pool_size": 10, "max_overflow": 20}
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "size=10, overflow=20" in report
@@ -511,11 +552,13 @@ class TestPoolConfigRendering:
         analyses[0]["pool_config"] = None
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=_mock_epochs(),
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=_mock_epochs(),
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "not observed" in report
@@ -540,11 +583,13 @@ class TestRestartGapRendering:
         analyses = [_mock_analyses()[0], _mock_analyses()[0]]
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=epochs,
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=epochs,
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "Gap" in report
@@ -555,11 +600,13 @@ class TestRestartGapRendering:
         epochs = [{**_mock_epochs()[0], "restart_gap_seconds": None}]
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=epochs,
-            epoch_analyses=_mock_analyses(),
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=epochs,
+                epoch_analyses=_mock_analyses(),
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "Gap" in report
@@ -580,11 +627,13 @@ class TestRestartGapRendering:
         analyses = [_mock_analyses()[0], _mock_analyses()[0]]
 
         report = render_review_report(
-            sources=_mock_sources(),
-            epochs=epochs,
-            epoch_analyses=analyses,
-            summative_users=_mock_summative(),
-            trends=[],
+            ReportData(
+                sources=_mock_sources(),
+                epochs=epochs,
+                epoch_analyses=analyses,
+                summative_users=_mock_summative(),
+                trends=[],
+            )
         )
 
         assert "0s" in report

--- a/tests/unit/test_respond_reference_card_html.py
+++ b/tests/unit/test_respond_reference_card_html.py
@@ -15,7 +15,10 @@ import pytest
 
 def _render(**kwargs: object) -> str:
     """Shortcut to import and call the function under test."""
-    from promptgrimoire.pages.annotation.respond import _render_reference_card_html
+    from promptgrimoire.pages.annotation.respond import (
+        ReferenceCardContent,
+        _render_reference_card_html,
+    )
 
     defaults: dict[str, object] = {
         "tag_display": "Jurisdiction",
@@ -26,7 +29,7 @@ def _render(**kwargs: object) -> str:
         "comments": [],
     }
     defaults.update(kwargs)
-    return _render_reference_card_html(**defaults)
+    return _render_reference_card_html(ReferenceCardContent(**defaults))
 
 
 class TestReferenceCardHtml:

--- a/tests/unit/test_search_worker.py
+++ b/tests/unit/test_search_worker.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,12 +25,26 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+class _DirtyWorkspaceRow(NamedTuple):
+    """Row-like tuple matching the workspace SELECT columns.
+
+    A real SQLAlchemy Row supports both positional and by-label (attribute)
+    access; process_dirty_workspaces() reads it by label (see
+    docs/architecture/raw-sql-convention.md), so the mock must too.
+    """
+
+    id: Any
+    crdt_state: Any
+    ws_title: Any
+    activity_title: Any
+
+
 def _make_row(*values: Any) -> tuple[Any, ...]:
-    """Build a plain tuple row matching the workspace SELECT columns.
+    """Build a Row-like tuple matching the workspace SELECT columns.
 
     Columns: (id, crdt_state, ws_title, activity_title)
     """
-    return tuple(values)
+    return _DirtyWorkspaceRow(*values)
 
 
 def _make_mock_session(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,6 +11,7 @@ import logging
 import os
 from pathlib import Path
 from tempfile import gettempdir
+from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -54,7 +55,7 @@ class TestTypeValidation:
         public_token = _sample_public_token_value()
         log_dir = _sample_log_dir()
         s = Settings(
-            _env_file=None,  # type: ignore[call-arg]
+            _env_file=None,
             stytch=StytchConfig(
                 project_id="proj-123",
                 secret=SecretStr("sec-456"),
@@ -116,28 +117,28 @@ class TestTypeValidation:
     )
     def test_bool_coercion_case_insensitive(self, raw: str, expected: bool) -> None:
         """AC1.2: DevConfig coerces string values to bool."""
-        cfg = DevConfig(auth_mock=raw)  # type: ignore[arg-type]
+        cfg = DevConfig(auth_mock=raw)
         assert cfg.auth_mock is expected
 
     def test_int_coercion_from_string(self) -> None:
         """AC1.3: Int fields coerce string values."""
-        app = AppConfig(port="9090")  # type: ignore[arg-type]
+        app = AppConfig(port="9090")
         assert app.port == 9090
         assert isinstance(app.port, int)
 
-        llm1 = LlmConfig(thinking_budget="2048")  # type: ignore[arg-type]
+        llm1 = LlmConfig(thinking_budget="2048")
         assert llm1.thinking_budget == 2048
         assert isinstance(llm1.thinking_budget, int)
 
         budget_text = str(500)
-        llm2 = LlmConfig(lorebook_token_budget=budget_text)  # type: ignore[arg-type]
+        llm2 = LlmConfig(lorebook_token_budget=budget_text)
         assert llm2.lorebook_token_budget == 500
         assert isinstance(llm2.lorebook_token_budget, int)
 
     def test_invalid_int_raises_validation_error(self) -> None:
         """AC1.4: Invalid int string raises ValidationError."""
         with pytest.raises(ValidationError):
-            AppConfig(port="not-a-number")  # type: ignore[arg-type]
+            AppConfig(port="not-a-number")
 
     def test_missing_env_file_uses_defaults(
         self, monkeypatch: pytest.MonkeyPatch
@@ -156,7 +157,7 @@ class TestTypeValidation:
                 "DEV",
             ):
                 monkeypatch.delenv(key, raising=False)
-        s = Settings(_env_file=None)  # type: ignore[call-arg]
+        s = Settings(_env_file=None)
         assert s.app.port == 8080
         assert s.app.base_url == "http://localhost:8080"
         assert s.dev.auth_mock is False
@@ -191,8 +192,8 @@ class TestFeaturesConfig:
     def test_bool_coercion_from_string(self) -> None:
         """Feature flags coerce string values to bool (env var style)."""
         cfg = FeaturesConfig(
-            enable_roleplay="false",  # type: ignore[arg-type]
-            enable_file_upload="true",  # type: ignore[arg-type]
+            enable_roleplay="false",
+            enable_file_upload="true",
         )
         assert cfg.enable_roleplay is False
         assert cfg.enable_file_upload is True
@@ -202,7 +203,7 @@ class TestFeaturesConfig:
         for key in list(os.environ):
             if key.startswith("FEATURES__"):
                 monkeypatch.delenv(key, raising=False)
-        s = Settings(_env_file=None)  # type: ignore[call-arg]
+        s = Settings(_env_file=None)
         assert s.features.enable_roleplay is True
         assert s.features.enable_file_upload is True
 
@@ -210,7 +211,7 @@ class TestFeaturesConfig:
         """Settings reads FEATURES__ env vars to override defaults."""
         monkeypatch.setenv("FEATURES__ENABLE_ROLEPLAY", "false")
         monkeypatch.setenv("FEATURES__ENABLE_FILE_UPLOAD", "false")
-        s = Settings(_env_file=None)  # type: ignore[call-arg]
+        s = Settings(_env_file=None)
         assert s.features.enable_roleplay is False
         assert s.features.enable_file_upload is False
 
@@ -289,9 +290,9 @@ class TestWorktreeEnvPaths:
         # without reading the real .env (which may have old-format vars).
         original_init = config_module.Settings.__init__
 
-        def _patched_init(self: object, *args: object, **kwargs: object) -> None:
+        def _patched_init(self: Settings, *args: Any, **kwargs: Any) -> None:
             kwargs.setdefault("_env_file", None)
-            original_init(self, *args, **kwargs)  # type: ignore[invalid-argument-type]
+            original_init(self, *args, **kwargs)
 
         monkeypatch.setattr(config_module.Settings, "__init__", _patched_init)
         get_settings.cache_clear()
@@ -315,7 +316,7 @@ class TestTestIsolation:
     def test_settings_construction_without_env(self) -> None:
         """AC8.1: Direct Settings construction with explicit values."""
         s = Settings(
-            _env_file=None,  # type: ignore[unknown-argument]
+            _env_file=None,
             app=AppConfig(port=1234),
         )
         assert s.app.port == 1234
@@ -328,9 +329,9 @@ class TestTestIsolation:
 
         original_init = config_module.Settings.__init__
 
-        def _patched_init(self: object, *args: object, **kwargs: object) -> None:
+        def _patched_init(self: Settings, *args: Any, **kwargs: Any) -> None:
             kwargs.setdefault("_env_file", None)
-            original_init(self, *args, **kwargs)  # type: ignore[invalid-argument-type]
+            original_init(self, *args, **kwargs)
 
         monkeypatch.setattr(config_module.Settings, "__init__", _patched_init)
         get_settings.cache_clear()
@@ -487,7 +488,7 @@ class TestBranchDbIsolation:
     def test_both_urls_suffixed(self, _mock_branch: object) -> None:
         """AC9.3: Both database.url and dev.test_database_url suffixed."""
         s = Settings(
-            _env_file=None,  # type: ignore[call-arg]
+            _env_file=None,
             database=DatabaseConfig(url="postgresql://u:p@h/mydb"),
             dev=DevConfig(test_database_url="postgresql://u:p@h/testdb"),
         )
@@ -500,7 +501,7 @@ class TestBranchDbIsolation:
     def test_main_branch_urls_unchanged(self, _mock_branch: object) -> None:
         """AC9.1 via validator: main branch leaves URLs unchanged."""
         s = Settings(
-            _env_file=None,  # type: ignore[call-arg]
+            _env_file=None,
             database=DatabaseConfig(url="postgresql://u:p@h/mydb"),
             dev=DevConfig(test_database_url="postgresql://u:p@h/testdb"),
         )
@@ -514,7 +515,7 @@ class TestBranchDbIsolation:
     def test_opt_out_branch_db_suffix(self, _mock_branch: object) -> None:
         """AC9.10: branch_db_suffix=False leaves URL unchanged."""
         s = Settings(
-            _env_file=None,  # type: ignore[call-arg]
+            _env_file=None,
             database=DatabaseConfig(url="postgresql://u:p@h/mydb"),
             dev=DevConfig(branch_db_suffix=False),
         )

--- a/tests/unit/test_sharing_button_visibility.py
+++ b/tests/unit/test_sharing_button_visibility.py
@@ -1,7 +1,9 @@
-"""Unit tests for share button visibility guard logic.
+"""Behavioural tests for sharing-control visibility.
 
-Tests the boolean expressions controlling share button rendering
-in sharing.py without requiring NiceGUI context.
+Exercises the production predicates on SharingUiFlags (sharing.py) —
+previously these tables ran against an inline re-implementation of the
+expression with an ast-grep shape-guard as the only link to production;
+converted 2026-08-17 (tracker ledger 13).
 
 AC3.1: Button visible when allow_sharing=True and can_manage_sharing=True
 AC3.2: Button hidden when allow_sharing=False and non-staff
@@ -11,13 +13,28 @@ AC3.4: Class toggle has NO staff bypass (regression guard)
 
 from __future__ import annotations
 
-import subprocess
-
 import pytest
+
+from promptgrimoire.pages.annotation.sharing import SharingUiFlags
+
+
+def _flags(
+    *,
+    allow_sharing: bool,
+    viewer_is_privileged: bool,
+    can_manage_sharing: bool,
+    shared_with_class: bool = False,
+) -> SharingUiFlags:
+    return SharingUiFlags(
+        allow_sharing=allow_sharing,
+        shared_with_class=shared_with_class,
+        can_manage_sharing=can_manage_sharing,
+        viewer_is_privileged=viewer_is_privileged,
+    )
 
 
 class TestShareButtonVisibility:
-    """Pure boolean logic tests for the share button guard."""
+    """Share-with-user button: (allow_sharing or staff) and can_manage."""
 
     @pytest.mark.parametrize(
         ("allow_sharing", "viewer_is_privileged", "can_manage_sharing", "expected"),
@@ -32,51 +49,50 @@ class TestShareButtonVisibility:
             pytest.param(True, True, True, True, id="staff-sharing-allowed"),
             pytest.param(True, False, False, False, id="cannot-manage-sharing"),
             pytest.param(True, True, False, False, id="staff-cannot-manage"),
+            pytest.param(False, False, False, False, id="nothing-granted"),
+            pytest.param(False, True, False, False, id="staff-without-manage"),
         ],
     )
-    def test_share_button_guard(
+    def test_share_button_visibility(
         self,
         allow_sharing: bool,
         viewer_is_privileged: bool,
         can_manage_sharing: bool,
         expected: bool,
     ) -> None:
-        """Share button expression matches expected visibility."""
-        result = (allow_sharing or viewer_is_privileged) and can_manage_sharing
-        assert result is expected
+        """Production predicate matches the hand-written truth table."""
+        flags = _flags(
+            allow_sharing=allow_sharing,
+            viewer_is_privileged=viewer_is_privileged,
+            can_manage_sharing=can_manage_sharing,
+        )
+        assert flags.shows_share_button is expected
 
 
-class TestClassToggleNoStaffBypass:
-    """Regression guard: class toggle has no staff bypass (AC3.4)."""
+class TestClassToggleVisibility:
+    """Share-with-class toggle: allow_sharing and can_manage — no staff bypass."""
 
     def test_class_toggle_false_when_sharing_disabled(self) -> None:
-        """Staff bypass does NOT apply to 'Share with class' toggle."""
-        allow_sharing = False
-        can_manage_sharing = True
-        # viewer_is_privileged intentionally True to prove no bypass
-        result = allow_sharing and can_manage_sharing
-        assert result is False
-
-
-class TestStructuralGuard:
-    """ast-grep structural guard for share button guard expression."""
-
-    def test_share_button_guard_expression(self) -> None:
-        """sharing.py contains the expected guard expression."""
-        result = subprocess.run(
-            [
-                "sg",
-                "run",
-                "-p",
-                "(allow_sharing or viewer_is_privileged) and can_manage_sharing",
-                "-l",
-                "python",
-                "src/promptgrimoire/pages/annotation/sharing.py",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
+        """AC3.4: staff bypass does NOT apply to the class toggle."""
+        flags = _flags(
+            allow_sharing=False,
+            viewer_is_privileged=True,  # intentionally staff, to prove no bypass
+            can_manage_sharing=True,
         )
-        assert result.returncode == 0, (
-            "Expected guard expression not found in sharing.py"
+        assert flags.shows_class_toggle is False
+
+    def test_class_toggle_true_when_allowed_and_managing(self) -> None:
+        flags = _flags(
+            allow_sharing=True,
+            viewer_is_privileged=False,
+            can_manage_sharing=True,
         )
+        assert flags.shows_class_toggle is True
+
+    def test_class_toggle_false_without_manage_rights(self) -> None:
+        flags = _flags(
+            allow_sharing=True,
+            viewer_is_privileged=False,
+            can_manage_sharing=False,
+        )
+        assert flags.shows_class_toggle is False

--- a/tests/unit/test_tag_toolbar_gating.py
+++ b/tests/unit/test_tag_toolbar_gating.py
@@ -14,7 +14,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from promptgrimoire.pages.annotation import PageState
+from promptgrimoire.pages.annotation import PageState, PermissionLevel
 from promptgrimoire.pages.annotation.document import _render_document_with_highlights
 
 
@@ -77,12 +77,12 @@ class TestTagToolbarGating:
 
     @pytest.mark.parametrize("permission", ["peer", "editor", "owner"])
     async def test_tag_toolbar_shown_for_annotating_user(
-        self, workspace_id: UUID, permission: str
+        self, workspace_id: UUID, permission: PermissionLevel
     ) -> None:
         """Users with peer/editor/owner permission must get the tag toolbar."""
         state = PageState(
             workspace_id=workspace_id,
-            effective_permission=permission,  # type: ignore[arg-type]  # parametrize yields str, not Literal PermissionLevel
+            effective_permission=permission,
         )
         assert state.can_annotate is True
 

--- a/tests/unit/test_to_jsonb_field_type_guard.py
+++ b/tests/unit/test_to_jsonb_field_type_guard.py
@@ -1,0 +1,196 @@
+"""Structural guard: to_jsonb-hydrated models must carry no lossy field types.
+
+``to_jsonb(table.*)`` silently corrupts ``bytea`` columns (verified on
+``Workspace.crdt_state``; see docs/architecture/raw-sql-convention.md §
+"ty gotchas"). ``resolve_annotation_context`` and its siblings in
+``db/workspaces.py`` work around this by hydrating ``Workspace`` from its
+own unprefixed columns (``w.*`` + ``model_validate(row, from_attributes=True)``)
+and reserving ``to_jsonb(...)`` for scalar-only entities (currently
+ACLEntry, Activity, Week, Course).
+
+This guard parses ``workspaces.py``'s source to find every
+``to_jsonb(alias.*) AS x_json`` result column and the
+``Model.model_validate(...)`` call each alias feeds, then asserts the
+resolved model has no field typed ``bytes``, ``Decimal``, ``float``, or
+``timedelta`` -- the pydantic-level signature of "would silently corrupt
+or lose precision under to_jsonb's opaque JSON round-trip". The model
+list is derived from the source, not hand-maintained: a hand-maintained
+list would be a tautology against exactly the regression this guard
+exists to catch. Adding a new to_jsonb column, or a
+bytes/Decimal/float/timedelta field to an existing to_jsonb-hydrated
+model, must fail this test.
+"""
+
+import ast
+import re
+import types
+import typing
+from datetime import timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_WORKSPACES_PY = (
+    Path(__file__).parents[2] / "src" / "promptgrimoire" / "db" / "workspaces.py"
+)
+
+_TO_JSONB_ALIAS_RE = re.compile(r"to_jsonb\([\w.]+\*\)\s+AS\s+(\w+)", re.IGNORECASE)
+
+_FORBIDDEN_TYPES: tuple[type, ...] = (bytes, Decimal, float, timedelta)
+
+
+def _find_to_jsonb_aliases(source: str) -> set[str]:
+    """Return every ``to_jsonb(x.*) AS <alias>`` result-column alias in *source*."""
+    return set(_TO_JSONB_ALIAS_RE.findall(source))
+
+
+def _find_model_validate_targets(
+    source: str,
+    aliases: set[str],
+    *,
+    filename: str = "<source>",
+) -> dict[str, str]:
+    """Map each to_jsonb alias to the model class hydrated from it.
+
+    Walks every ``<Model>.model_validate(<expr>.<alias>)`` call in
+    *source* and records ``alias -> Model`` for aliases in *aliases*.
+    ``ast.walk`` visits every descendant node regardless of whether the
+    call sits bare, inside a ternary, or nested some other way, so no
+    special-casing of surrounding syntax is needed.
+    """
+    tree = ast.parse(source, filename=filename)
+    mapping: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "model_validate"):
+            continue
+        if not (isinstance(func.value, ast.Name) and node.args):
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Attribute) and arg.attr in aliases:
+            mapping[arg.attr] = func.value.id
+    return mapping
+
+
+def _iter_leaf_types(annotation: object) -> Iterator[object]:
+    """Yield the non-None leaf types of *annotation*, unwrapping ``X | None``."""
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        for arg in typing.get_args(annotation):
+            if arg is type(None):
+                continue
+            yield from _iter_leaf_types(arg)
+    else:
+        yield annotation
+
+
+def _forbidden_fields(model: type[BaseModel]) -> list[str]:
+    """Return field names on *model* typed bytes/Decimal/float/timedelta."""
+    violations: list[str] = []
+    for name, field in model.model_fields.items():
+        for leaf in _iter_leaf_types(field.annotation):
+            if isinstance(leaf, type) and issubclass(leaf, _FORBIDDEN_TYPES):
+                violations.append(name)
+                break
+    return violations
+
+
+def test_synthetic_alias_and_model_extraction() -> None:
+    """The extractor maps a to_jsonb alias to its hydrating model.
+
+    Proves the mechanism independently of the real file: a change that
+    breaks alias or model-name extraction fails here directly, rather
+    than showing up as a silently-empty scan of workspaces.py that would
+    make the main guard test below pass for the wrong reason.
+    """
+    snippet = (
+        "row = await session.execute(\n"
+        '    tstring(t"SELECT to_jsonb(x.*) AS thing_json FROM x")\n'
+        ")\n"
+        "thing = Thing.model_validate(row.thing_json) if row.thing_json else None\n"
+    )
+
+    aliases = _find_to_jsonb_aliases(snippet)
+    assert aliases == {"thing_json"}
+
+    mapping = _find_model_validate_targets(snippet, aliases)
+    assert mapping == {"thing_json": "Thing"}
+
+
+def test_forbidden_field_type_detection() -> None:
+    """The field-type checker flags bytes/Decimal/float/timedelta fields."""
+
+    class _Dirty(BaseModel):
+        ok: int
+        bad: bytes | None = None
+
+    class _AlsoDirty(BaseModel):
+        amount: Decimal
+        elapsed: timedelta | None = None
+        ratio: float = 0.0
+
+    class _Clean(BaseModel):
+        ok: int
+        name: str | None = None
+        count: int = 0
+
+    assert _forbidden_fields(_Dirty) == ["bad"]
+    assert set(_forbidden_fields(_AlsoDirty)) == {"amount", "elapsed", "ratio"}
+    assert _forbidden_fields(_Clean) == []
+
+
+def test_to_jsonb_hydrated_models_have_no_forbidden_field_types() -> None:
+    """No model hydrated via to_jsonb in workspaces.py may carry a
+    bytes/Decimal/float/timedelta field.
+
+    ``to_jsonb(table.*)`` silently corrupts such columns (bytea observed
+    on Workspace.crdt_state; Decimal/float/timedelta share the same
+    "opaque JSON round-trip" risk surface). If this fails, either
+    hydrate the new field from its real column instead of via to_jsonb
+    (see Workspace's ``w.*`` + ``model_validate(row, from_attributes=True)``
+    pattern), or keep the to_jsonb entity scalar-only.
+    """
+    source = _WORKSPACES_PY.read_text()
+
+    aliases = _find_to_jsonb_aliases(source)
+    assert aliases, (
+        f"No `to_jsonb(...) AS <alias>` found in {_WORKSPACES_PY} -- the "
+        "extractor regex may be broken, or the query no longer uses "
+        "to_jsonb. Either way this guard is currently checking nothing; "
+        "investigate before trusting a green run here."
+    )
+
+    alias_to_model = _find_model_validate_targets(
+        source, aliases, filename=str(_WORKSPACES_PY)
+    )
+    unresolved = aliases - alias_to_model.keys()
+    assert not unresolved, (
+        f"to_jsonb alias(es) {sorted(unresolved)} in {_WORKSPACES_PY} have "
+        "no matching `Model.model_validate(row.<alias>)` call this guard "
+        "can find -- update the extractor, or hydrate via a traceable "
+        "`Model.model_validate(row.<alias>)` call so the model stays "
+        "checkable."
+    )
+
+    import promptgrimoire.db.models as models_module
+
+    violations: dict[str, list[str]] = {}
+    for model_name in set(alias_to_model.values()):
+        model = getattr(models_module, model_name)
+        bad_fields = _forbidden_fields(model)
+        if bad_fields:
+            violations[model_name] = bad_fields
+
+    assert not violations, (
+        "to_jsonb(...) hydration in workspaces.py would silently corrupt "
+        "or lose precision on these fields (see docs/architecture/"
+        "raw-sql-convention.md § 'ty gotchas'):\n"
+        + "\n".join(f"  {m}: {fs}" for m, fs in violations.items())
+    )

--- a/tests/unit/test_word_count_badge.py
+++ b/tests/unit/test_word_count_badge.py
@@ -25,7 +25,7 @@ class TestBadgeStateDataclass:
     def test_frozen(self) -> None:
         state = BadgeState(text="Words: 0", css_classes=_NEUTRAL)
         with pytest.raises(AttributeError):
-            state.text = "changed"  # type: ignore[invalid-assignment]  # intentional: testing runtime immutability
+            setattr(state, "text", "changed")  # noqa: B010  -- intentional: testing runtime immutability
 
 
 class TestFormatWordCountBadge:

--- a/tests/unit/test_word_count_enforcement.py
+++ b/tests/unit/test_word_count_enforcement.py
@@ -21,7 +21,7 @@ class TestWordCountViolationDataclass:
     def test_frozen(self) -> None:
         v = WordCountViolation()
         with pytest.raises(AttributeError):
-            v.over_limit = True  # type: ignore[invalid-assignment]  # intentional: testing runtime immutability
+            setattr(v, "over_limit", True)  # noqa: B010  -- intentional: testing runtime immutability
 
     def test_defaults_no_violation(self) -> None:
         v = WordCountViolation()

--- a/tests/unit/test_word_count_models.py
+++ b/tests/unit/test_word_count_models.py
@@ -5,6 +5,7 @@ Pure model instantiation tests -- no database required.
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -16,26 +17,26 @@ _WEEK_ID = uuid4()
 _TEMPLATE_WS_ID = uuid4()
 
 
-def _make_activity(**overrides: object) -> Activity:
+def _make_activity(**overrides: Any) -> Activity:
     """Create an Activity with required fields pre-filled."""
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "week_id": _WEEK_ID,
         "template_workspace_id": _TEMPLATE_WS_ID,
         "title": "Test Activity",
     }
     defaults.update(overrides)
-    return Activity(**defaults)  # type: ignore[arg-type]
+    return Activity(**defaults)
 
 
-def _make_course(**overrides: object) -> Course:
+def _make_course(**overrides: Any) -> Course:
     """Create a Course with required fields pre-filled."""
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "code": "TEST101",
         "name": "Test Course",
         "semester": "2026S1",
     }
     defaults.update(overrides)
-    return Course(**defaults)  # type: ignore[arg-type]
+    return Course(**defaults)
 
 
 class TestActivityWordCountFields:

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+complexipy = "2026-08-12T22:19:40Z"
+ty = "2026-08-14T21:35:43Z"
+ruff = "2026-08-13T15:17:14Z"
 nicegui = "2026-08-12T15:18:33Z"
+
+[manifest]
+overrides = [{ name = "sqlalchemy", specifier = "==2.1.0b3" }]
 
 [[package]]
 name = "aiofiles"
@@ -375,24 +381,38 @@ wheels = [
 
 [[package]]
 name = "complexipy"
-version = "5.2.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/82/3128712a672e30a5fe76d484d72b09f31cb73e9dbc518bd9655fca934f9f/complexipy-5.2.0.tar.gz", hash = "sha256:3eee6916cf2acab5e247abfc75d09610b24fd370e45903810f1f33d20914e0c1", size = 301752, upload-time = "2026-01-28T19:23:09.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a1/25719a32617e791fa47d8c2659b3b23dae131795260617ef5c80f85354f7/complexipy-7.0.1.tar.gz", hash = "sha256:e9aeafb66d9f6e04e98feb1ce14cd31b114ae567578ed2ceaf0e6bbac7fa29fa", size = 442243, upload-time = "2026-08-12T22:19:39.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/df4ed58f447c2e822a0c2cf98f9bd08a17c5943bb98239f11c217b25c90e/complexipy-5.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:09c416a46f99083b87ea7912f3bf98768bba06207b3f917a68aef9679cb50c64", size = 2039221, upload-time = "2026-01-28T19:21:41.561Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e9/7c691b4ef7a33ceabfd09a79150de329d0b3597e5fac04355b66d305f5a9/complexipy-5.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4201f65c874ca32c44e9926a932fe2905c52492223a3e33c463fa60350ad2f05", size = 1949845, upload-time = "2026-01-28T19:21:43.224Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/d2/d5da93d83c9170c901c2606a53ad13b784f516c5e3e3a558a5c227759bde/complexipy-5.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b70c3eefcbd4bd8efb1d939b0acaa7046f384a1c0b999e2f3173197153e325c5", size = 2113399, upload-time = "2026-01-28T19:21:44.902Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/81/333e01b9644ab0a3695e3f0a3e65b3241aeec0bc8d777f46b7a9d46b9cd1/complexipy-5.2.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:b055c8e2aecd5aa2146001d9bd1672194508fcf82b64b0958ceb51ca55f13684", size = 2046688, upload-time = "2026-01-28T19:21:46.558Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e0/ebbcf90113a990e8628f26e0ef57d3e6f2783aefd7590d76c1bf6108970d/complexipy-5.2.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1024b5589a7bb8ffec286d1ede20c18cbe6387525077b44507d310f83ae5ce0c", size = 2231206, upload-time = "2026-01-28T19:21:48.623Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/ae/5f45665e4995365e5e3df67240d5d56ec50bd0dd6fca0cec2fef914ae753/complexipy-5.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db78059193ed960d1d76214aaaa5311046c9e2f884f5bfc2ba56a981f3afb920", size = 2472974, upload-time = "2026-01-28T19:21:50.241Z" },
-    { url = "https://files.pythonhosted.org/packages/29/f4/334621a1397d837514e003c6d8763e41b3fb31861951ec4b0039990cceeb/complexipy-5.2.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a2adbd79a2f16aec8169e78084d1e3693aa905ce907a37aa065ceaa94a67988f", size = 2253186, upload-time = "2026-01-28T19:21:52.293Z" },
-    { url = "https://files.pythonhosted.org/packages/36/1e/ed1271ae9b99b65dd12a7ae0a8c298e1fe70ce00d58beb5d77f7581ea4e7/complexipy-5.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:238bb47723cfc77c999aa2ffb8182d49b74093538280129bec34a8f47e270226", size = 2168498, upload-time = "2026-01-28T19:21:54.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/09/4f6da93151b9b4d4f6a2a8a21aaafd117ed7aabde6f7871baf757d1fee56/complexipy-5.2.0-cp314-cp314-win32.whl", hash = "sha256:23da083d986cf880eccef8446269bd626ef025d327bb4e20a2bd557675989f77", size = 1746821, upload-time = "2026-01-28T19:21:55.722Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/52/251510b9b20eb79674bec668a52fe27b2384a3829d1585d1f05e0ac383a7/complexipy-5.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:fc7342f782edbe63e66197b25ce7716e8e6e6ab684c84c276977f5e2f797810a", size = 1872163, upload-time = "2026-01-28T19:21:57.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/40/7e71997c42350239346544fa96c1bdaf24487f341d5b54286007e017ee87/complexipy-7.0.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cbacaa05423a78765f2c71cca3c22a7bb60aed478e1aff40c21708a124422e5d", size = 2384964, upload-time = "2026-08-12T22:18:29.682Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f4/4d073477cbbe036a4d4e6cf2f5b7dd88496c4a19ca643658251fe4d52881/complexipy-7.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3923526fd3005848376ec64e2be15cdb7d8391093301c9ec3693d7510fdbf3c9", size = 2322023, upload-time = "2026-08-12T22:18:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/19/c89a5d8b1c7552d6b4546d9f1e4fbd5c0f00d8f7ef3ac6676da084548231/complexipy-7.0.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a41144de681a8fbaa8ee4fa0035cee6331c9dced8539b1664349481da911b1f2", size = 2526081, upload-time = "2026-08-12T22:18:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a7/dc16525a990706c3a71bf183001b1a4f3fc7d04898891825520e758212c7/complexipy-7.0.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1a597ffbbdd4eaed3aa59ec258e0f8097cb75d899d017e7d3f52e0181c2fe650", size = 2460165, upload-time = "2026-08-12T22:18:33.577Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bb/b98c40de9d581c5ec6e9dcf26b6acbff63a52194b67f57ee77f62945ac86/complexipy-7.0.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2da01466b2c302bf9b3bd3e73bb8bbc1616e07cebb4834e4f61b1edfde6578ab", size = 2686829, upload-time = "2026-08-12T22:18:34.681Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/f50c0c4d3ef908363c95311a9e0a52ac80e5ceaa74f4b93b7d865da7ef17/complexipy-7.0.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:78933708b59719c4829a338209d24c8816576c882aaf9de1a0bbd0e538bc5bff", size = 2921406, upload-time = "2026-08-12T22:18:35.87Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7b/579098e787eed0d02443175dfd74b1a292c5c8ada02792a0095efd805263/complexipy-7.0.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e16d46d5ea559421c24c552d78f8b29e2858278fd940e707bb5fdf137c4e300d", size = 2586715, upload-time = "2026-08-12T22:18:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f7/f100ac59a722c076043789b6c30c15cecbec66253dd99c720052115b4daa/complexipy-7.0.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6560ddb896270f5575d01bcef52a4d7e4fe7445a7812bbc70fc6af5ac522142a", size = 2551173, upload-time = "2026-08-12T22:18:38.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/54/efeb021c17c9cfc02622626500e8fbdde0a1f6c003c3e03880ba9c5aff4b/complexipy-7.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dcc304acccd9ab1685a84c14a708c373dd4679e7132dd71cc2d7129e5826c9ed", size = 2706114, upload-time = "2026-08-12T22:18:39.487Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f2/c4072e96bf516291ee7c9d8e8602998b9567497c9cda0995790c40d7e14d/complexipy-7.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:160fbbe5197f720ff28b2940d59286154c3b93797fe950f11216a7906e9c1e0b", size = 2808532, upload-time = "2026-08-12T22:18:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ac/aedfdb359028f2616e479b7d43050d0a5b8af0ae9d1c904eed6332dd1482/complexipy-7.0.1-cp314-cp314-win32.whl", hash = "sha256:337665732690599805178230923cf653c823cf55c231afde60ff8a6a922339be", size = 2085776, upload-time = "2026-08-12T22:18:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2a/d6d43a0ac1ac50ed673a35eb28ba077f9168d4c919f17b56dc3284db84e7/complexipy-7.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:f1ccdf3aaf55bf477187bdaa7c4b765a7d91033ed3187f1090e510ab2d468ab9", size = 2250961, upload-time = "2026-08-12T22:18:43.238Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/3e/5a2deeb4a2a177127e6bc00f4ec27abf6ae02f697ca3aca08824b1296f17/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e68809dcd7cb752cb3f88b336bfe44c9f82079ae5f5a323fdda20ddb5bf89385", size = 2523596, upload-time = "2026-08-12T22:18:44.407Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ce/98c826e4e8c25ce075bf1ba4a230b11cf253e57dec9b82d8509aa6292e08/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d49be5a9ab8b2e9f20a63570b7ed6a53b3e052897dfd135453ab867cf8c9e4d7", size = 2460428, upload-time = "2026-08-12T22:18:45.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ca/af44aa7d6e32ee426d591c29440ceff4d07b335b48000d0b372067c04592/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbb1e4381d91cf233616652528bd702b5c1d8ee7e7d1eac237d07bed9f0b4df7", size = 2686732, upload-time = "2026-08-12T22:18:46.868Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/fdddb7366313dbccb1e0da559824cb7098b1c2ee46fc558c181083299fda/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3202989419df622dffb1ecd24fdf9acc6fcf2354981d63cdea4ffe2d8a92610", size = 2919040, upload-time = "2026-08-12T22:18:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d3/c55c463eccedbd61179efc552c750abb5961eadfb6024b4be078b4639707/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0d7b9494b36b65b12dbc0e3be4417c0e1409b908dc252d60c418c20cb254c09", size = 2587702, upload-time = "2026-08-12T22:18:49.244Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/84/450b73146a0c02d3f13cb6aad6f86da66afa205c3109d2f35d8c2ca37257/complexipy-7.0.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c04019e3b5d4ba4ebc769096bded578f40ae3bfe0674e5a62b19ad8e6f4bb063", size = 2550030, upload-time = "2026-08-12T22:18:50.644Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4a/5c360db78099c29c29ff6c10164f088ea5fc4b9e29031a1cb0eccac24523/complexipy-7.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:37c42db8e1255f002e7bd66f3c13683bf857c45971fec809c89fbad1cff63d92", size = 2702458, upload-time = "2026-08-12T22:18:51.827Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/69/6543a6b801fd4298b2baefa0b8668206dfdd369df9b16b9dc0aad933289d/complexipy-7.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1e399b22d7e0c4ec7f6785bd0797339419d98a1ee1b4952055d515138df35bf", size = 2806439, upload-time = "2026-08-12T22:18:52.924Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6c/bcb789e44eeb5f3cde2de28da3a39e45d6b7aee3c160a75af10e8e50d17c/complexipy-7.0.1-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9cf6026e149f62a96adeccd120813897599af865c290b5eae3db2b1c6910d7f0", size = 2690105, upload-time = "2026-08-12T22:18:54.332Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d1/237597ef59d2a6a1249c8e7741dab9dbb5f626aa2175ab1a9cb26b7e7a79/complexipy-7.0.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cc8f3028cddee9fbd3a8258765e00b4b06990d311e803122f71ba5faa167c59", size = 2550932, upload-time = "2026-08-12T22:18:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ea/e6b137f2017893ff6868773e33c0fb5c0cd34ae65a20bad9e061e1718cc2/complexipy-7.0.1-cp315-cp315t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b26c9674cc71642b0b7c6a519b34a5c381c86f72883a96dd746aafcd1ff41d15", size = 2689690, upload-time = "2026-08-12T22:18:56.939Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6d/9045128929c116c82ae6e87b7d9f6f13f4e492ce861eb72b572051cc3cd8/complexipy-7.0.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c74bc6d1018308a9269ce3daf3079b828b7c375bc6580993d09d98133eaecad3", size = 2552183, upload-time = "2026-08-12T22:18:58.406Z" },
 ]
 
 [[package]]
@@ -1541,6 +1561,7 @@ dev = [
     { name = "rich" },
     { name = "ruff" },
     { name = "shellcheck-py" },
+    { name = "ty" },
     { name = "types-openpyxl" },
     { name = "vulture" },
 ]
@@ -1578,7 +1599,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ast-grep-cli", specifier = ">=0.40.5" },
-    { name = "complexipy", specifier = ">=5.2.0" },
+    { name = "complexipy", specifier = "==7.0.1" },
     { name = "junitparser", specifier = ">=4.0.2" },
     { name = "mkdocs-glightbox", specifier = ">=0.5.2" },
     { name = "mkdocs-material", specifier = ">=9.7" },
@@ -1600,8 +1621,9 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0" },
     { name = "rich", specifier = ">=14.3.1" },
-    { name = "ruff", specifier = ">=0.15.5" },
+    { name = "ruff", specifier = "==0.16.3" },
     { name = "shellcheck-py", specifier = ">=0.11.0" },
+    { name = "ty", specifier = "==0.0.72" },
     { name = "types-openpyxl", specifier = ">=3.1.5.20250919" },
     { name = "vulture", specifier = ">=2.14" },
 ]
@@ -2245,27 +2267,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.9"
+version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
-    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]
@@ -2356,26 +2378,34 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.46"
+version = "2.1.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b4/3eae7859c5a749016162e0d1ff09810e1221b731f2d28d422b9f2324d9df/sqlalchemy-2.1.0b3.tar.gz", hash = "sha256:68e9cd28deb1ea91c57c63bc16410f654e0c6c06942b3447d4af9f9feb633da5", size = 10284525, upload-time = "2026-06-27T18:52:29.689Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/f8/5ecdfc73383ec496de038ed1614de9e740a82db9ad67e6e4514ebc0708a3/sqlalchemy-2.0.46-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada", size = 2152079, upload-time = "2026-01-21T19:05:58.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/bf/eba3036be7663ce4d9c050bc3d63794dc29fbe01691f2bf5ccb64e048d20/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366", size = 3272216, upload-time = "2026-01-21T18:46:52.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/45/1256fb597bb83b58a01ddb600c59fe6fdf0e5afe333f0456ed75c0f8d7bd/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d", size = 3277208, upload-time = "2026-01-21T18:40:16.38Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a0/2053b39e4e63b5d7ceb3372cface0859a067c1ddbd575ea7e9985716f771/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e", size = 3221994, upload-time = "2026-01-21T18:46:54.622Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/87/97713497d9502553c68f105a1cb62786ba1ee91dea3852ae4067ed956a50/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf", size = 3243990, upload-time = "2026-01-21T18:40:18.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/87/5d1b23548f420ff823c236f8bea36b1a997250fd2f892e44a3838ca424f4/sqlalchemy-2.0.46-cp314-cp314-win32.whl", hash = "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908", size = 2114215, upload-time = "2026-01-21T18:42:55.232Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/20/555f39cbcf0c10cf452988b6a93c2a12495035f68b3dbd1a408531049d31/sqlalchemy-2.0.46-cp314-cp314-win_amd64.whl", hash = "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b", size = 2139867, upload-time = "2026-01-21T18:42:56.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f0/f96c8057c982d9d8a7a68f45d69c674bc6f78cad401099692fe16521640a/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa", size = 3561202, upload-time = "2026-01-21T18:33:10.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/53/3b37dda0a5b137f21ef608d8dfc77b08477bab0fe2ac9d3e0a66eaeab6fc/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863", size = 3526296, upload-time = "2026-01-21T18:45:12.657Z" },
-    { url = "https://files.pythonhosted.org/packages/33/75/f28622ba6dde79cd545055ea7bd4062dc934e0621f7b3be2891f8563f8de/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede", size = 3470008, upload-time = "2026-01-21T18:33:11.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/42/4afecbbc38d5e99b18acef446453c76eec6fbd03db0a457a12a056836e22/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330", size = 3476137, upload-time = "2026-01-21T18:45:15.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", size = 1937882, upload-time = "2026-01-21T18:22:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5b/85b4ccdedb39cc1ad9164289fdd94a5bd0a015b05252aac1a11eb089e498/sqlalchemy-2.1.0b3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a8ca6931a259f32cafe93054a227d64b16fa68d29ba22d60ba223762a2dae272", size = 2329551, upload-time = "2026-06-27T19:36:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b4/ef2fa5ebf56cb38d021d7423231d004082975aa2a0a811496ca0149264a0/sqlalchemy-2.1.0b3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95ced600a762b3c3d0e3a39986c87613425442b99bc03947d6c4c78983090430", size = 4041979, upload-time = "2026-06-27T20:45:58.238Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b2/f6a540617ae24a07cf4ea363ccffb28efae672f9b00a0b2d805b7536b24b/sqlalchemy-2.1.0b3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09e36e4e770483e86c5408bb8cd76286ff4ab21cfc732da2d46cccd5fd11130", size = 4065456, upload-time = "2026-06-27T20:50:19.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/c052d78f4024fb9eaac2f066ff26644cbbb96f52069ac81c5cb28dc58e14/sqlalchemy-2.1.0b3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ba1dacc33b3da57b9cb92216492a41c9124d5011fad1265c6e885a3b2882e428", size = 3813492, upload-time = "2026-06-28T02:09:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/74/b232ad26ab9beb950679f65839aea00cc52c9600c529f19c7e080fdb5b0b/sqlalchemy-2.1.0b3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01175cf8f66306fd33da4bf11f6899df9dc8c117b1604556967eed97c66a250a", size = 3978328, upload-time = "2026-06-27T20:46:00.032Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5f/a1e0eda9b8a5f975b09de0e432c6b7da032866243db4604d9c7f44ab881f/sqlalchemy-2.1.0b3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:10e978f7675cc462fe47411194a7c71da7d6f78e967604f119b629756a26485e", size = 3815045, upload-time = "2026-06-28T02:09:37.037Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/78/cbbd73debafbf5470af955415d5e712ff84ca147bb2838b132c5f9a020a9/sqlalchemy-2.1.0b3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:030fb4bae174e47df07f2f2d03e122eafe2d901df5655cd8cc2756396343a38f", size = 4033676, upload-time = "2026-06-27T20:50:21.882Z" },
+    { url = "https://files.pythonhosted.org/packages/02/eb/c2109bc126c13fc0a163eea51b790e96ce8add3c81eabd849fc698ff0e33/sqlalchemy-2.1.0b3-cp314-cp314-win32.whl", hash = "sha256:509d9512ba8a1407b29fa9884fb8873c8997ec0d96ad35ddac532f7f86185741", size = 2267886, upload-time = "2026-06-27T20:50:06.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/94f3db2443ba2b7189e94438ff0491a16a3157121dd2b0893e3900b38805/sqlalchemy-2.1.0b3-cp314-cp314-win_amd64.whl", hash = "sha256:0e2ab1d4f7571de1f03a928b52384ca5bf275c3c18e929183255d38d18c3b8ea", size = 2310553, upload-time = "2026-06-27T20:50:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5a/f1867cb2fa2c955db78b46de1fcfb64000e4862f8c529fdb1520806cf90a/sqlalchemy-2.1.0b3-cp314-cp314-win_arm64.whl", hash = "sha256:86ccaf41f89b98da04afc933e229ec54ede3674b4fe751f2cb3d8c002293a617", size = 2266448, upload-time = "2026-06-27T20:16:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/4cce08e36b9f0bc273370dd93debd43937515f9a4c312c875b1b0242f8d9/sqlalchemy-2.1.0b3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:998fd1e19275dba2889b53d57db2df95e190cd2867819342b856ec79c74bef00", size = 2360159, upload-time = "2026-06-27T20:05:09.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a7/8b01766945797344b7c21b24a61add71f6574029b3afb999ca465d28dea5/sqlalchemy-2.1.0b3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3bf8f31ef487cb609918ab7a04dfade2a15cdbd5430de6fd6b7421a336c6a581", size = 4345945, upload-time = "2026-06-27T19:36:20.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f8/593826aeeba004f1448393033cc9c52a8b074d7360476a3bcf7c36114b4f/sqlalchemy-2.1.0b3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c7c780f4b6a720b80ea43eb2932cad9ab2a49afbb29ef6d96ac9ac93bedf18b", size = 4269641, upload-time = "2026-06-27T19:53:21.09Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2b/68eff5440c564272195b7ec3f1aa9cb133c68b4752619ea03a3c1d463417/sqlalchemy-2.1.0b3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1bc8dd7d8f5290d337096873e6b6c6c01ffe8fbec3f6b897aa9e13003ecf6cf3", size = 3994407, upload-time = "2026-06-27T23:37:12.999Z" },
+    { url = "https://files.pythonhosted.org/packages/49/88/dd0df1d0164be2112d26c5b86519200a35cf3cd34f27868c890bc9b6781b/sqlalchemy-2.1.0b3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4560bf101d13ab20d75ebf70ce852eac6a9c16372a820c39812ddbed0b2d9adb", size = 4226062, upload-time = "2026-06-27T19:36:22.499Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/28/3c37c2f187667b9cd28953528e36e9cb1578786cfee7a79908a61a7d6255/sqlalchemy-2.1.0b3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f178f1e2ad2ea8fe843570b463297c0b87274d7302286ddd9f42af988c0a0cdf", size = 3997608, upload-time = "2026-06-27T23:37:15.46Z" },
+    { url = "https://files.pythonhosted.org/packages/44/01/493f0ed70053bebabbbc012914e02f41f028ac127e9dc1f30655bdde207d/sqlalchemy-2.1.0b3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:656d6539bee0895fd82823ad111ef49d971289563701b59586d595db84746f00", size = 4215732, upload-time = "2026-06-27T19:53:23.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/a77b241714390c2fb82d9136024abd1e14abad32b944da390c7b916c793a/sqlalchemy-2.1.0b3-cp314-cp314t-win32.whl", hash = "sha256:2b0e40f34bd7f936472a4cfdc215a3bdfdb2f5c8697eb55f90c471e7d33b51c3", size = 2315354, upload-time = "2026-06-27T20:34:18.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/91/9068db9cf0e6105502b49b26b3833b8a43b37aa8233d8b997dd6829720b4/sqlalchemy-2.1.0b3-cp314-cp314t-win_amd64.whl", hash = "sha256:f45b74e818c347d5dfbb64e8b962cb7a21404d70f39318aebfd51e2f0fb244b1", size = 2372038, upload-time = "2026-06-27T20:34:21.082Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ff/7b97eb3e81fe5232ca8e90c5a35c5c4afdfa8e3e0944a4a8ff7193991d36/sqlalchemy-2.1.0b3-cp314-cp314t-win_arm64.whl", hash = "sha256:fab024f1624b76182609884a03877b4e1a5aecd76616c4b74ffaace50cf85dee", size = 2288736, upload-time = "2026-06-27T20:11:00.162Z" },
+    { url = "https://files.pythonhosted.org/packages/02/21/341897a151b5d17d069b855cdda4da5d616e12a9456a80909cd775c74d11/sqlalchemy-2.1.0b3-py3-none-any.whl", hash = "sha256:53266e619324e252dd517d2b061316cf01e4376857d8e5b65fd74dc92fd0c326", size = 1995669, upload-time = "2026-06-27T19:35:57.589Z" },
 ]
 
 [[package]]
@@ -2504,6 +2534,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.72"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/df/656e684bafb13c1d146e7d5b5f3e7978ca177232acc84998ff36427e9462/ty-0.0.72.tar.gz", hash = "sha256:ec2b8066b618df18cab4cb8e992f8da45d360332acb23fa34df7fa29cd1b9d3a", size = 6654939, upload-time = "2026-08-14T21:35:42.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/3b/f51461239a4e66565d4b362f97a3b55fe7fdba2e944068341f87c62f6743/ty-0.0.72-py3-none-linux_armv6l.whl", hash = "sha256:fda86db153ffd85ee52000cf175d6a3f1c0223772cf7c5b6f726200bf92c7b44", size = 12621989, upload-time = "2026-08-14T21:35:01.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/79ddf683affc679ca856f3510b5640ec3a88a842ba5f654f5d4bc78f1786/ty-0.0.72-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ceb944c612529b9023acfdc9cf4c0dcbb722549f9d17d46baecd1141baf01d7f", size = 12233910, upload-time = "2026-08-14T21:35:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/45/10562a0d84802158db8fa4ec46de54aa9fdcecdeeaabbfe3639ae7042b66/ty-0.0.72-py3-none-macosx_11_0_arm64.whl", hash = "sha256:108d76218333d6c092e5f1cebf8e9b06f25738613a0236a28e2dd47c936ee52c", size = 12084108, upload-time = "2026-08-14T21:35:06.686Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/dc/1fe1aef8d697e3509face271a5331700c7aa1d1e44a4b622707bdfa41d4b/ty-0.0.72-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f3943f186f741a2499a31053872169250c9264a9a49684920e48d8fcf4ef4f5", size = 12132640, upload-time = "2026-08-14T21:35:09.305Z" },
+    { url = "https://files.pythonhosted.org/packages/14/46/41ceb265e96969487311a2014bd0e53abb4fbc1395efb2ebe411fcb4db62/ty-0.0.72-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf283c07dc3cc52ca48a3ad8ab100fb5aec3aebbd03ef6a12d5f910b8e596fc5", size = 12402489, upload-time = "2026-08-14T21:35:11.555Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/45/30bf43cb4fd505c5c2dd30fda27dde5f05208686cd21217adec77c954204/ty-0.0.72-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:95f3b6462c38f9f115d10cee21f47fedf715fcf2040daf36eef210359300bc7c", size = 13130835, upload-time = "2026-08-14T21:35:13.746Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2f/03bba754d2613f640df168335c41f83f41db150bb515839c60d80e3a7880/ty-0.0.72-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30caf658feb8ffb250d9e9e47107657a78f5f3425c227df1664d8df2ebe38880", size = 13590392, upload-time = "2026-08-14T21:35:16.839Z" },
+    { url = "https://files.pythonhosted.org/packages/04/c7/03c67f00e63005ec41585653dc3096064570b1e6273742baae2798cd242f/ty-0.0.72-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27bdc012ddfbeec8948e4a6036c0dc39ac7cf2c8ec7c7d48dc7d2fd56d57b399", size = 13309629, upload-time = "2026-08-14T21:35:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/df/102d3b264eb7f2a58dd11952f229bb5150bb5668d176a6154976a6675981/ty-0.0.72-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:802c5970a77d7739e6f499921fbb6984fb7ad8a31d95e1ff42fd46f3642e4f3b", size = 12734028, upload-time = "2026-08-14T21:35:22.099Z" },
+    { url = "https://files.pythonhosted.org/packages/61/85/d0737c8c54d0ba67366ddfb9f31d88edf0b02299e65923e6945ae60ebcb5/ty-0.0.72-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:47dce65114fdc615c68ca0edb393b433df0956447e4267df0e264137a789598d", size = 13174832, upload-time = "2026-08-14T21:35:24.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/31/497f5a96c36d9b586ab6afe0574986835c6fd5b835a89773d2bec4711b49/ty-0.0.72-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:325144fa07e2675d0faa337fcc864213c272a499eb0cfe5bde2fdc62282d27bc", size = 12215005, upload-time = "2026-08-14T21:35:26.892Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/46e65b17b4966c7cd0140f134380d33d8e84fe6efccd761533ce793dc502/ty-0.0.72-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a5c9f15d0f58e43707d8848274be1821a0ef408eccb8aa7dda28a4a9eddf7640", size = 12421298, upload-time = "2026-08-14T21:35:29.301Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2a/12ada4ec17700b3cb1d4fd3bc3e5b1852df9e6885288429318cade87b3c1/ty-0.0.72-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee508d64b381871529cc22c412b41071bf5e908b7aa5d66a38f3f6b2573a806", size = 12669242, upload-time = "2026-08-14T21:35:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/4692536880790fb550ed6d44a6096778dc71bb112f2c6d615cebb01a57e5/ty-0.0.72-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3699e2ec7921d44da79d6b089f7bf239b2cc53c4e45a5a38430adc34ee9e9a55", size = 12988199, upload-time = "2026-08-14T21:35:33.749Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0d/f5e5a50322e9c45865e7b7a428ba6cd6527387cf0f2472492ac3cf746243/ty-0.0.72-py3-none-win32.whl", hash = "sha256:f25f72a67bd36cd247707c4784e52fad0b6b4f42a1b7dd14804110fa95c486ed", size = 11939708, upload-time = "2026-08-14T21:35:36.006Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4e/8af3534b2e4214e6184a5a59c34101e94a68d578f081f97b995866bab1bf/ty-0.0.72-py3-none-win_amd64.whl", hash = "sha256:cdeee869341717e1736cea2e2d7856738c6957c320f584ed2f68c8f90100d2f5", size = 12643876, upload-time = "2026-08-14T21:35:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/a2606e654c7276bd08586391a2525b0af3f3bf60228a8c57b2d248f273f9/ty-0.0.72-py3-none-win_arm64.whl", hash = "sha256:1bd3ac3ed4424a6d6990a85dc388556aea012bd752de21349a84b685951de0d8", size = 12394857, upload-time = "2026-08-14T21:35:40.277Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Stacked PR — reviews second.** This branch stacks on #535
> (`perf/initial-snapshot-delivery`) and targets that branch, not main.
> Merge #535 first; this PR then retargets/merges on top of it.

## What this is

The August toolchain-and-conventions campaign: the lint/type toolchain moves
into uv.lock as exact-pinned dev dependencies, four new ADRs land, the read
path migrates to raw SQL t-strings on SQLAlchemy 2.1.0b3, ~85 signatures
restructure under newly-enforced PLR rules, and every over-complexity
function decomposes below the gate. Nine commits, each one concern.

## The ADR story (docs/decisions/)

- **ADR 0004 — raw SQL for reads.** Query-shaped reads use
  `tstring(t"...")` (PEP 750, auto-bound params). SQLModel keeps schema,
  Alembic, and simple writes. Ratified corollary: an `ORDER BY` marks a
  display read, which marks a t-string migration (carve-outs: queue-claim
  `FOR UPDATE SKIP LOCKED`, identity-map-dependent reads).
  `docs/architecture/raw-sql-convention.md` carries the idiom and the ty
  gotchas (Row binding, `to_jsonb` type allowlist, tzinfo asymmetry).
- **ADR 0005 — SQLAlchemy 2.1.0b3** under SQLModel via
  `[tool.uv] override-dependencies`. Gate: full `e2e all` green on the
  beta (met — see evidence). Reversal clause: fall back to `text()` on 2.0.x.
- **ADR 0006 — toolchain single-sourced in uv.lock.** ty==0.0.72,
  ruff==0.16.3, complexipy==7.0.1 as exact-pinned dev deps; `uv run`
  everywhere (hooks, pre-commit, CI); bounded `exclude-newer-package`
  exceptions under the ADR 0003 controlled-upgrade ritual.
- **ADR 0007 — PLR0913/PLR0917/PLR2004 enforced.** Scoped ignores only
  (tests: PLR2004+PLR0913; `unicode_latex.py`/`word_count.py`: PLR2004).
  Every remaining noqa carries caller evidence and a tracker link.

## Campaign totals

| Gate | Before | After |
|---|---|---|
| ty diagnostics | 276 | 0 |
| ruff errors | 203 | 0 |
| complexipy >15 | 24 functions | 0 |

Zero banned suppressions introduced.

## Also in here

- **Four EXPLAIN-promoted partial indices** (Alembic `c9d1e7a40b21`):
  `user(id) WHERE is_admin`, `workspace(activity_id|course_id) WHERE
  shared_with_class`, `workspace(id) WHERE search_dirty`. Only candidates
  the planner actually chose were promoted; measurements in
  `docs/implementation-plans/2026-08-17-ty-bump-toolchain/index-candidates.md` §6.
  Migration is concurrent + `if_not_exists`, up/down round-tripped.
- **`resolve_annotation_context` raw-SQL hydration** (`to_jsonb`
  per-entity, single round trip, DBA-reviewed with all four conditions
  implemented) — this sits on #535's measured perf path; a 100-way
  re-attachment leg runs against the stacked head after merge.
- **Test-runner fixes**: per-lane dispatch for mixed invocations
  (previously silently dropped foreign paths — a false-green, hit twice
  in one day) and `--help` no longer takes the cross-worktree lock.
- **New tests**: instructor-marking E2E journey (enrollment-derived staff
  access with no ACL row, SQL-asserted), behavioural share-button truth
  tables (replacing an inline tautology + ast-grep shape guard),
  contamination-hardened shared fixtures, `to_jsonb` field-type AST guard,
  loadtest query integration tests.

## Merge flags

- **Hooks**: `.claude/hooks/{python_lint,final_lint}.py` must resolve to
  the versionless `uv run --quiet ty check` form. A `ty@<version>` pin
  reappearing there is a merge mistake (agreed with the #535 session).
- Tracker: `docs/implementation-plans/2026-08-17-ty-bump-toolchain/tracker.md`
  holds the findings ledger, including parked items (two pre-existing
  placement bugs, dead-ACL-path un-fork decision) scheduled for the
  follow-up test-quality layer.

## Evidence

- Static: ty 0 / ruff 0 / format clean / complexipy 0-over on the stacked tree.
- `test all`: 4090 unit + 123 JS + BATS, green on the stack.
- `e2e all`: all 8 lanes green on the stacked head (and previously on the
  pre-rebase chain; `e2e slow` 10 lanes green pre-rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
