### PR TITLE
Keep annotation tabs mounted

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,6 +71,26 @@ It accepts:
 - `E2E_CRAM_DIAG_SAMPLE_SECONDS` for the diagnostics sampling interval; and
 - `E2E_CRAM_DIAG_PATH` for the JSON evidence path.
 
+The single-browser Respond mount probe
+(`test_browser_perf_377.py::TestBrowserPerf377::test_respond_mount_boundaries`)
+separates tab delivery from Milkdown readiness across repeated visits. Each
+successful visit types and visibly acknowledges a sequenced marker. The probe
+then crosses the managed server's explicit persistence barrier, reads
+`workspace.crdt_state` directly from PostgreSQL, hydrates a fresh CRDT document,
+and verifies every acknowledged marker appears exactly once, in the same order
+as the final browser-visible document, in both the
+Milkdown fragment and markdown mirror. It accepts:
+
+- `E2E_RESPOND_MOUNT_VISITS` for the number of Source/Respond cycles
+  (default 5);
+- `E2E_RESPOND_MOUNT_TIMEOUT_MS` for each observed boundary (default 30000);
+  and
+- `E2E_RESPOND_MOUNT_DIAG_PATH` for the JSON evidence path.
+
+The probe records timeouts as evidence and only fails when the Respond
+container never appears, because it is an attribution probe rather than a
+latency release gate.
+
 Comparative performance claims require alternating or interleaved arms (ABBA
 at minimum), per-leg results, and within-arm spread. Report server-side and
 browser-side boundaries separately; browser timings from co-located load

--- a/docs/uat-565.md
+++ b/docs/uat-565.md
@@ -1,0 +1,13 @@
+# Issue 565 UAT notes
+
+## 2026-08-19 — bunyip
+
+- Environment: isolated mock-auth UAT instance at `http://bunyip:18082`.
+- Tester: Brian.
+- Source → Organise → Respond switching: no reported failure.
+- Respond: second text entry remained present after leaving and returning.
+- Annotation: remained present after leaving and returning.
+- Tester assessment: “seems reliable”.
+- Managed app restart: passed; both edits remained present afterward.
+- Incidental finding: PDF export failed in the temporary UAT environment;
+  investigate whether its minimal container lacks the export toolchain.

--- a/src/promptgrimoire/cli/e2e/_server_script.py
+++ b/src/promptgrimoire/cli/e2e/_server_script.py
@@ -450,6 +450,20 @@ async def _diagnostics():
     }
 
 
+@app.post("/api/test/persist-crdt")
+async def _persist_crdt():
+    """Provide an exact persistence barrier for E2E durability assertions."""
+    from promptgrimoire.crdt.persistence import get_persistence_manager
+
+    manager = get_persistence_manager()
+    dirty_before = len(manager._workspace_dirty)
+    await manager.persist_all_dirty_workspaces()
+    return {
+        "dirty_before": dirty_before,
+        "dirty_after": len(manager._workspace_dirty),
+    }
+
+
 _QUALNAME_TAIL_SEGMENTS = 2
 
 

--- a/src/promptgrimoire/pages/annotation/tab_bar.py
+++ b/src/promptgrimoire/pages/annotation/tab_bar.py
@@ -802,13 +802,19 @@ async def _build_tab_panels(  # noqa: PLR0913 -- param-object migration: tracker
                     footer=footer,
                 )
 
-        with ui.tab_panel("Organise") as organise_panel:
-            state.organise_panel = organise_panel
-            ui.label("Organise tab content will appear here.").classes("text-gray-400")
+        with ui.tab_panel("Organise"), ui.keep_alive():
+            state.organise_panel = ui.column().classes("w-full")
+            with state.organise_panel:
+                ui.label("Organise tab content will appear here.").classes(
+                    "text-gray-400"
+                )
 
-        with ui.tab_panel("Respond") as respond_panel:
-            state.respond_panel = respond_panel
-            ui.label("Respond tab content will appear here.").classes("text-gray-400")
+        with ui.tab_panel("Respond"), ui.keep_alive():
+            state.respond_panel = ui.column().classes("w-full")
+            with state.respond_panel:
+                ui.label("Respond tab content will appear here.").classes(
+                    "text-gray-400"
+                )
 
     logger.debug("[RENDER] tab panels built, workspace=%s", workspace_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -483,6 +483,19 @@ async def _diagnostics():
         "nicegui_clients": len(Client.instances),
     }}
 
+
+@app.post("/api/test/persist-crdt")
+async def _persist_crdt():
+    from promptgrimoire.crdt.persistence import get_persistence_manager
+
+    manager = get_persistence_manager()
+    dirty_before = len(manager._workspace_dirty)
+    await manager.persist_all_dirty_workspaces()
+    return {{
+        "dirty_before": dirty_before,
+        "dirty_after": len(manager._workspace_dirty),
+    }}
+
 ui.run(
     port=port, reload=False, show=False,
     storage_secret='{TEST_STORAGE_SECRET}',

--- a/tests/e2e/test_browser_perf_377.py
+++ b/tests/e2e/test_browser_perf_377.py
@@ -18,23 +18,36 @@ import json
 import os
 import re
 import time
+import urllib.request
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
 from playwright.sync_api import ConsoleMessage, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from promptgrimoire.config import get_settings
 from promptgrimoire.docs.helpers import select_chars
 from tests.e2e.card_helpers import PABAI_WORKSPACE_ID, ensure_pabai_workspace
-from tests.e2e.db_fixtures import grant_acl
+from tests.e2e.db_fixtures import _get_sync_engine, grant_acl
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     from playwright.sync_api import Browser, Page
 _MAX_LOAD_AVG = 10.0  # 1-min load average ceiling for perf tests
+_RESPOND_VISITS = (
+    int(os.environ["E2E_RESPOND_MOUNT_VISITS"])
+    if "E2E_RESPOND_MOUNT_VISITS" in os.environ
+    else 5
+)
+_RESPOND_TIMEOUT_MS = (
+    int(os.environ["E2E_RESPOND_MOUNT_TIMEOUT_MS"])
+    if "E2E_RESPOND_MOUNT_TIMEOUT_MS" in os.environ
+    else 30_000
+)
 
 # structlog events we want to capture
 _SERVER_TIMING_EVENTS = frozenset(
@@ -46,6 +59,146 @@ _SERVER_TIMING_EVENTS = frozenset(
         "resolve_step",
     }
 )
+
+
+@dataclass
+class RespondMountObservation:
+    """Browser-visible boundaries for one Respond-tab visit."""
+
+    visit: int
+    click_to_container_ms: int = -1
+    container_to_editor_ms: int = -1
+    click_to_editor_ms: int = -1
+    acknowledged_marker: str | None = None
+    error: str | None = None
+
+
+def _measure_respond_visit(
+    page: Page, visit: int, marker: str
+) -> RespondMountObservation:
+    """Measure tab delivery separately from Milkdown becoming interactive."""
+    observation = RespondMountObservation(visit=visit)
+    started = time.perf_counter()
+    page.get_by_test_id("tab-respond").click()
+
+    container = page.get_by_test_id("milkdown-editor-container")
+    try:
+        container.wait_for(state="visible", timeout=_RESPOND_TIMEOUT_MS)
+        container_ready = time.perf_counter()
+        observation.click_to_container_ms = round((container_ready - started) * 1000)
+
+        editor = container.locator("[contenteditable]").first
+        editor.wait_for(state="visible", timeout=_RESPOND_TIMEOUT_MS)
+        editor_ready = time.perf_counter()
+        observation.container_to_editor_ms = round(
+            (editor_ready - container_ready) * 1000
+        )
+        observation.click_to_editor_ms = round((editor_ready - started) * 1000)
+        editor.click()
+        page.keyboard.press("Control+End")
+        page.keyboard.press("Enter")
+        page.keyboard.type(marker)
+        expect(editor).to_contain_text(marker, timeout=_RESPOND_TIMEOUT_MS)
+        observation.acknowledged_marker = marker
+    except PlaywrightTimeoutError as exc:
+        observation.error = f"{type(exc).__name__}: {exc}"
+
+    return observation
+
+
+def _write_respond_mount_evidence(
+    observations: list[RespondMountObservation],
+    persisted_audit: dict[str, object],
+) -> None:
+    """Print raw evidence and optionally persist it for cross-leg comparison."""
+    payload = {
+        "visits": [asdict(observation) for observation in observations],
+        "persisted_audit": persisted_audit,
+    }
+    print("\n=== Respond mount boundaries (Pabai, single browser) ===")
+    print(json.dumps(payload, indent=2))
+
+    raw_path = (
+        os.environ["E2E_RESPOND_MOUNT_DIAG_PATH"]  # noqa: SIM401 - env guard
+        if "E2E_RESPOND_MOUNT_DIAG_PATH" in os.environ
+        else None
+    )
+    if raw_path:
+        path = Path(raw_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _force_crdt_persistence(app_server: str) -> dict[str, int]:
+    """Cross the managed test server's explicit persistence barrier."""
+    request = urllib.request.Request(
+        f"{app_server}/api/test/persist-crdt", data=b"", method="POST"
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload: dict[str, int] = json.loads(response.read().decode())
+    assert payload["dirty_after"] == 0
+    return payload
+
+
+def _load_persisted_respond_state(workspace_id: str) -> tuple[str, str]:
+    """Read PostgreSQL bytes and hydrate a document outside the live registry."""
+    from sqlalchemy import text
+
+    from promptgrimoire.crdt.annotation_doc import AnnotationDocument
+
+    engine = _get_sync_engine()
+    try:
+        with engine.connect() as connection:
+            crdt_state = connection.execute(
+                text(
+                    "SELECT crdt_state FROM workspace "
+                    "WHERE id = CAST(:workspace_id AS uuid)"
+                ),
+                {"workspace_id": workspace_id},
+            ).scalar_one()
+    finally:
+        engine.dispose()
+    assert crdt_state is not None
+    persisted = AnnotationDocument("respond-perf-fresh-db-hydration")
+    persisted.apply_update(crdt_state)
+    return str(persisted.response_draft), persisted.get_response_draft_markdown()
+
+
+def _audit_persisted_markers(
+    observations: list[RespondMountObservation],
+    browser_text: str,
+    fragment: str,
+    markdown: str,
+    barrier: dict[str, int],
+) -> dict[str, object]:
+    """Assert acknowledged edits are durable, unique, and ordered."""
+    markers = [
+        observation.acknowledged_marker
+        for observation in observations
+        if observation.acknowledged_marker is not None
+    ]
+    assert markers, "No Respond edit reached the browser acknowledgement boundary"
+
+    for marker in markers:
+        assert fragment.count(marker) == 1, (
+            f"Persisted response fragment did not contain {marker!r} exactly once"
+        )
+        assert markdown.count(marker) == 1, (
+            f"Persisted markdown mirror did not contain {marker!r} exactly once"
+        )
+
+    browser_order = sorted(markers, key=browser_text.index)
+    fragment_order = sorted(markers, key=fragment.index)
+    markdown_order = sorted(markers, key=markdown.index)
+    return {
+        "acknowledged_markers": markers,
+        "browser_order": browser_order,
+        "fragment_order": fragment_order,
+        "markdown_order": markdown_order,
+        "fragment_matches_browser": fragment_order == browser_order,
+        "markdown_matches_browser": markdown_order == browser_order,
+        "persistence_barrier": barrier,
+    }
 
 
 def _check_system_load() -> None:
@@ -333,6 +486,51 @@ class TestBrowserPerf377:
         server_phases = {e.get("phase") or e.get("step") for e in server_entries}
         assert "ui_html" in server_phases, (
             f"H2: ui_html timing not captured. Got: {server_phases}"
+        )
+
+    def test_respond_mount_boundaries(
+        self, pabai_page: Page, app_server: str, server_log: ServerLogReader
+    ) -> None:
+        """Split Respond tab delivery from browser-side Milkdown readiness.
+
+        This is an evidence probe, not a latency gate. Revisit timeouts are
+        retained in the output so the degradation remains measurable.
+        """
+        page = pabai_page
+        ws_url = f"{app_server}/annotation?workspace_id={PABAI_WORKSPACE_ID}"
+        page.goto("about:blank")
+        page.goto(ws_url, wait_until="networkidle")
+        page.get_by_test_id("doc-container").wait_for(state="visible", timeout=60_000)
+
+        observations: list[RespondMountObservation] = []
+        run_id = uuid4().hex[:8]
+        server_log.checkpoint()
+        for visit in range(1, _RESPOND_VISITS + 1):
+            marker = f"respond-probe-{run_id}-{visit:04d}"
+            observations.append(_measure_respond_visit(page, visit, marker))
+            if visit < _RESPOND_VISITS:
+                page.get_by_test_id("tab-source-1").click()
+                page.get_by_test_id("doc-container").wait_for(
+                    state="visible", timeout=_RESPOND_TIMEOUT_MS
+                )
+
+        browser_text = (
+            page.get_by_test_id("milkdown-editor-container")
+            .locator("[contenteditable]")
+            .first.inner_text()
+        )
+        barrier = _force_crdt_persistence(app_server)
+        fragment, markdown = _load_persisted_respond_state(PABAI_WORKSPACE_ID)
+        persisted_audit = _audit_persisted_markers(
+            observations, browser_text, fragment, markdown, barrier
+        )
+        _write_respond_mount_evidence(observations, persisted_audit)
+        _print_server_timings(server_log.read_since(), "Respond mount probe")
+
+        assert persisted_audit["fragment_matches_browser"] is True
+        assert persisted_audit["markdown_matches_browser"] is True
+        assert any(item.click_to_container_ms >= 0 for item in observations), (
+            "Respond container never appeared; mount split was not observed"
         )
 
     def test_tag_apply_timings(

--- a/tests/integration/test_workspace_persistence.py
+++ b/tests/integration/test_workspace_persistence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pycrdt
 import pytest
 
 from promptgrimoire.config import get_settings
@@ -104,6 +105,46 @@ class TestWorkspacePersistence:
         assert len(highlights) == 2
         assert any(h["id"] == hl1_id for h in highlights)
         assert any(h["id"] == hl2_id for h in highlights)
+
+    @pytest.mark.asyncio
+    async def test_workspace_persist_preserves_ordered_response_draft(self) -> None:
+        """Fresh DB hydration preserves both Respond CRDT representations."""
+        from promptgrimoire.crdt.annotation_doc import AnnotationDocument
+        from promptgrimoire.crdt.persistence import get_persistence_manager
+        from promptgrimoire.db.workspaces import create_workspace, get_workspace
+
+        workspace = await create_workspace()
+        doc = AnnotationDocument(f"ws-{workspace.id}")
+        markers = [f"[respond-persist:{index:04d}]" for index in range(1, 4)]
+        markdown_field = doc.response_draft_markdown
+
+        with doc.doc.transaction():
+            for marker in markers:
+                doc.response_draft.children.append(pycrdt.XmlText(marker))
+                markdown_field += marker
+
+        pm = get_persistence_manager()
+        pm.register_document(doc)
+        pm.mark_dirty_workspace(workspace.id, doc.doc_id, last_editor="test-client")
+        await pm.force_persist_workspace(workspace.id)
+
+        loaded_workspace = await get_workspace(workspace.id)
+        assert loaded_workspace is not None
+        assert loaded_workspace.crdt_state is not None
+        loaded_doc = AnnotationDocument("fresh-db-hydration")
+        loaded_doc.apply_update(loaded_workspace.crdt_state)
+
+        fragment = str(loaded_doc.response_draft)
+        markdown = loaded_doc.get_response_draft_markdown()
+        for marker in markers:
+            assert fragment.count(marker) == 1
+            assert markdown.count(marker) == 1
+        assert [fragment.index(marker) for marker in markers] == sorted(
+            fragment.index(marker) for marker in markers
+        )
+        assert [markdown.index(marker) for marker in markers] == sorted(
+            markdown.index(marker) for marker in markers
+        )
 
 
 class TestWorkspaceLoading:

--- a/tests/unit/test_markdown_sync_event.py
+++ b/tests/unit/test_markdown_sync_event.py
@@ -185,6 +185,38 @@ class TestOnYjsUpdateMardownSync:
         md_arg = mock_wc.call_args[0][0]
         assert md_arg == "Five words are right here"
 
+    @pytest.mark.asyncio
+    async def test_apply_broadcast_mirror_and_dirty_stages_are_ordered(self) -> None:
+        """An acknowledged edit crosses each server stage in causal order."""
+        crdt_doc = _make_crdt_doc()
+        handler, broadcast, _ = _capture_on_yjs_handler(crdt_doc)
+        marker = "[respond-stage:0001]"
+        stages: list[str] = []
+
+        def observe_broadcast(*_args: object) -> None:
+            assert "hello" in str(crdt_doc.response_draft)
+            assert str(crdt_doc.response_draft_markdown) == ""
+            stages.append("broadcast")
+
+        mock_pm = MagicMock()
+
+        def observe_dirty(*_args: object, **_kwargs: object) -> None:
+            assert "hello" in str(crdt_doc.response_draft)
+            assert str(crdt_doc.response_draft_markdown) == marker
+            stages.append("dirty")
+
+        broadcast.side_effect = observe_broadcast
+        mock_pm.mark_dirty_workspace.side_effect = observe_dirty
+        event = SimpleNamespace(args={"update": _make_yjs_update(), "markdown": marker})
+
+        with patch(
+            "promptgrimoire.pages.annotation.respond.get_persistence_manager",
+            return_value=mock_pm,
+        ):
+            await handler(event)
+
+        assert stages == ["broadcast", "dirty"]
+
 
 class TestOnYjsUpdateNoRunJavascript:
     """AC3.2: on_yjs_update does NOT call run_javascript (no JS round-trip)."""


### PR DESCRIPTION
Closes #565.

## What changed

- Keep the Respond and Organise tab contents alive across Quasar tab switches.
- Preserve deferred first initialization of Milkdown while avoiding repeated browser-CPU-heavy remounts.
- Add a single-browser probe that separates tab delivery from editor readiness.
- Verify acknowledged Respond edits through the complete write path: browser, CRDT, Markdown mirror, persistence barrier, PostgreSQL, and fresh CRDT hydration.
- Add unit and integration coverage for ordering and persistence, plus UAT notes.

## Root cause

Quasar destroys inactive tab-panel DOM. Each Respond visit therefore rebuilt Milkdown/ProseMirror from scratch. The server remained responsive while clients spent tens of seconds mounting the editor under classroom load.

Fresh classroom-load evidence reports Milkdown mount-on-tab-visit failures in 37–66% of Respond attempts as pace rises. It was the single largest degradation class in the latest 200-concurrent campaign.

## Results

Bunyip probe:

- First Respond mount: 2.919 s
- Revisits: 0.857 s, 0.701 s, 0.635 s, 0.739 s
- Five browser-acknowledged markers persisted exactly once
- Fresh CRDT and Markdown order matched the final browser-visible order

Manual UAT confirmed Source → Organise → Respond switching, text and annotation persistence, and survival across an app restart.

The issue contains the classroom-load baseline; this PR does not claim a controlled same-host pre/post comparison.

## Interaction boundaries

- Respond remains deferred until first visit and then stays mounted.
- Organise retains its intentional CRDT-driven refresh behavior.
- The #563/#564 snapshot bootstrap cache remains unchanged.
- The `window.__annotationCardsEpoch` rebuild contract remains covered by the passing `tests/js/annotationsidebar.test.js` guard tests; manual cross-tab UAT also passed.
- `window._flushRespondMarkdownNow` remains intact.

## Validation

- 4,108 Python tests passed; 2 skipped
- 140 Vitest tests passed, including the annotation-card epoch guards
- 96 BATS tests passed
- Ruff lint/format, ty, commit hooks, and diff checks passed
