### PR TITLE
fix(annotation): cache snapshot bundles so tab return survives token expiry

### DIFF
--- a/src/promptgrimoire/static/annotation-snapshot-bootstrap.js
+++ b/src/promptgrimoire/static/annotation-snapshot-bootstrap.js
@@ -29,11 +29,19 @@ async function loadAnnotationSnapshot(cfg) {
   var container = document.getElementById(cfg.containerId);
   if (!container) return false;
 
+  // Tab switches destroy the panel DOM (Quasar default); the
+  // re-rendered skeleton carries the SAME bundle URL, whose token
+  // (TTL 60s) has usually expired by then.  The bundle already
+  // reached this client once, so repeat mounts come from cache and
+  // never touch the network.
+  window.__snapshotBundleCache = window.__snapshotBundleCache || {};
+  var cache = window.__snapshotBundleCache;
+  var bundle = cache[cfg.url];
+
   // One silent retry covers a service restart blip or a dropped
   // connection without the student ever seeing an error.
   var retryDelay = cfg.retryDelayMs === undefined ? 1500 : cfg.retryDelayMs;
-  var bundle;
-  try {
+  if (!bundle) try {
     try {
       bundle = await fetchSnapshotBundle(cfg.url);
     } catch (firstErr) {
@@ -41,6 +49,7 @@ async function loadAnnotationSnapshot(cfg) {
       await new Promise(function (resolve) { setTimeout(resolve, retryDelay); });
       bundle = await fetchSnapshotBundle(cfg.url);
     }
+    cache[cfg.url] = bundle;
   } catch (err) {
     console.error('snapshot bundle load failed', err);
     container.dataset.snapshotState = 'error';

--- a/tests/js/annotation-snapshot-bootstrap.test.js
+++ b/tests/js/annotation-snapshot-bootstrap.test.js
@@ -32,6 +32,7 @@ afterEach(() => {
   document.body.innerHTML = '';
   CSS.highlights.clear();
   delete globalThis.fetch;
+  delete window.__snapshotBundleCache;
   delete window._textNodes;
   delete window._sidebarBundleApply;
   delete window.__pendingSidebarBundle;
@@ -209,6 +210,38 @@ describe('scanSnapshotContainers (declarative discovery)', () => {
       expect(container.dataset.snapshotState).toBe('done'),
     );
     expect(container.textContent).toContain('quick brown fox');
+  });
+
+  test('re-mounted container after token expiry mounts from cache, no re-fetch', async () => {
+    // Quasar destroys the source tab panel DOM on tab switch.  On
+    // return, NiceGUI re-renders the skeleton with the SAME bundle URL,
+    // whose token (TTL 60s) has usually expired — a re-fetch gets 403
+    // and the student loses the document until a full reload.  The
+    // bundle already reached this client once, so a repeat mount must
+    // come from cache without touching the network.
+    const container = mountArmedContainer('doc-container-remount');
+    mockFetch({ ok: true, json: async () => BUNDLE });
+    scanSnapshotContainers();
+    await vi.waitFor(() =>
+      expect(container.dataset.snapshotState).toBe('done'),
+    );
+
+    // Tab away: panel DOM destroyed. Token expires: fetch now 403s.
+    container.remove();
+    mockFetch({ ok: false, status: 403 });
+
+    // Tab back: fresh skeleton, same URL. Observer discovers it.
+    const remounted = mountArmedContainer('doc-container-remount');
+    await vi.waitFor(() =>
+      expect(remounted.dataset.snapshotState).toBe('done'),
+    );
+
+    expect(remounted.textContent).toContain('quick brown fox');
+    expect(remounted.querySelector('[data-testid="snapshot-error"]')).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    // The text walker must reference the NEW container's nodes.
+    expect(window._textNodes.length).toBeGreaterThan(0);
+    expect(remounted.contains(window._textNodes[0].node)).toBe(true);
   });
 
   test('observer picks up a container rendered after script load', async () => {


### PR DESCRIPTION
Fixes #563.

## Problem

With `SNAPSHOT__ENABLED=true`, a student who switches tabs and returns to the source tab more than ~60 s after page load loses the document pane until a full page reload. Quasar destroys the tab panel DOM on switch; NiceGUI re-renders the skeleton with the **same** bundle URL, whose token (`TOKEN_TTL_SECONDS = 60`) has expired — the bootstrap re-fetches, gets 403 twice (initial + silent retry), and shows the error card.

## Fix

Cache successful bundle fetches in `window.__snapshotBundleCache`, keyed by bundle URL. A repeat mount of the same container applies from cache and never touches the network. Token TTL is unchanged. The sidebar side needs nothing: `applyBundle` already no-ops once the server has pushed authoritative state (`serverPushed` guard in `annotationsidebar.js`).

## Evidence

Found by the snapshot-on soak shakedown (n=2, 5 min, perf/soak-full-crud):

- Before: each student's initial bundle fetch 200, then the same token re-fetched after tab-away → 403 ×4; from the first tab-return onward every `highlight_create` failed with needle-pool exhaustion (no document text left in the pane).
- After (identical shakedown): 1 passed, 33/33 actions ok, exactly 2 bundle fetches (one per student), zero 403s.

## Tests

TDD: `tests/js/annotation-snapshot-bootstrap.test.js` gains "re-mounted container after token expiry mounts from cache, no re-fetch" — reproduces the destroy → expire → re-mount sequence, asserts mount from cache with zero fetches and a fresh `_textNodes` walk over the new container. Red before the fix; JS lane 140/140 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
