### PR TITLE
fix(test): reliable select_chars drag + loud whiff assert (#562)

### DIFF
--- a/src/promptgrimoire/docs/helpers.py
+++ b/src/promptgrimoire/docs/helpers.py
@@ -210,8 +210,11 @@ def select_chars(page: Page, start_char: int, end_char: int) -> None:
         [start_char, end_char],
     )
 
-    # Perform mouse-based selection (real user interaction)
-    page.mouse.click(coords["startX"], coords["startY"])
+    # Perform mouse-based selection (real user interaction). No leading
+    # click: a press within the double-click window acquires word-select
+    # semantics, and steps=8 avoids Chromium's single-step teleport-move
+    # selection misses (#562).
+    page.mouse.move(coords["startX"], coords["startY"])
     page.mouse.down()
-    page.mouse.move(coords["endX"], coords["endY"])
+    page.mouse.move(coords["endX"], coords["endY"], steps=8)
     page.mouse.up()

--- a/tests/e2e/highlight_tools.py
+++ b/tests/e2e/highlight_tools.py
@@ -204,6 +204,17 @@ def create_highlight_with_tag(
         sel_state,
         toolbar_state,
     )
+    # Harness whiff guard (#562): a collapsed selection here means the
+    # select_chars mouse drag produced nothing — the tag click would
+    # silently no-op and the failure would be misbilled to the app.
+    # Assert loudly, never retry.
+    if sel_state["isCollapsed"] is not False:
+        msg = (
+            f"select_chars drag whiffed: selection collapsed/empty after "
+            f"harness mouse drag (chars={start_char}-{end_char}, "
+            f"sel_state={sel_state}). Harness bug (#562), not an app bug."
+        )
+        raise RuntimeError(msg)
 
     tag_button = page.locator("[data-testid='tag-toolbar'] button").nth(tag_index)
     tag_button.click()


### PR DESCRIPTION
Refs #562 (does not close it — the root cause remains open).

## What changed

- `select_chars` (src/promptgrimoire/docs/helpers.py) now drags as `move(start) → down() → move(end, steps=8) → up()`. The leading full `click()` is removed: it has no recorded rationale (predates the extraction in f9fa89e5) and a press landing within the browser's double-click window acquires word-selection semantics.
- `create_highlight_with_tag` (tests/e2e/highlight_tools.py) now **asserts** the selection is non-collapsed after the drag, reusing the existing `sel_state` evaluate. A whiff raises a distinct `RuntimeError` naming the harness drag and #562. An assert, not a retry — whiffs are loudly attributed to the harness, never masked or misbilled to the app.

## Evidence (statistical, bounded)

- Selection-heavy E2E lane green with the new drag shape: `test_text_selection.py` + `test_annotation_highlight_api.py` + `test_highlight_rendering.py`, 11/11.
- n=1 30-min soak on `perf/soak-full-crud` + this fix (`6b687308`, idle 32-core host, `perf-data/soak_n1_fixed.json` in the perf worktree): **3/44 highlight_create whiffs vs 4/43 before** — statistically indistinguishable. The drag rewrite does **not** cure the miss; the issue's double-click-window and teleport-move hypotheses are refuted as the dominant mechanism. What the run does verify: every whiff now fails loudly at the exact action with harness attribution (`isCollapsed: true, rangeCount: 1, text: ''`), instead of a silent no-op followed by a 30 s card-count timeout billed to the app.
- Two of the three whiffs were drags in the same fixture region (chars 9317–9383, 9322–9424) — geometry/coordinate-staleness remains the standing suspect, with #154's real-pointer rewrite the natural home for that investigation.
- Full local gate: all 8 lanes (`e2e all`) pass.

## Value shipped

Attribution, not cure: harness whiffs can no longer masquerade as app failures in E2E and perf runs, and every future run contributes labelled whiff-location data to #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
