### PR TITLE
fix(export): preserve code-block annotations in PDF export (#495)

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -230,12 +230,14 @@ The annotation export uses a pre-Pandoc span injection + Lua filter pipeline (Is
 
 1. **Region computation** - `compute_highlight_spans()` in `highlight_spans.py` computes non-overlapping regions from overlapping highlights using an event-sweep algorithm, then inserts `<span data-hl="..." data-colors="..." data-annots="...">` elements into clean HTML
 2. **Block boundary splitting** - Boundary detection in `span_boundaries.py`. Spans are pre-split at block element boundaries (p, h1-h6, li, etc.) and inline formatting boundaries (b, em, code, etc.) because Pandoc silently destroys cross-boundary spans
-3. **Pandoc conversion** - HTML to LaTeX with `highlight.lua` Lua filter included
-4. **Lua filter rendering** - `highlight.lua` reads span attributes and emits nested `\highLight` / `\underLine` / `\annot` LaTeX commands using a "one, two, many" stacking model:
+3. **Code-block metadata promotion** - `promote_code_block_highlights()` in `html_normaliser.py` moves selected line numbers, colour, and annotation commands onto `<pre>` attributes before Pandoc flattens its descendants into a `CodeBlock`
+4. **Pandoc conversion** - HTML to LaTeX with `highlight.lua` Lua filter included
+5. **Lua filter rendering** - `highlight.lua` reads span attributes and emits nested `\highLight` / `\underLine` / `\annot` LaTeX commands using a "one, two, many" stacking model:
    - 1 highlight: single 1pt underline in tag's dark colour
    - 2 highlights: stacked 2pt outer + 1pt inner underlines
    - 3+ highlights: single 4pt underline in many-dark colour
-5. **Post-processing** - `\annot` commands (which contain `\par`) are moved outside restricted LaTeX contexts (e.g. `\section{}` arguments)
+   - Annotated code blocks use `fvextra` for wrapped verbatim text and selected-line backgrounds; unannotated code blocks retain Pandoc's native rendering
+6. **Post-processing** - `\annot` commands (which contain `\par`) are moved outside restricted LaTeX contexts (e.g. `\section{}` arguments)
 
 Key files:
 - `highlight_spans.py` - `compute_highlight_spans()`, `_HlRegion`, region computation + DOM insertion

--- a/scripts/setup_latex.py
+++ b/scripts/setup_latex.py
@@ -67,6 +67,7 @@ REQUIRED_PACKAGES = [
     "luabidi",  # Bidirectional text for LuaLaTeX (for dir="ltr" HTML elements)
     # Code blocks
     "fancyvrb",  # Verbatim/code blocks from Pandoc syntax highlighting
+    "fvextra",  # Line wrapping and selected-line backgrounds in code blocks
     # Speaker turns
     "tcolorbox",  # Breakable coloured boxes for speaker turns with left border
     "pdfcol",  # Colour stack management (tcolorbox breakable dependency)

--- a/src/promptgrimoire/export/filters/highlight.lua
+++ b/src/promptgrimoire/export/filters/highlight.lua
@@ -28,6 +28,74 @@ local function light_to_dark(name)
   return (string.gsub(name, "%-light$", "-dark"))
 end
 
+local annotated_code_counter = 0
+
+--- Return a generated verbatim environment name absent from the code text.
+--- A content-derived collision check prevents a literal \end{...} in user code
+--- from terminating the environment and becoming executable LaTeX.
+--- @param text string  code block contents
+--- @return string  safe environment name
+local function next_code_environment(text)
+  while true do
+    annotated_code_counter = annotated_code_counter + 1
+    local name = "PGAnnotatedCode" .. annotated_code_counter
+    if not string.find(text, "\\end{" .. name .. "}", 1, true) then
+      return name
+    end
+  end
+end
+
+--- Validate and normalise a comma-separated list of positive line numbers.
+--- @param value string|nil  generated block attribute
+--- @return string|nil  safe LaTeX option value
+local function code_highlight_lines(value)
+  if value == nil or value == "" then return nil end
+  local result = {}
+  for line in string.gmatch(value, "[^,]+") do
+    if not string.match(line, "^%d+$") then return nil end
+    table.insert(result, line)
+  end
+  if #result == 0 then return nil end
+  return table.concat(result, ",")
+end
+
+--- CodeBlock callback: retain annotations that Pandoc's HTML reader would drop.
+--- Python promotes descendant span metadata onto the <pre> element.  Annotated
+--- blocks use fvextra for line-level selection highlighting; ordinary blocks
+--- retain Pandoc's native writer path unchanged.
+function CodeBlock(el)
+  if FORMAT ~= "latex" then return el end
+
+  local lines = code_highlight_lines(el.attributes["pg-code-lines"])
+  local annots = el.attributes["pg-code-annots"] or ""
+  if lines == nil and annots == "" then return el end
+
+  local colour = el.attributes["pg-code-color"] or "FancyVerbHighlightColor"
+  if not string.match(colour, "^[%w%-]+$") then
+    colour = "FancyVerbHighlightColor"
+  end
+
+  local options = {"breaklines=true", "breakanywhere=true"}
+  if lines ~= nil then
+    table.insert(options, "highlightlines={" .. lines .. "}")
+    table.insert(options, "highlightcolor=" .. colour)
+  end
+
+  local environment = next_code_environment(el.text)
+  local latex =
+    "\\DefineVerbatimEnvironment{" .. environment .. "}{Verbatim}{" ..
+    table.concat(options, ",") .. "}\n" ..
+    "\\begin{" .. environment .. "}\n" ..
+    el.text .. "\n" ..
+    "\\end{" .. environment .. "}\n"
+
+  if annots ~= "" then
+    latex = latex .. "\\noindent " .. annots .. "\n"
+  end
+
+  return pandoc.RawBlock("latex", latex)
+end
+
 --- Build underline open/close RawInline pairs based on highlight count.
 --- Returns two lists: opens (outermost first) and closes (innermost first).
 --- @param colors_list table  list of light colour names

--- a/src/promptgrimoire/export/html_normaliser.py
+++ b/src/promptgrimoire/export/html_normaliser.py
@@ -4,6 +4,7 @@ Provides HTML sanitization and normalization for the PDF export pipeline:
 - strip_scripts_and_styles: Remove <script>, <style>, and noscript content
 - normalise_styled_paragraphs: Wrap styled <p> tags for Pandoc attribute preservation
 - fix_midword_font_splits: Fix LibreOffice RTF mid-word font tag splits
+- promote_code_block_highlights: Preserve metadata Pandoc drops inside CodeBlock
 
 These functions handle browser copy-paste content which may contain JavaScript,
 CSS, and other non-content elements that shouldn't appear in PDFs.
@@ -18,6 +19,11 @@ from lxml import html as lxml_html
 from lxml.html import HtmlElement
 
 logger = structlog.get_logger()
+
+_CODE_LINES_ATTR = "data-pg-code-lines"
+_CODE_COLOR_ATTR = "data-pg-code-color"
+_CODE_ANNOTS_ATTR = "data-pg-code-annots"
+_CODE_METADATA_ATTRS = (_CODE_LINES_ATTR, _CODE_COLOR_ATTR, _CODE_ANNOTS_ATTR)
 
 
 def strip_scripts_and_styles(html_content: str) -> str:
@@ -186,6 +192,92 @@ def normalise_styled_paragraphs(html_content: str) -> str:
     # Serialize back to HTML string
     result = lxml_html.tostring(tree, encoding="unicode")
     return result
+
+
+def _highlighted_line_numbers(
+    pre: HtmlElement,
+) -> tuple[set[int], list[str], list[str]]:
+    """Collect highlighted code lines, colours, and annotations from *pre*."""
+    line_number = 1
+    lines: set[int] = set()
+    colours: list[str] = []
+    annotations: list[str] = []
+
+    def record_text(text: str | None, *, highlighted: bool) -> None:
+        nonlocal line_number
+        if not text:
+            return
+        for character in text:
+            if character == "\n":
+                line_number += 1
+            elif highlighted and character != "\r":
+                lines.add(line_number)
+
+    def walk(element: HtmlElement, *, highlighted: bool = False) -> None:
+        is_highlight = element.tag == "span" and element.get("data-hl") is not None
+        active = highlighted or is_highlight
+
+        if is_highlight:
+            for colour in (element.get("data-colors") or "").split(","):
+                if colour and colour not in colours:
+                    colours.append(colour)
+            annotation = element.get("data-annots")
+            if annotation:
+                annotations.append(annotation)
+
+        record_text(element.text, highlighted=active)
+        for child in element:
+            if not isinstance(child, HtmlElement):
+                continue
+            walk(child, highlighted=active)
+            record_text(child.tail, highlighted=active)
+
+    walk(pre)
+    return lines, colours, annotations
+
+
+def promote_code_block_highlights(html_content: str) -> str:
+    """Move annotated-code metadata onto ``pre`` before Pandoc flattens it.
+
+    Pandoc represents ``<pre><code>`` as a single ``CodeBlock`` and discards
+    descendant spans.  The block attributes survive, so this pass records the
+    selected line numbers, display colour, and annotation commands there for
+    the Lua filter.  Unannotated code blocks are returned unchanged.
+    """
+    if not html_content:
+        return html_content
+    if "data-hl" not in html_content and not any(
+        attribute in html_content for attribute in _CODE_METADATA_ATTRS
+    ):
+        return html_content
+
+    try:
+        tree = lxml_html.fromstring(html_content)
+    except Exception:
+        logger.warning("html_parse_failed", operation="promote_code_block_highlights")
+        return html_content
+
+    # These attributes are an internal Python→Lua channel.  Remove any
+    # source-provided values before deriving them from computed highlight spans.
+    for element in tree.xpath("descendant-or-self::*"):
+        if not isinstance(element, HtmlElement):
+            continue
+        for attribute in _CODE_METADATA_ATTRS:
+            element.attrib.pop(attribute, None)
+
+    code_blocks = tree.xpath("descendant-or-self::pre[.//span[@data-hl]]")
+    for pre in code_blocks:
+        if not isinstance(pre, HtmlElement):
+            continue
+        lines, colours, annotations = _highlighted_line_numbers(pre)
+        if lines:
+            pre.set(_CODE_LINES_ATTR, ",".join(str(line) for line in sorted(lines)))
+        if colours:
+            pre.set(_CODE_COLOR_ATTR, colours[0])
+        if annotations:
+            pre.set(_CODE_ANNOTS_ATTR, "".join(annotations))
+
+    return lxml_html.tostring(tree, encoding="unicode")
 
 
 def fix_midword_font_splits(html_content: str) -> str:

--- a/src/promptgrimoire/export/pandoc.py
+++ b/src/promptgrimoire/export/pandoc.py
@@ -22,6 +22,7 @@ from promptgrimoire.export.highlight_spans import compute_highlight_spans
 from promptgrimoire.export.html_normaliser import (
     fix_midword_font_splits,
     normalise_styled_paragraphs,
+    promote_code_block_highlights,
     strip_scripts_and_styles,
 )
 from promptgrimoire.export.list_normalizer import normalize_list_values
@@ -416,6 +417,10 @@ async def convert_html_with_annotations(
 
     # Inject paragraph number markers for PDF margin display
     span_html = inject_paragraph_markers_for_export(span_html, word_to_legal_para)
+
+    # Pandoc flattens descendants of <pre><code> into a metadata-free
+    # CodeBlock. Promote selection and annotation metadata to the block first.
+    span_html = promote_code_block_highlights(span_html)
 
     # Build filter list: always include highlight.lua, plus caller's filters
     filters: list[Path] = [_HIGHLIGHT_FILTER]

--- a/src/promptgrimoire/export/promptgrimoire-export.sty
+++ b/src/promptgrimoire/export/promptgrimoire-export.sty
@@ -26,6 +26,7 @@
 \RequirePackage{soul}             % Strikethrough (\st) — Pandoc 3.x emits \st{}
 \RequirePackage{accsupp}          % PDF /ActualText for emoji accessibility (#274)
 \RequirePackage{fancyvrb}  % Verbatim/code blocks from Pandoc syntax highlighting
+\RequirePackage{fvextra}   % Wrapped and line-highlighted annotated code blocks
 \RequirePackage[a4paper,left=2.5cm,right=6cm,top=2.5cm,bottom=2.5cm]{geometry}
 \RequirePackage[skins,breakable]{tcolorbox}  % For speaker turn borders (breakable for oversized turns)
 

--- a/tests/integration/test_code_block_annotation_export.py
+++ b/tests/integration/test_code_block_annotation_export.py
@@ -1,0 +1,213 @@
+"""Regression coverage for annotations inside preformatted code blocks (#495)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pymupdf
+import pytest
+
+from promptgrimoire.export.pandoc import convert_html_with_annotations
+from promptgrimoire.export.pdf_export import export_annotation_pdf
+from promptgrimoire.input_pipeline.html_input import extract_text_from_html
+from tests.conftest import requires_full_latexmk, requires_pandoc
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_HTML = (
+    "<pre><code>alpha = 1\n"
+    "beta_target &lt;- function(value) {\n"
+    "  value %&gt;% transform()\n"
+    "}\n"
+    "gamma = 3</code></pre>"
+)
+_ANNOTATION_TEXT = "Code block annotation survived export"
+
+
+def _code_highlight(
+    html: str = _HTML,
+    *,
+    needle: str = "beta_target",
+) -> dict[str, object]:
+    """Build a production-shaped highlight over *needle*."""
+    text = "".join(extract_text_from_html(html))
+    start = text.index(needle)
+    return {
+        "start_char": start,
+        "end_char": start + len(needle),
+        "tag": "code",
+        "tag_name": "Code",
+        "author": "Export Tester",
+        "created_at": "2026-08-17T02:44:21+00:00",
+        "comments": [
+            {
+                "author": "Export Tester",
+                "text": _ANNOTATION_TEXT,
+                "created_at": "2026-08-17T02:44:21+00:00",
+            }
+        ],
+    }
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_code_block_annotation_reaches_latex() -> None:
+    """The Pandoc boundary retains code, selection treatment, and note content."""
+    latex = await convert_html_with_annotations(
+        _HTML,
+        [_code_highlight()],
+        {"code": "#2ca02c"},
+    )
+
+    assert "beta_target <- function(value)" in latex
+    assert r"\annot{tag-code}" in latex
+    assert _ANNOTATION_TEXT in latex
+    assert "highlightlines={2}" in latex
+    assert "highlightcolor=tag-code-light" in latex
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_unannotated_code_block_keeps_pandoc_rendering() -> None:
+    """The fallback applies only when annotation metadata would be lost."""
+    latex = await convert_html_with_annotations(_HTML, [], {})
+
+    assert r"\begin{verbatim}" in latex
+    assert "PGAnnotatedCode" not in latex
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_cross_boundary_annotation_is_not_silently_dropped() -> None:
+    """A selection ending in code keeps ordinary highlighting and its note."""
+    html = "<p>ordinary text</p><pre><code>code target</code></pre>"
+    text = "".join(extract_text_from_html(html))
+    start = text.index("ordinary")
+    end = text.index("target") + len("target")
+    highlight = _code_highlight(html, needle="ordinary")
+    highlight["start_char"] = start
+    highlight["end_char"] = end
+
+    latex = await convert_html_with_annotations(
+        html,
+        [highlight],
+        {"code": "#2ca02c"},
+    )
+
+    assert r"\highLight[tag-code-light]{" in latex
+    assert "highlightlines={1}" in latex
+    assert r"\annot{tag-code}" in latex
+    assert _ANNOTATION_TEXT in latex
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_distinct_identical_annotations_are_both_preserved() -> None:
+    """Equal-looking annotations on separate selections keep distinct identity."""
+    text = "".join(extract_text_from_html(_HTML))
+    alpha_start = text.index("alpha")
+    gamma_start = text.index("gamma")
+    first = _code_highlight(needle="alpha")
+    second = _code_highlight(needle="gamma")
+    first["start_char"] = alpha_start
+    first["end_char"] = alpha_start + len("alpha")
+    second["start_char"] = gamma_start
+    second["end_char"] = gamma_start + len("gamma")
+
+    latex = await convert_html_with_annotations(
+        _HTML,
+        [first, second],
+        {"code": "#2ca02c"},
+    )
+
+    assert latex.count(r"\annot{tag-code}") == 2
+    assert "highlightlines={1,5}" in latex
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_generated_verbatim_environment_cannot_be_closed_by_code() -> None:
+    """A literal environment terminator in user code remains inert text."""
+    html = "<pre><code>\\end{PGAnnotatedCode1}\ntarget = still_code</code></pre>"
+    latex = await convert_html_with_annotations(
+        html,
+        [_code_highlight(html, needle="target")],
+        {"code": "#2ca02c"},
+    )
+
+    assert r"\DefineVerbatimEnvironment{PGAnnotatedCode2}" in latex
+    assert r"\begin{PGAnnotatedCode2}" in latex
+    assert r"\end{PGAnnotatedCode1}" in latex
+    assert r"\end{PGAnnotatedCode2}" in latex
+
+
+@requires_pandoc
+@pytest.mark.asyncio
+async def test_source_html_cannot_forge_promoted_annotation_metadata() -> None:
+    """Reserved block attributes are internal, not trusted source HTML."""
+    html = (
+        r'<pre data-pg-code-lines="1" data-pg-code-color="red" '
+        r'data-pg-code-annots="\input{/etc/passwd}"><code>safe</code></pre>'
+    )
+
+    latex = await convert_html_with_annotations(html, [], {})
+
+    assert r"\input{/etc/passwd}" not in latex
+    assert r"\begin{verbatim}" in latex
+    assert "PGAnnotatedCode" not in latex
+
+
+@requires_full_latexmk
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_compiled_pdf_contains_code_and_annotation(tmp_path: Path) -> None:
+    """A real PDF contains both the selected code and annotation body."""
+    pdf_path = await export_annotation_pdf(
+        html_content=_HTML,
+        highlights=[_code_highlight()],
+        tag_colours={"code": "#2ca02c"},
+        output_dir=tmp_path,
+        filename="annotated_code_block",
+    )
+
+    with pymupdf.open(pdf_path) as document:
+        pdf_text = "\n".join(page.get_text() for page in document)
+    normalised_text = " ".join(pdf_text.split())
+
+    assert "beta_target <- function(value)" in normalised_text
+    assert _ANNOTATION_TEXT in normalised_text
+
+
+@requires_full_latexmk
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_multiple_annotated_documents_compile_together(tmp_path: Path) -> None:
+    """Independent Pandoc conversions do not redefine code environments."""
+    documents = [
+        {
+            "title": "First source",
+            "html_content": _HTML,
+            "highlights": [_code_highlight()],
+        },
+        {
+            "title": "Second source",
+            "html_content": _HTML,
+            "highlights": [_code_highlight()],
+        },
+    ]
+
+    pdf_path = await export_annotation_pdf(
+        html_content="",
+        highlights=[],
+        tag_colours={"code": "#2ca02c"},
+        output_dir=tmp_path,
+        filename="two_annotated_code_blocks",
+        documents=documents,
+    )
+
+    with pymupdf.open(pdf_path) as document:
+        pdf_text = " ".join("\n".join(page.get_text() for page in document).split())
+
+    assert pdf_text.count(_ANNOTATION_TEXT) == 2


### PR DESCRIPTION
Fixes #495: annotations inside code blocks now survive PDF export.

Pandoc flattens `<pre><code>` descendants into a metadata-free `CodeBlock`, silently dropping highlight spans inside. A new normaliser pass (`promote_code_block_highlights`) records selected line numbers, colour, and annotation commands on the `<pre>` element before conversion; the Lua filter then renders annotated blocks through `fvextra` with wrapped verbatim text and selected-line backgrounds. Unannotated blocks keep Pandoc's native rendering unchanged.

Hardening built in:

- Generated verbatim environment names are collision-checked against a literal `\end{...}` in user code, so pasted code cannot break out into executable LaTeX.
- Line numbers and colour names are validated before reaching LaTeX options.
- The `data-pg-code-*` attributes are an internal Python→Lua channel: source-provided values are stripped before derivation, so pasted HTML cannot forge them (regression test asserts `\input{/etc/passwd}` in a forged attribute never reaches LaTeX).

Tests: 8 new integration tests including cross-boundary selections, duplicate annotations on separate selections, the environment-collision case, the forgery case, and two compiled-PDF tests that read the text back out of the real PDF.

**Deploy note:** `fvextra` joins `REQUIRED_PACKAGES` in `scripts/setup_latex.py` — the deploy path must run setup_latex before the first export uses this feature.

**UAT:** annotate text inside a code block, export the PDF, confirm both the code and the annotation appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
