### PR TITLE
perf: PgBouncer-series load evidence, probes, and pool fidelity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ APP__STORAGE_SECRET=change-me-generate-a-real-secret
 # Directory for structured JSON log files (default: logs)
 APP__LOG_DIR=logs
 
+# Session file logging: level and rotation (defaults shown).
+# DEBUG-to-file is the inspection exception; INFO is the default so the
+# rotation window holds hours of history rather than minutes.
+#LOGGING__FILE_LEVEL=INFO
+#LOGGING__MAX_BYTES=10485760
+#LOGGING__BACKUP_COUNT=5
+
 # Path to latexmk executable for PDF export
 # Leave empty to use TinyTeX at ~/.TinyTeX/bin/x86_64-linux/latexmk
 # Run `uv run python scripts/setup_latex.py` to install TinyTeX

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,8 @@ codex-prompts/
 
 # Local durable notes (session state, preferences) — not for sharing
 .notes/
+
+# Raw perf-run telemetry JSONs — stay on the run machine, regenerable
+# in kind via the perf probes. The handful committed before this rule
+# remain tracked (gitignore does not untrack).
+perf-data/

--- a/deploy/watch-class-load.sh
+++ b/deploy/watch-class-load.sh
@@ -4,7 +4,12 @@
 #
 #   /opt/promptgrimoire/deploy/watch-class-load.sh            # refresh every 60s
 #   /opt/promptgrimoire/deploy/watch-class-load.sh --once     # single snapshot
-#   COURSE_CODE=LAWS1000 WATCH_INTERVAL=30 .../watch-class-load.sh
+#   COURSE_CODE=LAWS8001 WATCH_INTERVAL=30 .../watch-class-load.sh
+#
+# COURSE_CODE narrows the per-activity table (ILIKE substring match).
+# The default matches every course: shared content can serve several
+# units (LAWS1000 daytime and LAWS8001 evening share JJ Savage), and a
+# narrow default silently hid the evening class on 2026-08-17.
 #
 # Reads the app's structured JSON log (memory_diagnostic / page_load_profile
 # events) and counts student workspaces per activity from PostgreSQL.
@@ -13,7 +18,7 @@
 set -euo pipefail
 
 INTERVAL="${WATCH_INTERVAL:-60}"
-COURSE_CODE="${COURSE_CODE:-LAWS1000}"
+COURSE_CODE="${COURSE_CODE:-}"
 DB_NAME="${DB_NAME:-promptgrimoire}"
 DB_USER="${DB_USER:-promptgrimoire}"
 LOG_DIR="${GRIMOIRE_LOG_DIR:-/opt/promptgrimoire/logs/sessions}"
@@ -97,7 +102,7 @@ snapshot() {
     file=$(log_file)
     since_10m=$(date -u -d '-10 minutes' +%Y-%m-%dT%H:%M:%S)
 
-    echo "=== $(date '+%H:%M:%S %Z')  (course: ${COURSE_CODE}) ==="
+    echo "=== $(date '+%H:%M:%S %Z')  (course: ${COURSE_CODE:-all}) ==="
     if [[ -n "$file" ]]; then
         echo "server   $(server_section "$file")"
         echo "loads (10m):"

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -80,6 +80,7 @@ library references during development.
 - [Causal Analysis: marginalia overflow-endnotes fallback never triggers](investigations/2026-08-06-marginalia-overflow-export.md)
 - [Causal analysis: production deploy JS-runner availability](investigations/2026-08-15-deploy-js-runner-availability.md)
 - [Production-Pool Large-Document Load Curve](investigations/2026-08-16-production-pool-load-curve.md)
+- [Soak and Cram Load Evidence — Initial Snapshot Delivery](investigations/2026-08-19-soak-cram-perf-evidence.md)
 - [Phase1 Hypotheses](investigations/phase1-hypotheses.md)
 
 ## lark

--- a/docs/investigations/2026-08-19-soak-cram-perf-evidence.md
+++ b/docs/investigations/2026-08-19-soak-cram-perf-evidence.md
@@ -1,0 +1,489 @@
+# Soak and Cram Load Evidence — Initial Snapshot Delivery
+
+Date: 2026-08-19 (PgBouncer-fidelity series and thundering herd added the
+same evening; document rebuilt 2026-08-20)
+Status: Evidence record, campaign complete. The PgBouncer-fidelity series in
+Part 1 is the authoritative result; the earlier NullPool series is retained
+in Part 2 as superseded history.
+Branch: `perf/soak-full-crud` (perf worktree, uncommitted), at `e6fd6b20`
+on `origin/main f7b3c2de` — **pre-#570**; see §9.
+Harnesses: `tests/e2e/test_soak_full_crud_load.py` (paced soak),
+`tests/e2e/test_assessment_cram_load.py` (synchronised cram),
+`tests/e2e/test_thundering_herd.py` (synchronised arrival + churn on a
+heavyweight fixture)
+Data: `perf-data/*.json` on the run machine, one file per run. The raw
+JSONs are per-event telemetry (per-action timings, diagnostic samples,
+server load profiles — no document content) and are **not committed**:
+they are large, and the numbers they hold are superseded by any rerun.
+Each is regenerable in kind, not in value, via the named harness and
+knobs (`scripts/perf-run.sh`). The five NullPool-era cram files that
+main already tracks remain tracked.
+
+## How to read this document
+
+Part 1 is the PgBouncer-fidelity results. Every figure in it is derived
+from a diagnostic JSON named in the `Evidence file` column, by re-reading
+that file. Where a metric is not present in the file, the cell is `—`.
+Nothing is carried over from a terminal session.
+
+Part 2 is the earlier NullPool series, retained because its wall at n=100
+is itself a finding about the harness, and because two of its caveats
+(§3, §4) were established on its runs.
+
+Part 3 records what the numbers do not say, ordered by how much each
+caveat constrains a reading of the tables.
+
+---
+
+## Part 1 — PgBouncer-fidelity series (authoritative)
+
+### Environment
+
+Every run in this part went through a local PgBouncer on `127.0.0.1:6433`,
+configured exactly as `docs/deployment.md` §7a documents production:
+transaction pooling, `default_pool_size 40` + `reserve_pool_size 10`,
+`max_client_conn 500`, `reserve_pool_timeout 3`,
+`max_prepared_statements 200`. The application side matched §7b:
+`DATABASE__POOL_SIZE=20`, `DATABASE__MAX_OVERFLOW=10`,
+`DATABASE__POOL_PRE_PING=false` (required with transaction pooling —
+SQLAlchemy #10226), `DATABASE__POOL_RECYCLE=1800`.
+
+The server ran QueuePool via the `_PROMPTGRIMOIRE_POOL_FIDELITY` opt-in in
+`db/engine.py::_resolve_pool_mode`, set by `grimoire e2e perf
+--queue-pool`. **Verification is per-leg and server-side**: every JSON's
+`server_page_load.pool_mode` block, parsed from the server's own startup
+log line, reads `mode=QueuePool, reason="pool_fidelity"`. (The `run_meta`
+env block records `_PROMPTGRIMOIRE_POOL_FIDELITY="0"` — that is the pytest
+subprocess's value, deliberately zeroed so test-lane engines stay on
+NullPool; the flag applies to the spawned server, and the server-side
+observation is the one that counts.)
+
+Other constants across every leg: server pinned to CPUs 0–7
+(`E2E_SERVER_CPU_LIST`), admission gate disabled, G3+settle harness
+(post-#566 drag code with `wait_for_scroll_settled`), and server-side
+`page_load_profile` capture via `tests/e2e/perf_reporting.py` — the
+`Server p50/p95/max` column that Part 2 could not fill. Coverage is
+verified per leg: `window_start_covered=true` on every row below (the
+first n=150 attempt lost its startup line to 10 MB log rotation and was
+discarded and rerun with a 20 MB × 15 rotation budget — the knobs are
+now `LOGGING__MAX_BYTES` / `LOGGING__BACKUP_COUNT`).
+
+### Soak ramp, n=2 → 200
+
+Paced soak: 5× = 3.25 actions/min per student, 15 min, 300 s arrival
+spread (the n=2 shakedown is shorter). Browser figures are
+browser-observed `load_elapsed_ms`; server figures are the server's own
+`page_load_profile.total_ms` over the same loads.
+
+| Run | Evidence file | n | Loads ok/att | Browser p50/p95 (ms) | Server p50/p95/max (ms) | Max DB hold (ms) | Max loop lag (ms) | Whiffs / drags | Fatal students | Respond audit (landed/lost/never-typed) |
+|---|---|---|---|---|---|---|---|---|---|---|
+| shakedown | `soak_pgb_shakedown.json` | 2 | 2/2 | 250 / 260 | 20.1 / 25.9 / 25.9 | 46 | 22 | 0 / 19 | 0 | 5 / 0 / 0 |
+| soak n=25 | `soak_n25_pgb.json` | 25 | 25/25 | 206 / 225 | 20.8 / 31.6 / 42.0 | 151 | 41 | 0 / 508 | 0 | 150 / 0 / 66 |
+| soak n=50 | `soak_n50_pgb.json` | 50 | 50/50 | 204 / 234 | 20.8 / 43.0 / 90.9 | 280 | 339 | 0 / 1005 | 0 | 302 / 0 / 132 |
+| soak n=75 | `soak_n75_pgb.json` | 75 | 75/75 | 204 / 240 | 21.2 / 33.1 / 111.1 | 289 | 456 | 0 / 1493 | 0 | 427 / 0 / 214 |
+| soak n=100 | `soak_n100_pgb.json` | 100 | 100/100 | 205 / 240 | 20.6 / 30.2 / 111.8 | 521 | 758 | 0 / 1982 | 1 | 518 / 0 / 295 |
+| soak n=100, snapshot on | `soak_n100_snap_pgb.json` | 100 | 100/100 | 200 / 282 | 20.5 / 29.7 / 34.8 | 330 | 757 | 0 / 1981 | 2 | 519 / 0 / 295 |
+| soak n=150 | `soak_n150_pgb.json` | 150 | 150/150 | 205 / 276 | 21.3 / 37.8 / 368.4 | 271 | 889 | 0 / 2956 | 1 | 738 / 0 / 467 |
+| soak n=200 | `soak_n200_pgb.json` | 200 | 200/200 | 208 / 274 | 20.8 / 40.6 / 214.5 | 971 | 1274 | 0 / 3917 | 1 | 918 / 0 / 661 |
+
+Readings:
+
+- **Server page-load p50 is flat at 20.5–21.3 ms from n=2 to n=200.** At
+  paced arrival on the light fixture, the connection wall that voided the
+  NullPool n=100 leg (Part 2 §1) is simply gone: 200/200 loads at every
+  scale, no `TooManyConnectionsError` anywhere in the series.
+- **Zero whiffs across 13,861 drags** in the whole soak series — the #562
+  settle fix (§3) holding at scale after the n=10 falsification soak.
+- **Respond audit: `ok_lost=0` on every leg** — no run in this series lost
+  a typed sentence from the CRDT. The `degraded_never_typed` counts (66 →
+  661, rising with n) are Milkdown mounts that never became interactable
+  (#565); no text was typed, so none was lost. See §9 for why these should
+  collapse on a rebased rerun.
+- **Event-loop lag maxima grow with n** (41 → 1274 ms) while server load
+  p50 stays flat; the spikes are GC pauses, §6.
+- The snapshot-on n=100 leg recorded `snapshot_served=244` for 100
+  students — the service was serving re-fetches during the run, not just
+  initial loads. Recorded as an observation; not investigated.
+
+### Cram A/B, order-controlled (ABBA)
+
+Synchronised cram: every student loads at once, waits on a barrier, then
+runs 10 highlights + 3 comments with 2000 ms think time. Each scale ran
+**A (flag off), B (on), B (on), A (off)** back-to-back; order is confirmed
+by `run_meta.started_utc` in the files. Snapshot state is corroborated
+per-leg by the server-side `snapshot_served` count (0 on every A leg;
+equal to loads served on every B leg).
+
+| Run | Evidence file | n | Loads ok/att | Browser p50 (ms) | Server p50/p95 (ms) | Max DB hold (ms) | Whiffs | Fatal students |
+|---|---|---|---|---|---|---|---|---|
+| n=50 A1 | `cram_n50_pgb_a1.json` | 50 | 50/50 | 2212 | 802 / 1336 | 935 | 0 | 0 |
+| n=50 B1 | `cram_n50_pgb_b1.json` | 50 | 50/50 | 2444 | 762 / 1250 | 482 | 0 | 1 |
+| n=50 B2 | `cram_n50_pgb_b2.json` | 50 | 50/50 | 2312 | 764 / 1161 | 456 | 1 | 2 |
+| n=50 A2 | `cram_n50_pgb_a2.json` | 50 | 50/50 | 2182 | 728 / 1301 | 536 | 0 | 3 |
+| n=100 A1 | `cram_n100_pgb_a1.json` | 100 | 100/100 | 4405 | 1260 / 2604 | 962 | 12 | 22 |
+| n=100 B1 | `cram_n100_pgb_b1.json` | 100 | 100/100 | 4698 | 1600 / 2352 | 633 | 16 | 25 |
+| n=100 B2 | `cram_n100_pgb_b2.json` | 100 | 100/100 | 4717 | 1293 / 2301 | 546 | 15 | 20 |
+| n=100 A2 | `cram_n100_pgb_a2.json` | 100 | 100/100 | 4472 | 1440 / 2956 | 740 | 23 | 25 |
+| n=200 A1 | `cram_n200_pgb_a1.json` | 200 | 200/200 | 18353 | 2305 / 5839 | 950 | 2 | 3 |
+| n=200 B1 | `cram_n200_pgb_b1.json` | 200 | **196/200** | 15156 | 2897 / 4942 | 724 | 0 | 200 (barrier) |
+| n=200 B2 | `cram_n200_pgb_b2.json` | 200 | 200/200 | 13814 | 1692 / 4603 | 931 | 4 | 6 |
+| n=200 A2 | `cram_n200_pgb_a2.json` | 200 | 200/200 | 13077 | 1597 / 5373 | 978 | 0 | 1 |
+| n=100 control (INFO log) | `cram_n100_pgb_info_control.json` | 100 | 100/100 | 4421 | 1278 / 2600 | 822 | 22 | 23 |
+
+Readings:
+
+- **No server-side snapshot win at any scale.** Server p50 pairs
+  (A legs vs B legs): n=50, 802/728 vs 762/764; n=100, 1260/1440 vs
+  1600/1293; n=200, 2305/1597 vs 2897/1692. The differences are within
+  leg-to-leg noise and carry no consistent sign. The browser-observed
+  −14 % from the single-A-single-B NullPool comparison (Part 2 §2) **does
+  not replicate under order control** — browser p50 with the snapshot on
+  is equal-or-slower at n=50 and n=100.
+- **Run position dominates the browser column at n=200**: 18353 → 15156 →
+  13814 → 13077 ms monotonically across positions 1–4 regardless of flag,
+  which is exactly the run-position effect the ABBA design was adopted to
+  expose. Browser deltas at this scale should not be attributed to the
+  flag at all.
+- **B1's 196/200 is the snapshot init-load hang (#573)**: four students
+  hit the 120 s annotation-load timeout (`load_elapsed_ms=-1`,
+  `annotation_loaded=false`), matching `snapshot_served=196`; the other
+  196 then broke on the arrival barrier (collateral, so the fatal column
+  reads 200). B2 served 200/200 cleanly — the tail is intermittent, one
+  leg in two at n=200.
+- **Cram failures anti-correlate with n**: 20–25 fatal students per leg at
+  n=100 against 1–6 at n=200 (B1's barrier break aside). §8 covers the
+  control leg and the surviving explanation (co-located browser CPU,
+  class G).
+- **Whiffs persist under simultaneous load** (up to 23/leg at n=100, ~2 %
+  of highlight attempts) despite the settle fix that took the paced soak
+  to zero. This is the #562 residual: a server-triggered scroll arriving
+  after settle but mid-drag. §3.
+
+### Thundering herd, n=150 on the heavyweight fixture
+
+`tests/e2e/test_thundering_herd.py`: 150 students, each on their own clone
+of the pabai workspace (190 annotation cards), double-barrier synchronised
+arrival, then 4 free-running cycles of reload → organise → locate ×2 →
+respond with 2000 ms think time. `locate` and `respond` failures are
+degraded-nonfatal by design; `organise` and reload failures are fatal.
+This reproduces the shape that historically crashed the server:
+everyone opens the annotated judgment at once, then browses.
+
+| Metric | Value (`herd_n150.json`) |
+|---|---|
+| First loads completed | 150/150 (none failed; slowest within the 120 s budget) |
+| Browser first-load p50 / p95 / max | 18042 / 20116 / 20265 ms |
+| Server page-load p50 / p95 / max (896 profiles, loads + reloads) | 2824 / 9611 / 17450 ms |
+| Reload p50 / max (600 completed cycles) | 39063 / 134245 ms |
+| Gate failures | **81/150** students (gate was max(3, 15) = 15) |
+| Fatal action errors | 98 organise opens timed out at 30 s waiting for the first `organise-card` |
+| Degraded-nonfatal errors | 334 locate, 61 respond (30 s timeouts) |
+| Max DB hold / max loop lag | 14549 / 5537 ms |
+| GC pauses (drained per 10 s diag sample) | max 4737 ms; 21 of 46 samples had a pause > 50 ms |
+| ASGI 500s in the server log | 184 × `KeyError: 'REQUEST_METHOD'`, 8 × `KeyError: 'Session is disconnected'` (#572 — disconnect noise, not an app failure; see the issue) |
+
+The server **drowned but did not die**: it served every first load and
+kept serving throughout, at page-load costs two orders of magnitude above
+the light fixture (p50 2824 ms vs ~21 ms). The dominant failure is the
+organise tab's synchronous per-card render — failure-mode class E, now
+measured (#575) — compounded by GC pauses to 4.7 s (#574, §6). At paced
+arrival (the soak table above) none of this fires; the burst/heavyweight
+combination is the trigger.
+
+---
+
+## Part 2 — NullPool series, superseded (2026-08-18 → 19 morning)
+
+Everything in this part ran before the PgBouncer environment existed:
+`grimoire e2e perf` forced `_PROMPTGRIMOIRE_USE_NULL_POOL=1`, so the app
+opened a fresh PostgreSQL connection per checkout against a 97-slot
+server. Figures here are retained as history; where they conflict with
+Part 1, Part 1 stands.
+
+### Harness generations
+
+The soak harness went through three generations, and the generation
+determines how a browser-side failure is classified:
+
+| Gen | Action fields in JSON | Classification |
+|---|---|---|
+| G1 | `error`, `retries` | Every browser-side failure is fatal. No degradation bucket. |
+| G2 | `error`, `retries`, `degraded` | Bounced actions retried, then degraded. |
+| G3 | `error`, `degraded` | Single attempt per action; a browser-side failure degrades, it is not retried. |
+
+The whiff classifier (`Harness bug (#562)`, from #566) first appears in a
+run recorded 2026-08-18 18:19. Every run before that carries **no whiff
+labelling at all**, so those cells read `n/c` (not classified); their
+unlabelled whiffs sit inside the `degraded` count (G2/G3) or the fatal
+count (G1).
+
+**Excluded as shakedown or superseded calibration:** `soak_n1*.json`
+(single-student #562 diagnostics), `soak_mech*.json` (scratchpad
+mechanism probes), `soak_n25_dragfatal.json` and `soak_n25.json`
+(calibration), `soak_snap_shakedown*.json` and
+`soak_audit_shakedown.json` (n=2 shakedowns; the audit shakedown is cited
+in §4), the 2026-08-18 cram ramp (`cram_n25/50/75/100.json`,
+`cram_n25_think8s.json` — pre-#566 drag code), and `budget_dryrun.json`.
+
+### Results (NullPool environment)
+
+No run in this part recorded a server-side `page_load_profile`; every
+latency figure is browser-observed.
+
+| Run | Evidence file | Gen | n | Pacing | Snapshot | Loads ok/att | Browser p50/p95 (ms) | Max DB hold (ms) | Whiffs | Fatal students |
+|---|---|---|---|---|---|---|---|---|---|---|
+| soak n=25, strict gate | `soak_n25_strict.json` | G1 | 25 | 5×, 15 min, 300 s spread | off | 25/25 | 213 / 294 | 163 | n/c | 20 |
+| soak n=25, degradation counted | `soak_n25_tailfatal.json` | G2 | 25 | 5×, 15 min, 300 s spread | off | 25/25 | 197 / 241 | 114 | n/c | 1 |
+| soak n=50 | `soak_n50.json` | G3 | 50 | 5×, 15 min, 300 s spread | off | 50/50 | 197 / 225 | 252 | n/c | 46 |
+| soak n=75 | `soak_n75.json` | G3 | 75 | 5×, 15 min, 300 s spread | off | 75/75 | 200 / 254 | 356 | n/c | 65 |
+| soak n=100 | `soak_n100.json` | G3 | 100 | 5×, 15 min, 300 s spread | off | 100/100 | 203 / 301 | 863 | n/c | 81 |
+| soak n=100, snapshot on | `soak_n100_snap.json` | G3 | 100 | 5×, 15 min, 300 s spread | on (filename only) | 100/100 | 214 / 343 | 770 | 34 (1.7 % of 1979) | 6 |
+| soak n=50, 10× pace | `soak_n50_r10.json` | G3 | 50 | 10×, 15 min, 300 s spread | not recorded | 50/50 | 199 / 320 | 230 | 23 (1.5 % of 1545) | 2 |
+| soak n=50, 20× pace | `soak_n50_r20.json` | G3 | 50 | 20×, 15 min, 300 s spread | off (log-corroborated, partial) | 50/50 | 202 / 274 | 581 | 38 (1.8 % of 2142) | 1 |
+| cram n=50, flag off | `cram_n50_off.json` | cram | 50 | think 2000 ms, 10 hl + 3 comments | off | 50/50 | 2997 / 3057 | 903 | 3 | 2 |
+| cram n=50, snapshot on | `cram_n50_snap.json` | cram | 50 | think 2000 ms, 10 hl + 3 comments | on (log-corroborated) | 50/50 | 2577 / 2636 | 459 | 7 | 1 |
+| cram n=100, flag off | `cram_n100_off.json` | cram | 100 | think 2000 ms, 10 hl + 3 comments | off | 99/100 | 6370 / 7109 | 2182 | 0 (no action ran) | 0 (99 aborted at barrier) |
+| cram n=100, snapshot on | `cram_n100_snap.json` | cram | 100 | think 2000 ms, 10 hl + 3 comments | on (log-corroborated) | 99/100 | 6245 / 6377 | 1242 | 0 (no action ran) | 0 (99 aborted at barrier) |
+| falsification soak n=10, settle fix | `soak_falsify_n10.json` | G3+settle | 10 | 5×, 30 min, 60 s spread | off | 10/10 | 197 / 235 | 91 | **0 of 354** (prediction: 0 — confirmed) | 1 |
+
+---
+
+## Part 3 — Honest caveats
+
+### 1. The NullPool wall was the harness, and the rerun proves it
+
+Part 2's n=100 cram legs both collapsed at a connection ceiling:
+`grimoire e2e perf` forced NullPool, a hundred simultaneous cold loads
+wanted a hundred PostgreSQL connections against 97 usable slots, one
+student's load failed with `TooManyConnectionsError`, and the barrier
+broke for the other 99 before any action ran. Those two files say nothing
+about the snapshot in either direction.
+
+The PgBouncer-fidelity rerun (Part 1) removes the wall exactly as the
+production-shaped pooling predicts: transaction pooling turns refusal into
+queueing, and 200/200 loads succeed at every scale in both harness
+shapes, with cram n=200 server p50 around 1.6–2.9 s. Every figure quoted
+from this campaign should come from Part 1.
+
+### 2. The snapshot verdict reversed under order control
+
+Part 2 §2 reported a browser-observed −14 % page-load win at n=50 from a
+single A followed by a single B, and flagged run-position variation as the
+reason to distrust it. The ABBA reruns settle it: **no server-side win at
+any scale, and the browser-side win does not replicate** (snapshot-on legs
+are equal-or-slower at n=50 and n=100; at n=200 run position swamps the
+flag entirely). Against no measured win now sits a measured cost: the
+intermittent init-load hang tail at n=200 (#573), four students in one leg
+of two hanging past 120 s with `snapshot_served=196` confirming four
+bundles never delivered. Whether the snapshot feature earns its place is a
+design conversation, not a perf question, and it is parked in #573.
+
+### 3. The #562 whiff race: harness side fixed and falsification-confirmed; app side remains
+
+Established in `scratchpad/comment_562_repro.md` and
+`scratchpad/whiff_repro_findings.md`, from an isolated perf-marked probe
+with a single idle browser.
+
+The whiff is a smooth scroll landing between `mouse.down()` and
+`mouse.up()`. Once the viewport shifts mid-drag, the anchor is reset to
+the focus on every pointer move and the selection never opens. The
+evidence that fixes the mechanism is a pair of conditions differing only
+in timing: the same `scrollBy` followed immediately by a drag whiffed 15
+of 100, and the same scroll with a 700 ms settle whiffed 0 of 100. Two
+standing suspects were refuted along the way — the candidate character
+ranges whiffed 0 of 140 each when the page was already parked, and drags
+at deliberately displaced coordinates (`dy` from −24 to +24 px, 147
+drags) whiffed 0 of 147, selecting the *wrong* text rather than nothing.
+
+It is reachable through shipped UI. The `locate-btn` on every annotation
+card round-trips to the server, which answers with
+`scrollToCharOffset(...)` → `window.scrollTo({behavior: 'smooth'})`.
+Clicking that button and then dragging across body text whiffed 5 of 40
+at a 60 ms delay, and 0 of 40 at both 0 ms and 900 ms — controls that
+hold the click, the double-click window and the coordinates fixed.
+
+It is **not silent**. `window._annotSel` stays null, the highlight menu
+does not appear, and clicking a tag then trips
+`_validate_highlight_state` → `ui.notify("No selection", warning)`. A
+student loses a gesture and gets a confusing toast, not work.
+
+The harness-side fix (`wait_for_scroll_settled()` in
+`src/promptgrimoire/docs/helpers.py`, called from `scroll_to_char` and
+`select_chars` before coordinates are re-read) was tested by
+falsification: the mechanism predicts zero whiffs from harness-initiated
+scrolls, and the n=10 falsification soak delivered **0 whiffs across 354
+drags** (`soak_falsify_n10.json`); the PgBouncer soak series then held
+**0 across 13,861 drags** at up to n=200. Against the 1.5–1.8 % G3 band,
+those zeros are not flukes. Confirmed.
+
+**The residual is the app side.** The PgBouncer cram legs still whiff —
+up to 23 per leg (~2 % of highlight attempts) at n=100 — because under
+simultaneous load a *server-triggered* scroll can arrive after the settle
+check and land mid-drag, which no amount of harness waiting can exclude.
+The app-side design call (cancel the smooth scroll on `mousedown`, or
+switch `scrollToCharOffset` to `behavior: 'instant'`) has been raised and
+not decided. Student incidence remains unmeasured, and all evidence is
+Chromium-only.
+
+### 4. Respond text was not lost; the Milkdown mount is a separate defect
+
+The marker audit reads each student's workspace back out of the CRDT
+after a run and classifies every typed marker. The falsification soak was
+the first evidence run whose audit verdict is written into its JSON
+(`ok_landed=78, ok_lost=0, degraded_never_typed=83`), and **every
+PgBouncer soak leg carries one: `ok_lost=0` on all eight rows of Part 1**
+(3,577 landed sentences across the series, zero lost). The earlier r20
+run's audit verdict (325/325 landed) is documented in session notes only;
+the artefact predates the JSON block.
+
+The earlier appearance of "lost" text was an artefact of the audit
+method: the harness clicked the centre of the editor before typing, so
+the caret spliced new sentences into old ones and broke the marker being
+counted. The `Control+End` caret fix in `_do_respond_type` removed the
+splice.
+
+The `degraded_never_typed` counts are the Milkdown mount defect (#565):
+the editor's `[contenteditable]` never becomes interactable within 30 s,
+no text is typed, so degraded responds are lost student time, not lost
+work. In the NullPool runs the share rose with pace (37 % at n=100 5×,
+52 % at n=50 10×, 66 % at n=50 20×); in the PgBouncer soak it rose with n
+(66 of 216 at n=25 to 661 of 1579 at n=200). **PR #570 (merged
+2026-08-19) is the fix for #565**, and it is *not* in the code under
+test — see §9.
+
+### 5. Throughput attainment replaced the stall assert
+
+The old gate asserted that every student complete at least half its paced
+budget, and fired on the 20× run exactly where it should not have: at 20×
+pace, 30 s Milkdown timeouts eat real time, so a legitimate student
+*should* fall short of budget. The assert measured the pace, not a fault.
+
+The measurement is now per-student attainment against the paced budget,
+reported every run as min/p50/max and never masked. Recomputed from the
+NullPool JSONs (attempted = succeeded or degraded):
+
+| Run | Budget | Attainment min / p50 / max |
+|---|---|---|
+| `soak_n25_tailfatal.json` | 49 | 72 % / 86 % / 103 % |
+| `soak_n50.json` | 49 | 57 % / 82 % / 96 % |
+| `soak_n75.json` | 49 | 57 % / 82 % / 101 % |
+| `soak_n100.json` | 49 | 2 % / 82 % / 103 % |
+| `soak_n100_snap.json` | 49 | 70 % / 88 % / 107 % |
+| `soak_n50_r10.json` | 98 | 53 % / 74 % / 89 % |
+| `soak_n50_r20.json` | 195 | 41 % / 50 % / 70 % |
+
+`MIN_ACTION_FRACTION = 0.25` is a wedge guard, not a performance target:
+a student under a quarter of budget is a browser that stopped recording.
+The 2 % minimum in `soak_n100.json` is what such a wedge looks like. The
+fatal-student gate is `max(3, n // 10)` — about spread, not run size —
+and the cram gate was reshaped the same way during the campaign: failures
+print as data (`reported, not fatal`) and only a collapse past the same
+`max(3, n // 10)` boundary fails the run.
+
+### 6. GC pauses are the event-loop stalls (#574)
+
+Convicted by instrumentation added during the campaign: a `gc.callbacks`
+pause recorder in the e2e server script, drained per diagnostic sample
+via `/api/test/diagnostics`.
+
+- **Herd n=150** (`herd_n150.json`): pauses to **4737 ms**, in lock-step
+  with the lag series — gc 4475 ↔ lag 4720 ms, gc 4737 ↔ lag 5537 ms,
+  gc 3848 ↔ lag 3953 ms; 21 of 46 samples carried a pause > 50 ms.
+  Every lag spike above ~2 s sits on a same-sized GC pause. Below
+  ~1.6 s the conviction narrows: five samples show 0.6–1.6 s lag maxima
+  with no notable GC pause, a residual consistent with the synchronous
+  per-card render work of §7.
+- **Soak n=200** (`soak_n200_pgb.json`, light fixture): rarer spikes —
+  13 samples above 200 ms in 21 min, maxima 594 → 887 → 1040 → 1274 ms,
+  growing monotonically as RSS climbed 950 → 1235 MB. This run predates
+  the GC instrumentation, so the mechanism is inferred from the herd's
+  direct measurement plus the RSS correlation, not measured here.
+
+During a pause every connected client freezes, and in production the
+admission gate's AIMD would read the lag as overload and shrink the cap.
+Candidate levers (generation thresholds, `gc.freeze()` after startup,
+periodic `gc.collect(1)`) are in #574; any fix validates against the
+`gc` block now present in perf diag JSONs.
+
+### 7. Class E is now measured (#575)
+
+CLAUDE.md's failure-mode class E — per-item synchronous UI loops during
+initial render — was known-but-unmeasured since April. The herd measured
+it: **98 organise-tab opens timed out at 30 s** waiting for the first
+`organise-card` to render, the dominant fatal failure of the run (81/150
+students), on a workspace of 190 cards under 150-way concurrency. Server
+page loads for the same workspace cost p50 2.8 s / p95 9.6 s against
+~21 ms for the light fixture. The April prescription (bulk `ui.html`
+emission or interaction-deferred construction) is the direction; #575
+carries it.
+
+### 8. The n=100/n=200 failure anti-correlation is the co-located harness, not logging
+
+Cram fatal students run 20–25 per leg at n=100 but 1–6 at n=200 — more
+browsers, fewer failures. The n=100 legs ran under the old hardcoded
+DEBUG file logging and the n=200 legs under the new INFO default, so
+logging density was a live confound. The control leg
+(`cram_n100_pgb_info_control.json`: n=100, flag off, INFO logging,
+otherwise identical) came back at **23 fatal students — squarely in the
+DEBUG band** — refuting the logging hypothesis.
+
+The surviving explanation is failure-mode class G: 100 or 200 Chromium
+instances share the host with the server, and the per-browser CPU
+starvation profile differs with n in ways that move browser-side 30 s
+action timeouts. This is stated as the best remaining hypothesis, not a
+measured mechanism; the split rig (§10) is the instrument that would
+test it.
+
+### 9. Everything here describes pre-#570 code
+
+The perf branch sits at `e6fd6b20` on `origin/main f7b3c2de`, and **PR
+#570 — the #565 Milkdown mount fix — merged after the campaign's code was
+frozen**. Every Milkdown-degradation figure in this document
+(`degraded_never_typed` counts, the 30 s respond timeouts in the herd,
+the pace/scale trends in §4) describes code without that fix and should
+collapse on a rebased rerun. Treat those figures as the "before" of a
+before/after pair whose "after" has not been run. The rebase decision
+belongs to the PR conversation.
+
+### 10. Harness caveats
+
+**Co-located browsers (class G).** Every run put the Chromium load
+generators, the application server and PostgreSQL on the same 32-core
+host (server pinned to CPUs 0–7 in the PgBouncer series). Browser-observed
+latency carries the browsers' own CPU contention — the herd's 18 s
+browser-side first loads against 2.8 s server-side p50 is the clearest
+case: the gap is mostly browser starvation, not server time. The server
+columns in Part 1 are the production-magnitude claims; the browser
+columns are not. A split rig (server on a separate box, harness-side
+`E2E_PERF_SERVER_URL` support already built) is prepared but had not run
+by the end of the campaign.
+
+**The settle fix costs wall-clock.** `wait_for_scroll_settled` resolves
+no sooner than two animation frames and is called twice per
+`highlight_create`, so post-fix runs do strictly more waiting per drag
+than pre-fix runs. The direction is certain; no magnitude was measured.
+
+**Serialisation.** The perf lane holds a host-wide lock and requires four
+consecutive 15-second samples at load ≤ 4.0 before starting, so runs did
+not overlap. The PgBouncer cram legs additionally controlled order
+(ABBA). No `act`/CI jobs ran on the host during any leg.
+
+**Exit codes.** Historical exit-1s in Part 2 were the old cram boundary
+assert and the old 20× stall assert (§5); both gates have since been
+reshaped to report rather than fail below the collapse boundary.
+
+---
+
+## What would change the tables
+
+1. **A rebased rerun on top of #570** — the Milkdown-degradation class
+   (§4, §9) should collapse; if it does not, #565 is not fully fixed.
+2. **The split rig** (server on the prepared second box) — removes class
+   G from the browser columns, tests §8's hypothesis, and enables the
+   knee hunt: step herd n by 25 until the server actually falls over.
+3. **GC tuning** (#574) validated by the `gc` diag block — should flatten
+   the lag maxima column of the soak table and cut the herd's multi-second
+   stalls.
+4. **Class E render work** (#575) — should turn the herd's 98 organise
+   timeouts and the 0.6–1.6 s non-GC lag residual (§6) into measurable
+   improvements at the same scale.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -42,7 +42,7 @@ Configured via `APP__LOG_DIR` (default: `logs/`). Files are isolated per instanc
 | Production (main/master) | `{log_dir}/promptgrimoire.jsonl` |
 | Branch (e.g. `feature-foo`) | `{log_dir}/promptgrimoire-feature-foo.jsonl` |
 
-**Rotation:** 10 MB max size, 5 backup files. File permissions: `0644` (readable by SSH users without sudo).
+**Rotation:** 10 MB max size, 5 backup files by default; tunable via `LOGGING__MAX_BYTES` and `LOGGING__BACKUP_COUNT` (high-n perf runs need a larger budget or the startup lines rotate away). File permissions: `0644` (readable by SSH users without sudo).
 
 ## Querying with jq
 
@@ -71,7 +71,7 @@ jq -s 'group_by(.level) | map({level: .[0].level, count: length})' logs/promptgr
 
 ## Per-Module Log Levels
 
-Each module sets an explicit log level appropriate to its role. The root logger is DEBUG (file handler captures everything); the console handler is INFO.
+Each module sets an explicit log level appropriate to its role. The file handler defaults to INFO; set `LOGGING__FILE_LEVEL=DEBUG` to capture debug output to file for a single run. The console handler is INFO.
 
 | Module category | Default level | Rationale |
 |----------------|---------------|-----------|

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,6 +91,34 @@ The probe records timeouts as evidence and only fails when the Respond
 container never appears, because it is an attribution probe rather than a
 latency release gate.
 
+The full-CRUD soak probe (`test_soak_full_crud_load.py`) spreads student
+arrivals over a window and then paces a weighted action mix for a fixed
+duration — the "realistic term-time load" shape, as opposed to the cram's
+single wave. It accepts `E2E_SOAK_SESSIONS`, `E2E_SOAK_MINUTES`,
+`E2E_SOAK_RATE_MULT` (multiplier over the observed 0.65 actions/min
+baseline), `E2E_SOAK_ARRIVAL_SPREAD_S`, `E2E_SOAK_WEIGHTS` (action-mix
+override), `E2E_SOAK_ACTION_TIMEOUT_MS`, `E2E_SOAK_DIAG_SAMPLE_SECONDS`
+and `E2E_SOAK_DIAG_PATH`.
+
+The thundering-herd probe (`test_thundering_herd.py`) puts every student
+on their own clone of the heavyweight Pabai workspace (190 annotation
+cards), synchronises arrival behind a double barrier, then runs
+free-running reload/organise/locate/respond churn — the "everyone opens
+the annotated judgment at once" shape. It accepts `E2E_HERD_SESSIONS`,
+`E2E_HERD_CYCLES`, `E2E_HERD_LOCATES`, `E2E_HERD_THINK_MS`,
+`E2E_HERD_SYNC_RELOADS`, `E2E_HERD_LOAD_TIMEOUT_MS`,
+`E2E_HERD_ACTION_TIMEOUT_MS`, `E2E_HERD_BARRIER_TIMEOUT_S`,
+`E2E_HERD_WATCH_SECONDS`, `E2E_HERD_DIAG_SAMPLE_SECONDS` and
+`E2E_HERD_DIAG_PATH`.
+
+All three probes write run provenance (`run_meta`) and the server-side
+`page_load_profile` percentiles (`server_page_load`, parsed from the
+server's own log with coverage checks) into their diagnostic JSONs via
+`tests/e2e/perf_reporting.py`. A perf run that needs production-shaped
+pooling passes `--queue-pool` to `grimoire e2e perf`; verify the leg by
+`server_page_load.pool_mode.reason == "pool_fidelity"` in the JSON, not
+by the environment you think you set.
+
 Comparative performance claims require alternating or interleaved arms (ABBA
 at minimum), per-leg results, and within-arm spread. Report server-side and
 browser-side boundaries separately; browser timings from co-located load

--- a/scripts/check_js_injection.py
+++ b/scripts/check_js_injection.py
@@ -58,6 +58,10 @@ ALLOWED_JS_FILES = {
     # Reads window.__annotationCardsEpoch / __cardEpochs (epoch-wait
     # pattern, no DOM surface) plus rAF paint pumps.
     "card_helpers.py",
+    # Soak load probe: reads window.__annotationCardsEpoch (same
+    # epoch-wait pattern as card_helpers, no DOM surface) to sequence
+    # comment deletion against the sidebar rebuild.
+    "test_soak_full_crud_load.py",
     # -- test files (entries predate 2026-08-17 audit; reasons verified) --
     # Clipboard API (navigator.clipboard.write) has no Playwright equivalent.
     # HTML paste simulation requires JavaScript to write text/html MIME type.

--- a/scripts/perf-run.sh
+++ b/scripts/perf-run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Detached perf-lane runner.
+#
+# Claude Code's background-shell reaper kills main-session background
+# tasks when a cgroup memory-pressure event coincides with >=30 min of
+# user idleness (found 2026-08-18; see
+# .notes/project_session-state-2026-08-17-perf-cram.md). Perf runs are
+# both long and the very thing that generates that pressure, so they
+# must not run inside the agent's cgroup at all. This wrapper launches
+# the command as a transient systemd user unit: own cgroup, immune to
+# the reaper, survives the launching terminal.
+#
+# Usage:
+#   scripts/perf-run.sh <logfile> <command...>
+# Example:
+#   scripts/perf-run.sh /tmp/soak_n25.log \
+#     env E2E_SOAK_SESSIONS=25 E2E_SOAK_DIAG_PATH=perf-data/soak_n25.json \
+#     uv run grimoire e2e perf tests/e2e/test_soak_full_crud_load.py
+#
+# The unit runs in the current directory. Progress: tail the logfile or
+# `systemctl --user status <unit>`. On completion the logfile ends with
+# "=== perf-run exit=<code>" and "<logfile>.done" is created holding the
+# exit code, so a poller has an unambiguous end signal.
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 <logfile> <command...>" >&2
+    exit 2
+fi
+
+log=$(realpath -m "$1")
+shift
+unit="perf-run-$(date +%Y%m%d-%H%M%S)"
+rm -f "$log.done"
+
+# Bounce through bash -c so redirection and the done-marker live inside
+# the unit; printf %q survives arguments with spaces.
+cmd=$(printf '%q ' "$@")
+systemd-run --user --collect --unit="$unit" --same-dir \
+    --property=Nice=19 \
+    bash -c "{ echo \"=== perf-run start \$(date +%F' '%T) unit=$unit\";
+               $cmd; rc=\$?;
+               echo \"=== perf-run exit=\$rc \$(date +%F' '%T)\";
+               echo \$rc >'$log.done'; } >'$log' 2>&1"
+
+echo "launched $unit (log: $log)"
+echo "watch: tail -f $log   status: systemctl --user status $unit"

--- a/src/promptgrimoire/cli/e2e/__init__.py
+++ b/src/promptgrimoire/cli/e2e/__init__.py
@@ -111,12 +111,39 @@ def _wait_for_idle_perf_host() -> None:
         time.sleep(15)
 
 
+def _check_remote_perf_server(url: str) -> None:
+    """Fail fast if the external perf server is not answering.
+
+    Split-rig runs point at a server on another machine; a typo'd URL or
+    a server that never started must die here, not as 150 browser
+    timeouts twenty minutes later.
+    """
+    import urllib.error
+    import urllib.request
+    from http import HTTPStatus
+
+    health = url.rstrip("/") + "/healthz"
+    try:
+        with urllib.request.urlopen(health, timeout=10) as resp:  # noqa: S310
+            if resp.status != HTTPStatus.OK:  # pragma: no cover - remote
+                console.print(f"[red]{health} answered {resp.status}[/]")
+                sys.exit(1)
+    except (urllib.error.URLError, OSError) as exc:
+        console.print(f"[red]External perf server unreachable: {health}: {exc}[/]")
+        sys.exit(1)
+
+
 def _configure_perf_server(*, queue_pool: bool) -> None:
     """Apply production-shaped settings to the managed perf server."""
     os.environ["E2E_RECONNECT_TIMEOUT"] = "15"
     os.environ["E2E_INSTRUMENT_OUTBOX"] = "1"
     if queue_pool:
         os.environ.pop("_PROMPTGRIMOIRE_USE_NULL_POOL", None)
+        # Positive override as well as the removal above: it survives any
+        # later re-set of the harness flag, and it makes the server's
+        # db_pool_mode log line say reason="pool_fidelity" rather than
+        # being indistinguishable from an ordinary QueuePool startup.
+        os.environ["_PROMPTGRIMOIRE_POOL_FIDELITY"] = "1"
         if database_url := os.environ.get("E2E_PERF_DATABASE_URL"):
             os.environ["DATABASE__URL"] = database_url
 
@@ -684,12 +711,25 @@ def perf(
     _wait_for_idle_perf_host()
     get_settings()
     _pre_test_db_cleanup()
-    _configure_perf_server(queue_pool=queue_pool)
 
-    port = _allocate_ports(1)[0]
-    url = f"http://localhost:{port}"
-    server_process = _start_e2e_server(port)
-    console.print(f"[green]Server ready at {url}[/]")
+    # Split-rig mode: E2E_PERF_SERVER_URL points browsers at a server on
+    # another machine (its pooling/env is configured there, e.g. by
+    # boxen/bunyip/perf-rig/run-perf-server.sh). The harness side keeps
+    # its own DB access via DEV__TEST_DATABASE_URL / E2E_PERF_DATABASE_URL
+    # pointing at that machine. The local host-load gate above still
+    # applies: it now guards the browser farm, not the server.
+    remote_url = os.environ.get("E2E_PERF_SERVER_URL")
+    if remote_url:
+        _check_remote_perf_server(remote_url)
+        url = remote_url
+        server_process = None
+        console.print(f"[green]Using external perf server at {url}[/]")
+    else:
+        _configure_perf_server(queue_pool=queue_pool)
+        port = _allocate_ports(1)[0]
+        url = f"http://localhost:{port}"
+        server_process = _start_e2e_server(port)
+        console.print(f"[green]Server ready at {url}[/]")
 
     os.environ["E2E_BASE_URL"] = url
     args = _prepend_pytest_flags(args, exit_first=exit_first, failed_first=False)
@@ -700,9 +740,16 @@ def perf(
             log_path=Path("test-perf.log"),
             default_args=default_args,
             extra_args=args,
+            # Production-shaped pooling is for the measured server only.
+            # _run_pytest calls _pre_test_db_cleanup() again, which restores
+            # _PROMPTGRIMOIRE_USE_NULL_POOL=1 and the direct database URL for
+            # the harness; clearing the fidelity flag here keeps the harness's
+            # own fixtures on NullPool, as they were before --queue-pool.
+            extra_env={"_PROMPTGRIMOIRE_POOL_FIDELITY": "0"},
         )
     finally:
-        _stop_e2e_server(server_process)
+        if server_process is not None:
+            _stop_e2e_server(server_process)
     sys.exit(exit_code)
 
 

--- a/src/promptgrimoire/cli/e2e/_server_script.py
+++ b/src/promptgrimoire/cli/e2e/_server_script.py
@@ -33,6 +33,54 @@ from promptgrimoire.logging_config import setup_logging
 
 setup_logging()
 
+# --- GC pause recorder ---
+# Convicts or acquits gen-2 GC for the sub-second event-loop stalls seen
+# at n=200 (spike magnitude tracked RSS growth; uninstrumented until now).
+# The callback runs synchronously around every collection, so it must
+# stay tiny. Drained by /api/test/diagnostics each poll.
+import gc
+import time as _time
+
+# No lock: the callback fires on whichever thread triggers collection and
+# the endpoint drains on the loop thread; a torn read misreports one
+# sample of diagnostics, which is acceptable for this instrument.
+_GC_NOTABLE_PAUSE_MS = 50.0
+
+_gc_state: dict[str, Any] = {
+    "start_ns": 0,
+    "pause_max_ms": [0.0, 0.0, 0.0],
+    "pauses_over_50ms": 0,
+    "count": [0, 0, 0],
+}
+
+
+def _gc_callback(phase: str, info: dict[str, Any]) -> None:
+    if phase == "start":
+        _gc_state["start_ns"] = _time.perf_counter_ns()
+        return
+    gen = info.get("generation", 0)
+    dur_ms = (_time.perf_counter_ns() - _gc_state["start_ns"]) / 1e6
+    _gc_state["count"][gen] += 1
+    _gc_state["pause_max_ms"][gen] = max(_gc_state["pause_max_ms"][gen], dur_ms)
+    if dur_ms > _GC_NOTABLE_PAUSE_MS:
+        _gc_state["pauses_over_50ms"] += 1
+
+
+gc.callbacks.append(_gc_callback)
+
+
+def _drain_gc_stats() -> dict[str, Any]:
+    out = {
+        "pause_max_ms": [round(v, 1) for v in _gc_state["pause_max_ms"]],
+        "pauses_over_50ms": _gc_state["pauses_over_50ms"],
+        "count": list(_gc_state["count"]),
+    }
+    _gc_state["pause_max_ms"] = [0.0, 0.0, 0.0]
+    _gc_state["pauses_over_50ms"] = 0
+    _gc_state["count"] = [0, 0, 0]
+    return out
+
+
 # --- Event loop watchdog (runs on a separate thread) ---
 import asyncio
 import structlog
@@ -447,6 +495,7 @@ async def _diagnostics():
         "asyncio_tasks": len(all_tasks),
         "asyncio_task_names": _task_summary(all_tasks),
         "load_metrics": drain_load_metrics(),
+        "gc": _drain_gc_stats(),
     }
 
 

--- a/src/promptgrimoire/config.py
+++ b/src/promptgrimoire/config.py
@@ -200,6 +200,22 @@ class IdleConfig(BaseModel):
     enabled: bool = True
 
 
+class LoggingConfig(BaseModel):
+    """Session file logging knobs (env prefix ``LOGGING__``).
+
+    ``file_level`` is INFO by default: DEBUG-to-file ran ~170 lines/s
+    under class load, shrinking the rotation window to minutes of
+    history.  DEBUG is the inspection exception, opted into per run.
+    Rotation is tunable because high-n perf runs out-write the default
+    budget and rotate away the startup lines that per-run pool
+    verification parses.
+    """
+
+    file_level: str = "INFO"
+    max_bytes: int = 10_485_760
+    backup_count: int = 5
+
+
 class SnapshotConfig(BaseModel):
     """Initial annotation snapshot delivery (standalone service).
 
@@ -350,6 +366,7 @@ class Settings(BaseSettings):
     stytch: StytchConfig = StytchConfig()
     database: DatabaseConfig = DatabaseConfig()
     llm: LlmConfig = LlmConfig()
+    logging: LoggingConfig = LoggingConfig()
     app: AppConfig = AppConfig()
     alerting: AlertingConfig = AlertingConfig()
     admin: AdminConfig = AdminConfig()

--- a/src/promptgrimoire/db/engine.py
+++ b/src/promptgrimoire/db/engine.py
@@ -176,6 +176,51 @@ def _is_test_environment() -> bool:
     return os.environ.get("_PROMPTGRIMOIRE_USE_NULL_POOL") == "1"
 
 
+def _pool_fidelity_requested() -> bool:
+    """Detect an explicit request for production-shaped connection pooling.
+
+    Returns True when _PROMPTGRIMOIRE_POOL_FIDELITY=1 is set.  The perf
+    lane sets it (``grimoire e2e perf --queue-pool``) so a load run
+    measures QueuePool against PgBouncer rather than the test harness's
+    forced NullPool, which opens one PostgreSQL connection per request
+    and hits ``max_connections`` at high session counts.
+    """
+    return os.environ.get("_PROMPTGRIMOIRE_POOL_FIDELITY") == "1"
+
+
+def _resolve_pool_mode(*, config_null_pool: bool) -> tuple[bool, str]:
+    """Decide NullPool vs QueuePool and name the deciding input.
+
+    Precedence, highest first:
+
+    1. ``_PROMPTGRIMOIRE_WORKER_NULLPOOL=1`` -- the standalone export
+       worker always gets NullPool ("worker_override").
+    2. ``DATABASE__USE_NULL_POOL`` -- an operator's deployment decision
+       outranks the harness escape hatch ("config").
+    3. ``_PROMPTGRIMOIRE_POOL_FIDELITY=1`` -- opts out of the test
+       forcing below, and only that ("pool_fidelity").
+    4. ``_PROMPTGRIMOIRE_USE_NULL_POOL=1`` -- the test harness ("test").
+    5. Otherwise QueuePool with the configured sizing ("default").
+
+    Args:
+        config_null_pool: ``settings.database.use_null_pool``.
+
+    Returns:
+        ``(use_null_pool, reason)`` -- the reason always names the input
+        that decided the returned mode, so a run's pool choice is
+        auditable from one log line.
+    """
+    if os.environ.get("_PROMPTGRIMOIRE_WORKER_NULLPOOL") == "1":
+        return True, "worker_override"
+    if config_null_pool:
+        return True, "config"
+    if _pool_fidelity_requested():
+        return False, "pool_fidelity"
+    if _is_test_environment():
+        return True, "test"
+    return False, "default"
+
+
 async def init_db() -> None:
     """Initialize database engine and session factory.
 
@@ -188,15 +233,18 @@ async def init_db() -> None:
     per request and closes it immediately, avoiding asyncpg connection-
     state leakage between tests under pytest-xdist parallel execution.
     See: asyncpg#784, SQLAlchemy#10226.
+
+    A perf run opts back into production-shaped pooling with
+    ``_PROMPTGRIMOIRE_POOL_FIDELITY=1``; see ``_resolve_pool_mode`` for
+    the full precedence.  The chosen mode is logged once as
+    ``db_pool_mode`` with the reason that decided it.
     """
     if _state.engine is not None:
         return
 
     settings = get_settings()
-    use_null_pool = (
-        _is_test_environment()
-        or settings.database.use_null_pool
-        or os.environ.get("_PROMPTGRIMOIRE_WORKER_NULLPOOL") == "1"
+    use_null_pool, pool_reason = _resolve_pool_mode(
+        config_null_pool=settings.database.use_null_pool
     )
 
     pool_kwargs: dict[str, object] = {
@@ -209,13 +257,7 @@ async def init_db() -> None:
 
     if use_null_pool:
         pool_kwargs["poolclass"] = NullPool
-        if _is_test_environment():
-            reason = "test"
-        elif os.environ.get("_PROMPTGRIMOIRE_WORKER_NULLPOOL") == "1":
-            reason = "worker_override"
-        else:
-            reason = "config"
-        logger.info("db_pool_mode", mode="NullPool", reason=reason)
+        logger.info("db_pool_mode", mode="NullPool", reason=pool_reason)
     else:
         db_config = settings.database
         pool_kwargs |= {
@@ -227,8 +269,10 @@ async def init_db() -> None:
         logger.info(
             "db_pool_mode",
             mode="QueuePool",
+            reason=pool_reason,
             pool_size=db_config.pool_size,
             max_overflow=db_config.max_overflow,
+            pool_pre_ping=db_config.pool_pre_ping,
         )
 
     _state.engine = create_async_engine(get_database_url(), **pool_kwargs)

--- a/src/promptgrimoire/docs/helpers.py
+++ b/src/promptgrimoire/docs/helpers.py
@@ -118,6 +118,27 @@ def wait_for_text_walker(page: Page, *, timeout: int = 15000) -> None:
         raise type(exc)(msg) from None
 
 
+def wait_for_scroll_settled(page: Page, *, timeout: int = 5000) -> None:
+    """Wait until the viewport scroll position is stable across two frames.
+
+    A smooth scroll (the app's ``scrollToCharOffset`` uses
+    ``behavior: 'smooth'``) landing between ``mouse.down()`` and
+    ``mouse.up()`` collapses the selection on every pointer move — the
+    scroll-during-drag race behind the #562 whiffs.  Any helper that
+    reads coordinates or drags after a possible scroll must settle
+    first.  Each poll spans two animation frames, so an in-flight
+    animation keeps resolving false until it stops.
+    """
+    page.wait_for_function(
+        """() => new Promise(resolve => {
+            const x0 = window.scrollX, y0 = window.scrollY;
+            requestAnimationFrame(() => requestAnimationFrame(() =>
+                resolve(window.scrollX === x0 && window.scrollY === y0)));
+        })""",
+        timeout=timeout,
+    )
+
+
 def select_chars(page: Page, start_char: int, end_char: int) -> None:
     """Select a character range using mouse events.
 
@@ -192,6 +213,12 @@ def select_chars(page: Page, start_char: int, end_char: int) -> None:
         }""",
         [start_char, end_char],
     )
+
+    # Settle any scroll still animating (our instant scroll aborts most
+    # smooth scrolls, but an earlier scrollToCharOffset with a different
+    # target can outlive it) BEFORE re-reading coordinates: a viewport
+    # shift mid-drag collapses the selection on every move (#562).
+    wait_for_scroll_settled(page)
 
     # Re-query coordinates after scroll (positions change)
     coords = page.evaluate(

--- a/src/promptgrimoire/logging_config.py
+++ b/src/promptgrimoire/logging_config.py
@@ -175,13 +175,22 @@ def setup_logging() -> None:
             structlog.processors.JSONRenderer(),
         ],
     )
+    # Rotation is tunable via the LOGGING__ settings because high-n perf
+    # runs out-write the default retention, rotating away the startup
+    # db_pool_mode line and the head of the page_load_profile stream
+    # that the perf harness's provenance capture depends on.
     file_handler = RotatingFileHandler(
         log_file,
-        maxBytes=10 * 1024 * 1024,
-        backupCount=5,
+        maxBytes=settings.logging.max_bytes,
+        backupCount=settings.logging.backup_count,
         encoding="utf-8",
     )
-    file_handler.setLevel(logging.DEBUG)
+    # INFO by default; DEBUG is the inspection exception, opted into
+    # per run via LOGGING__FILE_LEVEL (see LoggingConfig).
+    file_level = logging.getLevelNamesMapping().get(
+        settings.logging.file_level.upper(), logging.INFO
+    )
+    file_handler.setLevel(file_level)
     file_handler.setFormatter(file_formatter)
 
     # Set file permissions to 0o644

--- a/src/promptgrimoire/pages/annotation/organise.py
+++ b/src/promptgrimoire/pages/annotation/organise.py
@@ -391,7 +391,7 @@ def render_organise_tab(  # noqa: PLR0913 -- param-object migration: tracker led
             )
             card_count += len(untagged_highlights)
 
-    logger.info(
+    logger.debug(
         "organise_card_build",
         elapsed_ms=round((time.monotonic() - _t0) * 1000, 1),
         card_count=card_count,

--- a/src/promptgrimoire/pages/annotation/respond.py
+++ b/src/promptgrimoire/pages/annotation/respond.py
@@ -430,7 +430,7 @@ def _build_reference_panel(
                 _build_reference_card_html(hl, "#999999", "Untagged", state, on_locate)
                 card_count += 1
 
-    logger.info(
+    logger.debug(
         "respond_card_build",
         elapsed_ms=round((time.monotonic() - _t0) * 1000, 1),
         card_count=card_count,

--- a/src/promptgrimoire/pages/annotation/sidebar.py
+++ b/src/promptgrimoire/pages/annotation/sidebar.py
@@ -137,7 +137,7 @@ class AnnotationSidebar(ui.element, component=_JS_PATH):
         )
 
         _elapsed = round((time.monotonic() - _t0) * 1000, 1)
-        logger.info(
+        logger.debug(
             "vue_sidebar_refresh",
             trigger="refresh_from_state",
             elapsed_ms=_elapsed,

--- a/tests/e2e/assessment_fixtures.py
+++ b/tests/e2e/assessment_fixtures.py
@@ -1,0 +1,168 @@
+"""Assessment-fixture provisioning shared by the perf probes.
+
+Generalises the Narayan-only scaffolding from the cram probe over any
+extracted-workspace fixture (Narayan and Savage today): rehydrate the
+fixture, bind it as an Activity template, clone per synthetic student,
+and restore the original binding afterwards.
+
+Each fixture JSON is a prod extract (``scripts/extract_workspace.py``)
+whose workspace id is fixed, so rehydration is idempotent
+(delete-then-reinsert).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+NARAYAN_WORKSPACE_ID = "c7cf540f-53df-407e-b043-cc6f6e30cf5b"
+SAVAGE_WORKSPACE_ID = "8b7f15e9-49b8-4da7-bc4c-f1d7e50c5f1f"
+CASE_BRIEF_TAG_COUNT = 10
+
+
+@dataclass(frozen=True)
+class AssessmentFixture:
+    """One rehydratable assessment workspace fixture."""
+
+    name: str
+    workspace_id: str
+    json_path: Path
+
+
+NARAYAN_FIXTURE = AssessmentFixture(
+    name="narayan",
+    workspace_id=NARAYAN_WORKSPACE_ID,
+    json_path=FIXTURES_DIR / "narayan_workspace.json",
+)
+SAVAGE_FIXTURE = AssessmentFixture(
+    name="savage",
+    workspace_id=SAVAGE_WORKSPACE_ID,
+    json_path=FIXTURES_DIR / "savage_workspace.json",
+)
+
+
+def ensure_fixture_workspace(fixture: AssessmentFixture) -> str:
+    """Rehydrate a fixture workspace into the test DB; return its id."""
+    from promptgrimoire.config import get_settings
+
+    if not fixture.json_path.exists():
+        pytest.skip(
+            f"Workspace JSON not found at {fixture.json_path}. "
+            "Extract from prod with scripts/extract_workspace.py first."
+        )
+
+    from scripts.rehydrate_workspace import rehydrate
+
+    db_url = get_settings().database.url
+    if not db_url:
+        msg = "DATABASE__URL not configured"
+        raise RuntimeError(msg)
+    result = rehydrate(fixture.json_path, db_url)
+    assert result["workspace_id"] == fixture.workspace_id
+    return fixture.workspace_id
+
+
+async def create_template_activity(
+    fixture: AssessmentFixture,
+    *,
+    course_name: str,
+) -> tuple[str, str]:
+    """Create an Activity whose template workspace is the fixture.
+
+    Returns (activity_id, old_template_id) for later restoration.
+    """
+    from promptgrimoire.db.activities import create_activity
+    from promptgrimoire.db.courses import create_course
+    from promptgrimoire.db.engine import get_session
+    from promptgrimoire.db.models import Activity, Workspace
+    from promptgrimoire.db.weeks import create_week, publish_week
+
+    suffix = uuid4().hex[:8]
+    course = await create_course(
+        code=f"CR{suffix[:6].upper()}",
+        name=course_name,
+        semester="2026-S2",
+    )
+    week = await create_week(course_id=course.id, week_number=5, title="Week 5")
+    await publish_week(week.id)
+    activity = await create_activity(week_id=week.id, title=f"{course_name} {suffix}")
+
+    async with get_session() as session:
+        db_activity = await session.get(Activity, activity.id)
+        assert db_activity is not None
+        old_template_id = str(db_activity.template_workspace_id)
+        db_activity.template_workspace_id = UUID(fixture.workspace_id)
+        session.add(db_activity)
+
+        old_template = await session.get(Workspace, UUID(old_template_id))
+        if old_template is not None:
+            old_template.activity_id = None
+            session.add(old_template)
+
+        fixture_ws = await session.get(Workspace, UUID(fixture.workspace_id))
+        assert fixture_ws is not None
+        fixture_ws.activity_id = activity.id
+        session.add(fixture_ws)
+
+    return str(activity.id), old_template_id
+
+
+async def restore_template_binding(
+    fixture: AssessmentFixture,
+    activity_id: str,
+    old_template_id: str,
+) -> None:
+    """Restore the fixture to loose-workspace state after a probe."""
+    from promptgrimoire.db.engine import get_session
+    from promptgrimoire.db.models import Activity, Workspace
+
+    async with get_session() as session:
+        activity = await session.get(Activity, UUID(activity_id))
+        if activity is not None:
+            activity.template_workspace_id = UUID(old_template_id)
+            session.add(activity)
+
+        fixture_ws = await session.get(Workspace, UUID(fixture.workspace_id))
+        if fixture_ws is not None:
+            fixture_ws.activity_id = None
+            session.add(fixture_ws)
+
+        old_template = await session.get(Workspace, UUID(old_template_id))
+        if old_template is not None:
+            old_template.activity_id = UUID(activity_id)
+            session.add(old_template)
+
+
+async def provision_clone_for_email(activity_id: str, email: str) -> str:
+    """Create or reuse a user, then clone the template for them."""
+    from promptgrimoire.db.users import find_or_create_user
+    from promptgrimoire.db.workspaces import clone_workspace_from_activity
+
+    user, _ = await find_or_create_user(email, display_name=email.split("@", 1)[0])
+    clone, _ = await clone_workspace_from_activity(UUID(activity_id), user.id)
+    return str(clone.id)
+
+
+def fixture_document_words(fixture: AssessmentFixture) -> list[str]:
+    """Extract the fixture document's words for needle planning.
+
+    The browser's text walker collapses whitespace, so a needle built
+    from single-space-joined words matches what ``find_text_range``
+    searches.
+    """
+    from selectolax.lexbor import LexborHTMLParser
+
+    data = json.loads(fixture.json_path.read_text(encoding="utf-8"))
+    html = data["documents"][0]["content"]
+    words = LexborHTMLParser(html).text(separator=" ").split()
+    min_words_needed = 200
+    if len(words) < min_words_needed:
+        msg = f"fixture document too short ({len(words)} words)"
+        raise RuntimeError(msg)
+    return words

--- a/tests/e2e/highlight_tools.py
+++ b/tests/e2e/highlight_tools.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from promptgrimoire.docs.helpers import select_chars, wait_for_text_walker
+from promptgrimoire.docs.helpers import (
+    select_chars,
+    wait_for_scroll_settled,
+    wait_for_text_walker,
+)
 
 if TYPE_CHECKING:
     from playwright.sync_api import Page
@@ -287,7 +291,10 @@ def scroll_to_char(page: Page, char_offset: int) -> None:
         }""",
         char_offset,
     )
-    page.wait_for_function("new Promise(r => requestAnimationFrame(r))")
+    # scrollToCharOffset animates (behavior: 'smooth', ~300-500ms). A single
+    # frame is not enough: the animation outliving this wait is the
+    # scroll-during-drag race behind the #562 whiffs.
+    wait_for_scroll_settled(page)
 
 
 def wait_for_css_highlight(page: Page, *, timeout: int = 5000) -> None:

--- a/tests/e2e/perf_reporting.py
+++ b/tests/e2e/perf_reporting.py
@@ -1,0 +1,470 @@
+"""Run provenance and server-side page-load stats for the perf probes.
+
+Every latency number the soak and cram probes print is browser-observed:
+it includes Playwright, the co-located browser's own CPU contention, and
+the render, so it is not a production-magnitude claim (failure-mode class
+G, CLAUDE.md).  The server's own ``page_load_profile`` event is the
+production-magnitude number, and this module reads it back out of the
+structlog JSONL the measured server writes.
+
+Locating that file needs no new plumbing.  ``setup_logging()`` logs its
+absolute path as its final startup line, and ``_start_e2e_server`` sends
+the server's stdout to ``test-e2e-server.log``, so the path is readable
+from the harness process (same strategy as ``ServerLogReader`` in
+``test_browser_perf_377.py``, plus the rotated backups a multi-minute run
+produces).
+
+Three sources of provenance land in the run JSON, weakest first:
+
+- ``run_meta.env`` -- the harness process's raw environment.
+- ``run_meta.snapshot_enabled`` -- the harness process's resolved config.
+  Both processes read the same ``.env`` and the server inherits the
+  harness environment, so this is an inference about the server, not an
+  observation of it.
+- ``server_page_load`` -- read off the measured server's own log lines:
+  its pid, branch, commit, chosen pool mode, and (when the snapshot
+  service served bundles during the run) a nonzero ``snapshot_served``.
+  A run whose ``snapshot_enabled`` is true while ``snapshot_served`` is
+  zero is contradicted by its own evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
+PAGE_LOAD_EVENT = "page_load_profile"
+POOL_MODE_EVENT = "db_pool_mode"
+SNAPSHOT_SERVED_EVENT = "snapshot_served"
+_TRACKED_EVENTS = frozenset({PAGE_LOAD_EVENT, POOL_MODE_EVENT, SNAPSHOT_SERVED_EVENT})
+
+# Phases aggregated from each page_load_profile event.  total_ms is the
+# production-magnitude page-load number; the other two say where it went.
+_PHASE_KEYS = ("total_ms", "db_resolve_ms", "tab_panels_ms")
+
+# The route whose page loads the probes are measuring.  A profile from
+# another route is excluded and counted; an *unbound* path is kept, so a
+# build that stops binding request_path reports its loads rather than a
+# confident zero.
+_MEASURED_PATH_PREFIX = "/annotation"
+
+# Recorded verbatim in run_meta: the pool-mode and snapshot switches that
+# decide what a run actually measured.  A name absent from the harness
+# environment records as null, so the key means the same thing whichever
+# way the sibling pool work names its flags.
+PROVENANCE_ENV_VARS = (
+    "SNAPSHOT__ENABLED",
+    "_PROMPTGRIMOIRE_USE_NULL_POOL",
+    "_PROMPTGRIMOIRE_POOL_FIDELITY",
+    "_PROMPTGRIMOIRE_WORKER_NULLPOOL",
+    "DATABASE__USE_NULL_POOL",
+    "E2E_RECONNECT_TIMEOUT",
+    "E2E_INSTRUMENT_OUTBOX",
+)
+
+# Recorded as presence booleans only -- these hold DSNs with credentials.
+_PRESENCE_ONLY_ENV_VARS = (
+    "E2E_PERF_DATABASE_URL",
+    "DATABASE__URL",
+)
+
+DEFAULT_SERVER_STDOUT_LOG = Path("test-e2e-server.log")
+_LOG_PATH_MARKER = "Log file: "
+_STARTUP_LINES_SCANNED = 20
+
+
+def utc_now() -> datetime:
+    """Current UTC time, for the run-window bounds."""
+    return datetime.now(UTC)
+
+
+def iso(moment: datetime) -> str:
+    """Render *moment* the way structlog renders its timestamps."""
+    return moment.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: object) -> datetime | None:
+    """Parse a structlog ISO timestamp; None when unusable."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _stats(values: list[float]) -> dict[str, float] | None:
+    """Nearest-rank p50/p95 with max and mean; None for no samples.
+
+    None rather than zeros: an empty aggregate must not read as a page
+    that loaded instantly.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    n = len(ordered)
+
+    def at(quantile: float) -> float:
+        return ordered[min(n - 1, max(0, math.ceil(quantile * n) - 1))]
+
+    return {
+        "p50": round(at(0.50), 1),
+        "p95": round(at(0.95), 1),
+        "max": round(ordered[-1], 1),
+        "mean": round(sum(ordered) / n, 1),
+    }
+
+
+def _is_measured_path(record: dict[str, Any]) -> bool:
+    """Whether a page_load_profile belongs to the measured route."""
+    path = record.get("request_path")
+    if not isinstance(path, str):
+        return True
+    return path.startswith(_MEASURED_PATH_PREFIX)
+
+
+@dataclass
+class _Scan:
+    """Running totals for one pass over the server's log lines."""
+
+    samples: dict[str, list[float]] = field(
+        default_factory=lambda: {key: [] for key in _PHASE_KEYS}
+    )
+    pids: Counter[str] = field(default_factory=Counter)
+    branches: Counter[str] = field(default_factory=Counter)
+    commits: Counter[str] = field(default_factory=Counter)
+    pool_modes: dict[str, dict[str, Any]] = field(default_factory=dict)
+    earliest_log_ts: datetime | None = None
+    lines_scanned: int = 0
+    unparsed_lines: int = 0
+    before_window: int = 0
+    after_window: int = 0
+    other_path: int = 0
+    snapshot_served: int = 0
+
+    def add_profile(self, record: dict[str, Any]) -> None:
+        """Fold one in-window, on-route page_load_profile into the stats."""
+        self.pids[str(record.get("pid"))] += 1
+        if isinstance(branch := record.get("branch"), str):
+            self.branches[branch] += 1
+        if isinstance(commit := record.get("commit"), str):
+            self.commits[commit] += 1
+        for key in _PHASE_KEYS:
+            if isinstance(value := record.get(key), int | float):
+                self.samples[key].append(float(value))
+
+
+def _consume(
+    scan: _Scan,
+    record: dict[str, Any],
+    timestamp: datetime,
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> None:
+    """Fold one parsed log record into *scan*."""
+    event = record.get("event")
+    in_window = window_start <= timestamp <= window_end
+
+    if event == POOL_MODE_EVENT:
+        # Emitted once at engine init, ahead of the run window; keep the
+        # latest per pid and pick the server's after the scan.
+        if timestamp <= window_end:
+            scan.pool_modes[str(record.get("pid"))] = {
+                "mode": record.get("mode"),
+                "reason": record.get("reason"),
+                "timestamp": record.get("timestamp"),
+            }
+        return
+
+    if event == SNAPSHOT_SERVED_EVENT:
+        if in_window:
+            scan.snapshot_served += 1
+        return
+
+    if event != PAGE_LOAD_EVENT:
+        return
+    if not in_window:
+        if timestamp < window_start:
+            scan.before_window += 1
+        else:
+            scan.after_window += 1
+        return
+    if not _is_measured_path(record):
+        scan.other_path += 1
+        return
+    scan.add_profile(record)
+
+
+def _scan_lines(
+    lines: Iterable[str],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> _Scan:
+    """Parse *lines*, folding tracked events into a :class:`_Scan`."""
+    scan = _Scan()
+    for raw_line in lines:
+        scan.lines_scanned += 1
+        line = raw_line.strip()
+        if not line:
+            continue
+        # Cheap reject before JSON parsing: a soak scans tens of MB and
+        # only three event types matter.  The first line is parsed
+        # regardless, since it dates the oldest retained log.
+        interesting = any(event in line for event in _TRACKED_EVENTS)
+        if not interesting and scan.earliest_log_ts is not None:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            scan.unparsed_lines += 1
+            continue
+        timestamp = (
+            _parse_ts(record.get("timestamp")) if isinstance(record, dict) else None
+        )
+        if timestamp is None:
+            scan.unparsed_lines += 1
+            continue
+        if scan.earliest_log_ts is None:
+            scan.earliest_log_ts = timestamp
+        if interesting:
+            _consume(
+                scan,
+                record,
+                timestamp,
+                window_start=window_start,
+                window_end=window_end,
+            )
+    return scan
+
+
+def summarise_page_load_profile(
+    lines: Iterable[str],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, Any]:
+    """Aggregate server-side page-load events over the run window.
+
+    *lines* are raw JSONL log lines in chronological order (rotated
+    backups first).  Only ``page_load_profile`` events inside
+    ``[window_start, window_end]`` feed the latency statistics.
+
+    The returned ``coverage`` block states what the scan could see:
+    ``earliest_log_ts`` with ``window_start_covered`` says whether
+    rotation discarded the head of the window, in which case ``count`` is
+    a lower bound rather than the run's load total.  Events dropped by
+    the window or the route filter are counted rather than discarded
+    silently, so a zero aggregate can be told apart from a filter that
+    matched nothing.
+    """
+    scan = _scan_lines(lines, window_start=window_start, window_end=window_end)
+    earliest_log_ts = scan.earliest_log_ts
+    server_pid = scan.pids.most_common(1)[0][0] if scan.pids else None
+    summary: dict[str, Any] = {
+        "count": sum(scan.pids.values()),
+        "pids": dict(scan.pids),
+        "server_pid": int(server_pid) if server_pid is not None else None,
+        "server_branch": (
+            scan.branches.most_common(1)[0][0] if scan.branches else None
+        ),
+        "server_commit": scan.commits.most_common(1)[0][0] if scan.commits else None,
+        "pool_mode": scan.pool_modes.get(server_pid) if server_pid else None,
+        "snapshot_served": scan.snapshot_served,
+        "coverage": {
+            "window_start": iso(window_start),
+            "window_end": iso(window_end),
+            "lines_scanned": scan.lines_scanned,
+            "unparsed_lines": scan.unparsed_lines,
+            "earliest_log_ts": iso(earliest_log_ts) if earliest_log_ts else None,
+            "window_start_covered": (
+                earliest_log_ts is not None and earliest_log_ts <= window_start
+            ),
+            "profiles_before_window": scan.before_window,
+            "profiles_after_window": scan.after_window,
+            "profiles_other_path": scan.other_path,
+        },
+    }
+    summary.update({key: _stats(scan.samples[key]) for key in _PHASE_KEYS})
+    return summary
+
+
+def find_server_jsonl(
+    server_stdout_log: Path = DEFAULT_SERVER_STDOUT_LOG,
+) -> tuple[Path | None, str]:
+    """Resolve the JSONL file the measured server is writing to.
+
+    ``setup_logging()`` ends with "Structured logging configured. Log
+    file: <abs path>", which the E2E CLI captures in
+    ``test-e2e-server.log``.  That names the file of the process actually
+    under measurement.
+
+    Returns the path and the strategy that found it.  The strategy is
+    reported in the run JSON because the two are not equally
+    trustworthy: ``startup_line`` names the measured process's own file,
+    while ``glob_fallback`` picks the newest log under ``logs/`` and can
+    land on a different branch's or a previous run's file without any
+    other symptom.
+    """
+    if server_stdout_log.exists():
+        with server_stdout_log.open(encoding="utf-8", errors="replace") as handle:
+            for line_number, line in enumerate(handle):
+                if line_number >= _STARTUP_LINES_SCANNED:
+                    break
+                if _LOG_PATH_MARKER not in line:
+                    continue
+                try:
+                    event = json.loads(line).get("event", "")
+                except json.JSONDecodeError:
+                    event = line
+                if not isinstance(event, str):
+                    continue
+                _, _, tail = event.partition(_LOG_PATH_MARKER)
+                candidate = Path(tail.strip())
+                if candidate.is_file():
+                    return candidate, "startup_line"
+
+    candidates = sorted(
+        Path("logs").rglob("promptgrimoire*.jsonl"),
+        key=lambda path: path.stat().st_mtime,
+    )
+    if not candidates:
+        return None, "not_found"
+    return candidates[-1], "glob_fallback"
+
+
+def rotated_log_paths(base: Path) -> list[Path]:
+    """*base* and its RotatingFileHandler backups, oldest first.
+
+    A soak run writes well past the 10 MB rotation threshold, so the
+    current file alone holds only the tail of the window.
+    """
+    backups = sorted(
+        (
+            path
+            for path in base.parent.glob(base.name + ".*")
+            if path.suffix.lstrip(".").isdigit()
+        ),
+        key=lambda path: int(path.suffix.lstrip(".")),
+        reverse=True,
+    )
+    return [*backups, base]
+
+
+def _iter_lines(paths: Iterable[Path]) -> Iterator[str]:
+    """Stream lines from *paths* in order, skipping any that vanished."""
+    for path in paths:
+        if not path.is_file():
+            continue
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            yield from handle
+
+
+def collect_server_page_load(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    server_stdout_log: Path = DEFAULT_SERVER_STDOUT_LOG,
+) -> dict[str, Any]:
+    """Read the server's page-load profile for the run window.
+
+    Returns the aggregate, or an ``unavailable`` block naming what was
+    searched -- an unreadable log must be visible as a gap in the
+    evidence rather than as an absence of slow page loads.
+    """
+    base, resolved_by = find_server_jsonl(server_stdout_log)
+    if base is None:
+        return {
+            "unavailable": "server JSONL log not located",
+            "log_resolved_by": resolved_by,
+            "searched": [str(server_stdout_log), "logs/**/promptgrimoire*.jsonl"],
+        }
+    paths = rotated_log_paths(base)
+    summary = summarise_page_load_profile(
+        _iter_lines(paths),
+        window_start=window_start,
+        window_end=window_end,
+    )
+    summary["log_resolved_by"] = resolved_by
+    summary["log_paths"] = [str(path) for path in paths if path.is_file()]
+    return summary
+
+
+def build_run_meta(
+    *,
+    probe: str,
+    env: Mapping[str, str],
+    started: datetime,
+    ended: datetime,
+    knobs: Mapping[str, Any],
+    snapshot_enabled: bool,
+    branch: str | None,
+) -> dict[str, Any]:
+    """Describe what this run was, so its JSON stands alone.
+
+    *env* is the harness process's environment (the probe passes
+    ``os.environ``); the switches in :data:`PROVENANCE_ENV_VARS` are
+    recorded verbatim, and DSN-bearing variables as presence booleans
+    only.  ``snapshot_enabled`` is the harness's resolved config, which
+    is an inference about the server -- ``server_page_load`` carries the
+    server's own account.
+    """
+    return {
+        "probe": probe,
+        "started_utc": iso(started),
+        "ended_utc": iso(ended),
+        "duration_s": round((ended - started).total_seconds(), 1),
+        "branch": branch,
+        "snapshot_enabled": snapshot_enabled,
+        "knobs": dict(knobs),
+        "env": {name: env.get(name) for name in PROVENANCE_ENV_VARS}
+        | {f"{name}_set": name in env for name in _PRESENCE_ONLY_ENV_VARS},
+    }
+
+
+def print_server_page_load(summary: Mapping[str, Any]) -> None:
+    """Print the server-side page-load block next to the browser table."""
+    print("--- server-side page load (structlog page_load_profile) ---")
+    if "unavailable" in summary:
+        print(f"  UNAVAILABLE: {summary['unavailable']}")
+        print(f"  searched: {summary['searched']}")
+        return
+    coverage = summary["coverage"]
+    total = summary["total_ms"]
+    rendered = (
+        "n/a"
+        if total is None
+        else (
+            f"p50={total['p50']}ms p95={total['p95']}ms "
+            f"max={total['max']}ms mean={total['mean']}ms"
+        )
+    )
+    print(f"  total_ms n={summary['count']}  {rendered}")
+    if db_resolve := summary["db_resolve_ms"]:
+        print(
+            f"  db_resolve_ms   p50={db_resolve['p50']}ms "
+            f"p95={db_resolve['p95']}ms max={db_resolve['max']}ms"
+        )
+    print(
+        f"  pid={summary['server_pid']} commit={summary['server_commit']} "
+        f"pool={summary['pool_mode']} snapshot_served={summary['snapshot_served']}"
+    )
+    print(
+        f"  coverage: window_start_covered={coverage['window_start_covered']} "
+        f"earliest_log={coverage['earliest_log_ts']} "
+        f"lines={coverage['lines_scanned']} "
+        f"unparsed={coverage['unparsed_lines']} "
+        f"outside_window={coverage['profiles_before_window']}"
+        f"/{coverage['profiles_after_window']} "
+        f"other_path={coverage['profiles_other_path']}"
+    )

--- a/tests/e2e/test_assessment_cram_load.py
+++ b/tests/e2e/test_assessment_cram_load.py
@@ -41,11 +41,20 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
 from promptgrimoire.config import get_settings
+from tests.e2e.assessment_fixtures import (
+    CASE_BRIEF_TAG_COUNT,
+    NARAYAN_FIXTURE,
+    create_template_activity,
+    ensure_fixture_workspace,
+    fixture_document_words,
+    provision_clone_for_email,
+    restore_template_binding,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -63,12 +72,6 @@ pytestmark = [
         reason="DEV__TEST_DATABASE_URL not configured",
     ),
 ]
-
-NARAYAN_WORKSPACE_ID = "c7cf540f-53df-407e-b043-cc6f6e30cf5b"
-NARAYAN_FIXTURE_JSON = (
-    Path(__file__).parent.parent / "fixtures" / "narayan_workspace.json"
-)
-CASE_BRIEF_TAG_COUNT = 10
 
 N_CRAM_SESSIONS = int(os.environ.get("E2E_CRAM_SESSIONS", "25"))
 N_CRAM_HIGHLIGHTS = int(os.environ.get("E2E_CRAM_HIGHLIGHTS", "10"))
@@ -110,122 +113,6 @@ def _fetch_json(url: str) -> dict:
     """Fetch JSON from a localhost E2E helper endpoint."""
     with urllib.request.urlopen(url, timeout=30) as resp:
         return json.loads(resp.read().decode())
-
-
-def _ensure_narayan_workspace() -> str:
-    """Rehydrate the Narayan assessment template into the test DB.
-
-    The rehydrate script deletes then re-inserts, so calling this
-    unconditionally is safe. Returns the workspace ID.
-    """
-    if not NARAYAN_FIXTURE_JSON.exists():
-        pytest.skip(
-            f"Workspace JSON not found at {NARAYAN_FIXTURE_JSON}. "
-            "Extract from prod with scripts/extract_workspace.py first."
-        )
-
-    from scripts.rehydrate_workspace import rehydrate
-
-    db_url = get_settings().database.url
-    if not db_url:
-        msg = "DATABASE__URL not configured"
-        raise RuntimeError(msg)
-    result = rehydrate(NARAYAN_FIXTURE_JSON, db_url)
-    assert result["workspace_id"] == NARAYAN_WORKSPACE_ID
-    return NARAYAN_WORKSPACE_ID
-
-
-async def _create_narayan_template_activity() -> tuple[str, str]:
-    """Create an Activity whose template workspace is the Narayan fixture."""
-    from promptgrimoire.db.activities import create_activity
-    from promptgrimoire.db.courses import create_course
-    from promptgrimoire.db.engine import get_session
-    from promptgrimoire.db.models import Activity, Workspace
-    from promptgrimoire.db.weeks import create_week, publish_week
-
-    suffix = uuid4().hex[:8]
-    course = await create_course(
-        code=f"CR{suffix[:6].upper()}",
-        name="Assessment Cram Probe",
-        semester="2026-S2",
-    )
-    week = await create_week(course_id=course.id, week_number=5, title="Week 5")
-    await publish_week(week.id)
-    activity = await create_activity(week_id=week.id, title=f"Cram Load {suffix}")
-
-    async with get_session() as session:
-        db_activity = await session.get(Activity, activity.id)
-        assert db_activity is not None
-        old_template_id = str(db_activity.template_workspace_id)
-        db_activity.template_workspace_id = UUID(NARAYAN_WORKSPACE_ID)
-        session.add(db_activity)
-
-        old_template = await session.get(Workspace, UUID(old_template_id))
-        if old_template is not None:
-            old_template.activity_id = None
-            session.add(old_template)
-
-        narayan = await session.get(Workspace, UUID(NARAYAN_WORKSPACE_ID))
-        assert narayan is not None
-        narayan.activity_id = activity.id
-        session.add(narayan)
-
-    return str(activity.id), old_template_id
-
-
-async def _restore_narayan_template_binding(
-    activity_id: str,
-    old_template_id: str,
-) -> None:
-    """Restore the Narayan fixture to loose-workspace state after the probe."""
-    from promptgrimoire.db.engine import get_session
-    from promptgrimoire.db.models import Activity, Workspace
-
-    async with get_session() as session:
-        activity = await session.get(Activity, UUID(activity_id))
-        if activity is not None:
-            activity.template_workspace_id = UUID(old_template_id)
-            session.add(activity)
-
-        narayan = await session.get(Workspace, UUID(NARAYAN_WORKSPACE_ID))
-        if narayan is not None:
-            narayan.activity_id = None
-            session.add(narayan)
-
-        old_template = await session.get(Workspace, UUID(old_template_id))
-        if old_template is not None:
-            old_template.activity_id = UUID(activity_id)
-            session.add(old_template)
-
-
-async def _provision_clone_for_email(activity_id: str, email: str) -> str:
-    """Create or reuse a user, then clone the assessment template for them."""
-    from promptgrimoire.db.users import find_or_create_user
-    from promptgrimoire.db.workspaces import clone_workspace_from_activity
-
-    user, _ = await find_or_create_user(email, display_name=email.split("@", 1)[0])
-    clone, _ = await clone_workspace_from_activity(UUID(activity_id), user.id)
-    return str(clone.id)
-
-
-def _fixture_document_words() -> list[str]:
-    """Extract the assessment document's words from the fixture JSON.
-
-    The browser's text walker collapses whitespace, so a needle built
-    from single-space-joined words matches what ``find_text_range``
-    searches. Reading the fixture (rather than the browser) keeps the
-    probe file free of page.evaluate.
-    """
-    from selectolax.lexbor import LexborHTMLParser
-
-    data = json.loads(NARAYAN_FIXTURE_JSON.read_text(encoding="utf-8"))
-    html = data["documents"][0]["content"]
-    words = LexborHTMLParser(html).text(separator=" ").split()
-    min_words_needed = 200
-    if len(words) < min_words_needed:
-        msg = f"fixture document too short ({len(words)} words)"
-        raise RuntimeError(msg)
-    return words
 
 
 def _plan_highlight_needles(
@@ -336,7 +223,7 @@ def _run_annotation_pass(
     from tests.e2e.card_helpers import add_comment_to_highlight
 
     pass_start = time.perf_counter()
-    words = _fixture_document_words()
+    words = fixture_document_words(NARAYAN_FIXTURE)
     # Extra candidates cover needles the walker's whitespace collapsing
     # renders unfindable (e.g. words joined across a <br>).
     # 4x pool: retries and unfindable needles both consume candidates.
@@ -539,12 +426,16 @@ def _maybe_write_diag(
 @pytest.fixture(scope="module")
 def narayan_activity_template() -> Iterator[str]:
     """Create a temporary activity using the Narayan fixture as template."""
-    _ensure_narayan_workspace()
-    activity_id, old_template_id = asyncio.run(_create_narayan_template_activity())
+    ensure_fixture_workspace(NARAYAN_FIXTURE)
+    activity_id, old_template_id = asyncio.run(
+        create_template_activity(NARAYAN_FIXTURE, course_name="Assessment Cram Probe")
+    )
     try:
         yield activity_id
     finally:
-        asyncio.run(_restore_narayan_template_binding(activity_id, old_template_id))
+        asyncio.run(
+            restore_template_binding(NARAYAN_FIXTURE, activity_id, old_template_id)
+        )
 
 
 class TestAssessmentCramLoad:
@@ -560,7 +451,7 @@ class TestAssessmentCramLoad:
         for _ in range(N_CRAM_SESSIONS):
             email = f"cram-{uuid4().hex[:8]}@test.example.edu.au"
             workspace_id = asyncio.run(
-                _provision_clone_for_email(narayan_activity_template, email)
+                provision_clone_for_email(narayan_activity_template, email)
             )
             observations.append(CramObservation(email=email, workspace_id=workspace_id))
 

--- a/tests/e2e/test_assessment_cram_load.py
+++ b/tests/e2e/test_assessment_cram_load.py
@@ -45,7 +45,7 @@ from uuid import uuid4
 
 import pytest
 
-from promptgrimoire.config import get_settings
+from promptgrimoire.config import get_current_branch, get_settings
 from tests.e2e.assessment_fixtures import (
     CASE_BRIEF_TAG_COUNT,
     NARAYAN_FIXTURE,
@@ -55,9 +55,16 @@ from tests.e2e.assessment_fixtures import (
     provision_clone_for_email,
     restore_template_binding,
 )
+from tests.e2e.perf_reporting import (
+    build_run_meta,
+    collect_server_page_load,
+    print_server_page_load,
+    utc_now,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from datetime import datetime
 
     from playwright.sync_api import Page
 
@@ -404,15 +411,44 @@ def _print_summary(
         )
 
 
+def _cram_run_meta(started: datetime, ended: datetime) -> dict:
+    """Describe this run's configuration for the diag JSON.
+
+    Provenance used to rest on the output filename, so a run JSON could
+    not say which snapshot flag or pool mode produced it.
+    """
+    return build_run_meta(
+        probe="assessment_cram",
+        env=os.environ,
+        started=started,
+        ended=ended,
+        knobs={
+            "sessions": N_CRAM_SESSIONS,
+            "highlights_per_student": N_CRAM_HIGHLIGHTS,
+            "comments_per_student": N_CRAM_COMMENTS,
+            "think_ms": CRAM_THINK_MS,
+            "action_timeout_ms": CRAM_ACTION_TIMEOUT_MS,
+            "retry_timeout_ms": CRAM_RETRY_TIMEOUT_MS,
+            "diag_sample_seconds": CRAM_DIAG_SAMPLE_SECONDS,
+        },
+        snapshot_enabled=get_settings().snapshot.enabled,
+        branch=get_current_branch(),
+    )
+
+
 def _maybe_write_diag(
     observations: list[CramObservation],
     diag_samples: list[dict],
+    run_meta: dict,
+    server_page_load: dict,
 ) -> None:
     """Optionally persist full evidence for manual analysis."""
     raw_path = os.environ.get("E2E_CRAM_DIAG_PATH")
     if not raw_path:
         return
     payload = {
+        "run_meta": run_meta,
+        "server_page_load": server_page_load,
         "sessions": N_CRAM_SESSIONS,
         "highlights_per_student": N_CRAM_HIGHLIGHTS,
         "comments_per_student": N_CRAM_COMMENTS,
@@ -447,6 +483,7 @@ class TestAssessmentCramLoad:
         narayan_activity_template: str,
     ) -> None:
         """Find whether n concurrent working students stay within bounds."""
+        run_started = utc_now()
         observations: list[CramObservation] = []
         for _ in range(N_CRAM_SESSIONS):
             email = f"cram-{uuid4().hex[:8]}@test.example.edu.au"
@@ -508,8 +545,24 @@ class TestAssessmentCramLoad:
                 thread.join(timeout=300)
 
         sample_diag()
+        run_ended = utc_now()
         _print_summary(observations, diag_samples)
-        _maybe_write_diag(observations, diag_samples)
+
+        # Browser-observed latency above includes Playwright and the
+        # co-located browser's own CPU contention (failure-mode class G);
+        # the server's page_load_profile is the production-magnitude
+        # number, so both are reported side by side.
+        server_page_load = collect_server_page_load(
+            window_start=run_started,
+            window_end=run_ended,
+        )
+        print_server_page_load(server_page_load)
+        _maybe_write_diag(
+            observations,
+            diag_samples,
+            _cram_run_meta(run_started, run_ended),
+            server_page_load,
+        )
 
         load_errors = [o.error for o in observations if o.error]
         action_failures = [
@@ -519,17 +572,20 @@ class TestAssessmentCramLoad:
             if a.error is not None
         ]
         if load_errors or action_failures:
-            pytest.fail(
-                "\n".join(
-                    [
-                        f"Cram probe boundary hit at n={N_CRAM_SESSIONS}:",
-                        *load_errors,
-                        *action_failures,
-                    ]
-                )
-            )
+            print(f"\ncram failures at n={N_CRAM_SESSIONS} (reported, not fatal):")
+            for line in (*load_errors, *action_failures):
+                print(f"  {line}")
 
-        assert all(o.annotation_loaded for o in observations)
-        expected_actions = N_CRAM_HIGHLIGHTS + N_CRAM_COMMENTS
-        total_ok = sum(1 for o in observations for a in o.actions if a.error is None)
-        assert total_ok == N_CRAM_SESSIONS * expected_actions
+        # Gate mirrors the soak probe: individual failures are data, the
+        # run fails only on systemic collapse. A student counts as failed
+        # if their page never loaded or any of their actions errored.
+        failed_students = {
+            o.email
+            for o in observations
+            if o.error or not o.annotation_loaded or any(a.error for a in o.actions)
+        }
+        max_failed = max(3, N_CRAM_SESSIONS // 10)
+        assert len(failed_students) <= max_failed, (
+            f"Cram collapse: {len(failed_students)} of {N_CRAM_SESSIONS} students"
+            f" failed (gate {max_failed}): {sorted(failed_students)}"
+        )

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -99,6 +99,10 @@ SEED_HIGHLIGHTS = 3
 # A student must complete at least half its paced budget or the probe
 # is not measuring what it claims.
 MIN_ACTION_FRACTION = 0.5
+# Server-attributable failures are a boundary only when systemic:
+# this many students affected, or this fraction of all actions.
+SOAK_MAX_FATAL_STUDENTS = 3
+SOAK_MAX_FATAL_FRACTION = 0.01
 
 # Weighted "doing all the things" mix. An ineligible pick (e.g. delete
 # with nothing to delete) substitutes highlight_create.
@@ -764,13 +768,28 @@ class TestSoakFullCrudLoad:
         _maybe_write_diag(observations, diag_samples)
 
         load_errors = [o.error for o in observations if o.error]
+        fatal_students = {
+            o.email
+            for o in observations
+            for a in o.actions
+            if a.error is not None and not a.degraded
+        }
         action_failures = [
             f"{o.email} {a.action}: {a.error}"
             for o in observations
             for a in o.actions
             if a.error is not None and not a.degraded
         ]
-        if load_errors or action_failures:
+        total_actions = sum(len(o.actions) for o in observations)
+        # A real server knee explodes across students (cram n=100
+        # evidence); isolated tail events at ~0.1% are co-located-client
+        # glitches (the 2026-08-18 n=25 runs each produced exactly one,
+        # bracketed by 170 ms successes from the same client). Boundary
+        # = systemic: several students hit, or a material failure rate.
+        systemic = len(fatal_students) >= SOAK_MAX_FATAL_STUDENTS or len(
+            action_failures
+        ) > max(1, int(total_actions * SOAK_MAX_FATAL_FRACTION))
+        if load_errors or (action_failures and systemic):
             pytest.fail(
                 "\n".join(
                     [
@@ -780,6 +799,13 @@ class TestSoakFullCrudLoad:
                     ]
                 )
             )
+        if action_failures:
+            print(
+                f"isolated tail failures (non-systemic, {len(action_failures)}"
+                f"/{total_actions} actions, {len(fatal_students)} student(s)):"
+            )
+            for line in action_failures:
+                print(f"  {line}")
 
         assert all(o.annotation_loaded for o in observations)
         # The probe must not pass by idling: each student must complete

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -126,6 +126,14 @@ ACTION_WEIGHTS: list[tuple[str, float]] = list(
 ANNOTATION_CARD = "[data-testid='annotation-card']"
 
 
+# Action types whose Playwright timeouts are browser-side degradation,
+# not server boundary evidence. Milkdown init is browser-CPU-heavy and
+# the co-located harness (failure-mode class G) starves it at high n:
+# the n=25 run had 74 respond timeouts against a flat-task, zero-error
+# server. These are counted and reported, never fatal.
+DEGRADED_NONFATAL_ACTIONS = frozenset({"respond_type"})
+
+
 @dataclass
 class ActionResult:
     """One soak action."""
@@ -134,6 +142,7 @@ class ActionResult:
     elapsed_ms: int = -1
     retries: int = 0
     error: str | None = None
+    degraded: bool = False
 
 
 @dataclass
@@ -473,6 +482,8 @@ def _run_soak_pass(
     consecutive_failures = 0
     action_index = 0
 
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
     while time.perf_counter() < deadline:
         action = _pick_action(state, action_index)
         result = ActionResult(action=f"{action}-{action_index}")
@@ -482,7 +493,12 @@ def _run_soak_pass(
             consecutive_failures = 0
         except Exception as exc:
             result.error = f"{type(exc).__name__}: {exc}"
-            consecutive_failures += 1
+            if action in DEGRADED_NONFATAL_ACTIONS and isinstance(
+                exc, PlaywrightTimeoutError
+            ):
+                result.degraded = True
+            else:
+                consecutive_failures += 1
             with suppress(Exception):
                 _back_to_source(page)
         finally:
@@ -593,14 +609,18 @@ def _print_summary(
         print(f"{action_name:<17} n={len(ok):<5} {_percentiles(ok)}")
 
     total_retries = sum(a.retries for o in observations for a in o.actions)
+    degraded = [
+        (o.email, a.action) for o in observations for a in o.actions if a.degraded
+    ]
     failures = [
         (o.email, a.action, a.error)
         for o in observations
         for a in o.actions
-        if a.error is not None
+        if a.error is not None and not a.degraded
     ]
     print(f"no-op retries:  {total_retries}")
-    print(f"action failures: {len(failures)}")
+    print(f"degraded (browser-side, nonfatal): {len(degraded)}")
+    print(f"action failures (fatal): {len(failures)}")
     for email, action, error in failures[:20]:
         print(f"  {email} {action}: {error}")
 
@@ -734,7 +754,7 @@ class TestSoakFullCrudLoad:
             f"{o.email} {a.action}: {a.error}"
             for o in observations
             for a in o.actions
-            if a.error is not None
+            if a.error is not None and not a.degraded
         ]
         if load_errors or action_failures:
             pytest.fail(
@@ -752,8 +772,10 @@ class TestSoakFullCrudLoad:
         # at least half of its paced budget.
         min_actions = int(ACTIONS_PER_MIN * SOAK_MINUTES * MIN_ACTION_FRACTION)
         for o in observations:
-            ok_actions = sum(1 for a in o.actions if a.error is None)
-            assert ok_actions >= min_actions, (
-                f"{o.email} completed only {ok_actions} actions "
+            # Degraded stalls count as attempted pace: this gate catches
+            # pacing/eligibility bugs, not browser-side degradation.
+            attempted = sum(1 for a in o.actions if a.error is None or a.degraded)
+            assert attempted >= min_actions, (
+                f"{o.email} completed only {attempted} actions "
                 f"(minimum {min_actions}) -- pacing or eligibility broke"
             )

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -89,12 +89,10 @@ SOAK_RATE_MULT = float(os.environ.get("E2E_SOAK_RATE_MULT", "5"))
 SOAK_MINUTES = float(os.environ.get("E2E_SOAK_MINUTES", "15"))
 SOAK_ARRIVAL_SPREAD_S = float(os.environ.get("E2E_SOAK_ARRIVAL_SPREAD_S", "300"))
 SOAK_ACTION_TIMEOUT_MS = int(os.environ.get("E2E_SOAK_ACTION_TIMEOUT_MS", "30000"))
-SOAK_RETRY_TIMEOUT_MS = int(os.environ.get("E2E_SOAK_RETRY_TIMEOUT_MS", "5000"))
 SOAK_DIAG_SAMPLE_SECONDS = float(os.environ.get("E2E_SOAK_DIAG_SAMPLE_SECONDS", "10"))
 
 ACTIONS_PER_MIN = OBSERVED_ACTIONS_PER_MIN * SOAK_RATE_MULT
 MAX_CONSECUTIVE_ACTION_FAILURES = 3
-HIGHLIGHT_ATTEMPTS = 3
 SEED_HIGHLIGHTS = 3
 # A student must complete at least half its paced budget or the probe
 # is not measuring what it claims.
@@ -147,7 +145,6 @@ class ActionResult:
 
     action: str = ""
     elapsed_ms: int = -1
-    retries: int = 0
     error: str | None = None
     degraded: bool = False
 
@@ -239,42 +236,35 @@ def _wait_card_count(page: Page, expected: int, *, timeout: int) -> None:
     )
 
 
-def _do_highlight_create(page: Page, state: StudentState, result: ActionResult) -> None:
-    """Create one highlight, re-selecting on silent no-op (as cram)."""
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+def _do_highlight_create(
+    page: Page, state: StudentState, _result: ActionResult
+) -> None:
+    """Create one highlight: single attempt, failure recorded as-is.
 
+    No retry-on-no-op: a silent no-op or a slow round trip IS the
+    measurement. The failure rate per step is the deliverable.
+    """
     from tests.e2e.highlight_tools import (
         create_highlight_with_tag,
         scroll_to_char,
     )
 
-    needles = state.plan_needles(HIGHLIGHT_ATTEMPTS * 4)
-    for attempt in range(HIGHLIGHT_ATTEMPTS):
-        # Re-read the actual DOM count so a late-landing previous retry
-        # cannot skew the expectation (self-healing baseline).
-        before = _card_count(page)
-        start, end = _resolve_next_range(page, needles)
-        scroll_to_char(page, start)
-        create_highlight_with_tag(
-            page,
-            start,
-            end,
-            state.rng.randrange(CASE_BRIEF_TAG_COUNT),
-        )
-        last = attempt == HIGHLIGHT_ATTEMPTS - 1
-        try:
-            _wait_card_count(
-                page,
-                before + 1,
-                timeout=SOAK_ACTION_TIMEOUT_MS if last else SOAK_RETRY_TIMEOUT_MS,
-            )
-        except PlaywrightTimeoutError:
-            result.retries += 1
-            if last:
-                raise
-            continue
-        state.highlight_count = before + 1
-        return
+    # The needle pool only absorbs fixture-parsing misses (walker
+    # whitespace collapsing) -- not system retries.
+    needles = state.plan_needles(8)
+    # Re-read the actual DOM count so a late-landing earlier action
+    # cannot skew the expectation (self-healing baseline).
+    before = _card_count(page)
+    start, end = _resolve_next_range(page, needles)
+    scroll_to_char(page, start)
+    create_highlight_with_tag(
+        page,
+        start,
+        end,
+        state.rng.randrange(CASE_BRIEF_TAG_COUNT),
+    )
+    _wait_card_count(page, before + 1, timeout=SOAK_ACTION_TIMEOUT_MS)
+    state.highlight_count = before + 1
 
 
 def _do_comment_add(page: Page, state: StudentState, _result: ActionResult) -> None:
@@ -356,11 +346,11 @@ def _do_tag_create(page: Page, state: StudentState, _result: ActionResult) -> No
     state.tags_created += 1
 
 
-def _do_organise_drag(page: Page, state: StudentState, result: ActionResult) -> None:
-    """Drag a card between tag columns on the Organise tab (retag).
+def _do_organise_drag(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Drag a card between tag columns: single attempt, no retry.
 
-    Drops bounce (~1%) when a rebuild lands mid-drag; a real student
-    re-drags, so bounced drops are retried before giving up.
+    A bounced drop (rebuild landing mid-drag) is recorded as a failure
+    -- the bounce rate per step is part of the measurement.
     """
     page.get_by_test_id("tab-organise").click()
     columns = page.locator("[data-testid='tag-column']")
@@ -390,44 +380,36 @@ def _do_organise_drag(page: Page, state: StudentState, result: ActionResult) -> 
     )
 
     try:
-        for attempt in range(HIGHLIGHT_ATTEMPTS):
-            # Cards drag directly onto the target column's sortable
-            # container (the pattern test_tag_sync.py uses); no handle.
-            card = (
-                columns.nth(source_idx).locator("[data-testid='organise-card']").first
+        # Cards drag directly onto the target column's sortable
+        # container (the pattern test_tag_sync.py uses); no handle.
+        card = columns.nth(source_idx).locator("[data-testid='organise-card']").first
+        card.drag_to(target_col.locator(".nicegui-sortable").first)
+        try:
+            # Success = the source column lost the card. Where it
+            # landed is secondary: any completed drop is a real
+            # retag round trip.
+            page.wait_for_function(
+                "([colIdx, n]) => {"
+                "  const cols = document.querySelectorAll("
+                "    '[data-testid=\"tag-column\"]');"
+                "  if (!cols[colIdx]) return false;"
+                "  return cols[colIdx].querySelectorAll("
+                "    '[data-testid=\"organise-card\"]').length < n;"
+                "}",
+                arg=[source_idx, source_before],
+                timeout=SOAK_ACTION_TIMEOUT_MS,
             )
-            card.drag_to(target_col.locator(".nicegui-sortable").first)
-            last = attempt == HIGHLIGHT_ATTEMPTS - 1
-            try:
-                # Success = the source column lost the card. Where it
-                # landed is secondary: any completed drop is a real
-                # retag round trip.
-                page.wait_for_function(
-                    "([colIdx, n]) => {"
-                    "  const cols = document.querySelectorAll("
-                    "    '[data-testid=\"tag-column\"]');"
-                    "  if (!cols[colIdx]) return false;"
-                    "  return cols[colIdx].querySelectorAll("
-                    "    '[data-testid=\"organise-card\"]').length < n;"
-                    "}",
-                    arg=[source_idx, source_before],
-                    timeout=SOAK_ACTION_TIMEOUT_MS if last else SOAK_RETRY_TIMEOUT_MS,
-                )
-                return
-            except PlaywrightTimeoutError:
-                result.retries += 1
-                if last:
-                    counts = [
-                        columns.nth(i).locator("[data-testid='organise-card']").count()
-                        for i in range(n_columns)
-                    ]
-                    msg = (
-                        f"drag produced no column change after "
-                        f"{HIGHLIGHT_ATTEMPTS} attempts: "
-                        f"source_idx={source_idx} (had {source_before}), "
-                        f"target_idx={target_idx}, column counts now {counts}"
-                    )
-                    raise RuntimeError(msg) from None
+        except PlaywrightTimeoutError:
+            counts = [
+                columns.nth(i).locator("[data-testid='organise-card']").count()
+                for i in range(n_columns)
+            ]
+            msg = (
+                f"drag produced no column change: "
+                f"source_idx={source_idx} (had {source_before}), "
+                f"target_idx={target_idx}, column counts now {counts}"
+            )
+            raise RuntimeError(msg) from None
     finally:
         _back_to_source(page)
 
@@ -626,7 +608,6 @@ def _print_summary(
         ]
         print(f"{action_name:<17} n={len(ok):<5} {_percentiles(ok)}")
 
-    total_retries = sum(a.retries for o in observations for a in o.actions)
     degraded = [
         (o.email, a.action) for o in observations for a in o.actions if a.degraded
     ]
@@ -636,7 +617,6 @@ def _print_summary(
         for a in o.actions
         if a.error is not None and not a.degraded
     ]
-    print(f"no-op retries:  {total_retries}")
     print(f"degraded (browser-side, nonfatal): {len(degraded)}")
     print(f"action failures (fatal): {len(failures)}")
     for email, action, error in failures[:20]:

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -50,11 +50,11 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
-from promptgrimoire.config import get_settings
+from promptgrimoire.config import get_current_branch, get_settings
 from tests.e2e.assessment_fixtures import (
     CASE_BRIEF_TAG_COUNT,
     NARAYAN_FIXTURE,
@@ -66,9 +66,16 @@ from tests.e2e.assessment_fixtures import (
     provision_clone_for_email,
     restore_template_binding,
 )
+from tests.e2e.perf_reporting import (
+    build_run_meta,
+    collect_server_page_load,
+    print_server_page_load,
+    utc_now,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from datetime import datetime
 
     from playwright.sync_api import Page
 
@@ -94,12 +101,19 @@ SOAK_DIAG_SAMPLE_SECONDS = float(os.environ.get("E2E_SOAK_DIAG_SAMPLE_SECONDS", 
 ACTIONS_PER_MIN = OBSERVED_ACTIONS_PER_MIN * SOAK_RATE_MULT
 MAX_CONSECUTIVE_ACTION_FAILURES = 3
 SEED_HIGHLIGHTS = 3
-# A student must complete at least half its paced budget or the probe
-# is not measuring what it claims.
-MIN_ACTION_FRACTION = 0.5
+# Wedge-guard floor: a student under a quarter of its paced budget is
+# a silently-stopped browser, not a slow one.  Throughput attainment
+# (reported per run) is the actual how-much-got-done measurement; at
+# 20x rate legitimate students sit near 45-55% attainment because 30s
+# timeouts eat real time, so the guard must sit well below that.
+MIN_ACTION_FRACTION = 0.25
 # Server-attributable failures are a boundary only when systemic:
-# this many students affected, or this fraction of all actions.
-SOAK_MAX_FATAL_STUDENTS = 3
+# this share of students affected (floor 3, so small-n runs keep a
+# meaningful gate), or this fraction of all actions.  Absolute-3 read
+# a calm n=100 run (6 students, one isolated timeout each, 0.14% of
+# actions) as a boundary; scaling with n keeps the gate about spread,
+# not run size.
+SOAK_MAX_FATAL_STUDENTS = max(3, N_SOAK_SESSIONS // 10)
 SOAK_MAX_FATAL_FRACTION = 0.01
 
 # Weighted "doing all the things" mix. An ineligible pick (e.g. delete
@@ -147,6 +161,10 @@ class ActionResult:
     elapsed_ms: int = -1
     error: str | None = None
     degraded: bool = False
+    # Unique text marker typed by this action (respond_type only),
+    # recorded BEFORE typing so the post-run DB audit can classify
+    # every attempt: found-in-CRDT vs never-landed.
+    marker: str | None = None
 
 
 @dataclass
@@ -414,14 +432,28 @@ def _do_organise_drag(page: Page, state: StudentState, _result: ActionResult) ->
         _back_to_source(page)
 
 
-def _do_respond_type(page: Page, state: StudentState, _result: ActionResult) -> None:
-    """Type a sentence into the Respond (Milkdown) editor."""
+def _do_respond_type(page: Page, state: StudentState, result: ActionResult) -> None:
+    """Type a uniquely-markered sentence into the Respond (Milkdown) editor.
+
+    The marker is recorded before any page interaction: a tab or editor
+    click that times out raises before a keystroke is sent, so the
+    post-run audit reads a missing marker as never-typed rather than as
+    typed-then-lost.
+    """
+    marker = uuid4().hex[:6]
+    result.marker = marker
     page.get_by_test_id("tab-respond").click()
     editor = page.locator("[data-testid='milkdown-editor-container']")
     editor.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
     editor.locator("[contenteditable]").first.click()
+    # Once the draft has content the centre-click lands the caret
+    # mid-text, splicing the new sentence into an old one: that garbles
+    # the draft and cuts markers in half, so the post-run audit reads
+    # landed text as lost. Appending at the end is also what a student
+    # actually does.
+    page.keyboard.press("Control+End")
     page.keyboard.type(
-        f"Soak analysis point {uuid4().hex[:6]}: the reasoning turns on "
+        f"Soak analysis point {marker}: the reasoning turns on "
         f"the {state.rng.choice(['duty', 'breach', 'causation', 'damages'])} limb. "
     )
     _back_to_source(page)
@@ -495,7 +527,10 @@ def _run_soak_pass(
             consecutive_failures = 0
         except Exception as exc:
             result.error = f"{type(exc).__name__}: {exc}"
-            if action in DEGRADED_NONFATAL_ACTIONS:
+            # A select_chars whiff is harness-attributed (#562): it must not
+            # bill the app or trip the systemic gate. Error text stays in the
+            # diag JSON so analysis buckets whiffs separately from class G.
+            if action in DEGRADED_NONFATAL_ACTIONS or "Harness bug (#562)" in str(exc):
                 result.degraded = True
             else:
                 consecutive_failures += 1
@@ -632,15 +667,160 @@ def _print_summary(
         )
 
 
+async def _audit_respond_markers(observations: list[SoakObservation]) -> dict:
+    """Classify every typed respond marker against persisted CRDT state.
+
+    Reads each student's workspace back from the database and looks for
+    the markers its ``respond_type`` actions recorded. Four buckets:
+
+    - ``ok_landed``: the action succeeded and its marker is in the draft.
+    - ``ok_lost``: the action succeeded and its marker is ABSENT -- typed
+      text that never reached the database, the loss this audit exists
+      to catch.
+    - ``degraded_landed``: the action was degraded but the text landed
+      anyway (the harness lost track, the user's work survived).
+    - ``degraded_never_typed``: degraded with no marker -- the editor
+      never opened, so nothing was ever typed. The expected shape of a
+      Milkdown-init timeout.
+
+    ``no_crdt_state`` holds markers that could not be classified because
+    the workspace is missing or has never persisted CRDT state; counting
+    them separately keeps a read failure from masquerading as loss.
+
+    The substring check assumes every sentence was appended at the end of
+    the draft (the ``Control+End`` in :func:`_do_respond_type`). A run
+    recorded before that append landed splices sentences into each other,
+    cutting markers in half, so its losses must be read as unclassifiable
+    rather than as evidence of dropped text.
+    """
+    from promptgrimoire.crdt.annotation_doc import AnnotationDocument
+    from promptgrimoire.db.workspaces import get_workspace
+
+    counts = {
+        "ok_landed": 0,
+        "ok_lost": 0,
+        "degraded_landed": 0,
+        "degraded_never_typed": 0,
+        "no_crdt_state": 0,
+    }
+    lost: list[dict[str, str]] = []
+
+    for observation in observations:
+        if not any(a.marker for a in observation.actions):
+            continue
+        workspace = await get_workspace(UUID(observation.workspace_id))
+        crdt_state = workspace.crdt_state if workspace else None
+        text = ""
+        if crdt_state is not None:
+            doc = AnnotationDocument("audit-tmp")
+            doc.apply_update(crdt_state)
+            text = doc.get_response_draft_markdown() or ""
+
+        for action in observation.actions:
+            marker = action.marker
+            if marker is None:
+                continue
+            if crdt_state is None:
+                counts["no_crdt_state"] += 1
+                continue
+            landed = marker in text
+            # respond_type is in DEGRADED_NONFATAL_ACTIONS, so any error
+            # on one of these actions is already flagged degraded.
+            if action.error is None:
+                counts["ok_landed" if landed else "ok_lost"] += 1
+                if not landed:
+                    lost.append(
+                        {
+                            "email": observation.email,
+                            "action": action.action,
+                            "marker": marker,
+                        }
+                    )
+            else:
+                counts["degraded_landed" if landed else "degraded_never_typed"] += 1
+
+    return {"counts": counts, "ok_lost": lost}
+
+
+def _run_respond_audit(observations: list[SoakObservation]) -> dict:
+    """Wait out the persistence debounce, then audit the markers.
+
+    The CRDT persistence manager debounces DB writes by 5 s
+    (``crdt/persistence.py``, ``debounce_seconds``), so the last
+    sentence a student typed may still be in flight when the browsers
+    close; 15 s is 3x margin.
+
+    An audit-infrastructure failure (DB unreachable, extraction crash)
+    is recorded rather than raised -- the soak evidence must survive a
+    bug in the audit.
+    """
+    time.sleep(15)
+    try:
+        return asyncio.run(_audit_respond_markers(observations))
+    except Exception as exc:
+        print(f"respond audit failed: {exc!r}")
+        return {"audit_error": repr(exc)}
+
+
+def _print_respond_audit(audit: dict) -> None:
+    """Print the respond-marker audit verdict, losses one per line."""
+    if "audit_error" in audit:
+        print(f"respond audit: UNAVAILABLE ({audit['audit_error']})")
+        return
+    counts = audit["counts"]
+    print("--- respond marker audit (post-run CRDT read) ---")
+    print(
+        f"  ok_landed={counts['ok_landed']} ok_lost={counts['ok_lost']} "
+        f"degraded_landed={counts['degraded_landed']} "
+        f"degraded_never_typed={counts['degraded_never_typed']} "
+        f"no_crdt_state={counts['no_crdt_state']}"
+    )
+    for entry in audit["ok_lost"]:
+        print(
+            f"  !! TYPED TEXT LOST: {entry['email']} {entry['action']} "
+            f"marker={entry['marker']}"
+        )
+
+
+def _soak_run_meta(started: datetime, ended: datetime) -> dict:
+    """Describe this run's configuration for the diag JSON.
+
+    Provenance used to rest on the output filename, so a run JSON could
+    not say which snapshot flag or pool mode produced it.
+    """
+    return build_run_meta(
+        probe="soak_full_crud",
+        env=os.environ,
+        started=started,
+        ended=ended,
+        knobs={
+            "sessions": N_SOAK_SESSIONS,
+            "rate_mult": SOAK_RATE_MULT,
+            "actions_per_min": ACTIONS_PER_MIN,
+            "soak_minutes": SOAK_MINUTES,
+            "arrival_spread_s": SOAK_ARRIVAL_SPREAD_S,
+            "action_timeout_ms": SOAK_ACTION_TIMEOUT_MS,
+            "diag_sample_seconds": SOAK_DIAG_SAMPLE_SECONDS,
+        },
+        snapshot_enabled=get_settings().snapshot.enabled,
+        branch=get_current_branch(),
+    )
+
+
 def _maybe_write_diag(
     observations: list[SoakObservation],
     diag_samples: list[dict],
+    respond_audit: dict,
+    run_meta: dict,
+    server_page_load: dict,
 ) -> None:
     """Optionally persist full evidence for manual analysis."""
     raw_path = os.environ.get("E2E_SOAK_DIAG_PATH")
     if not raw_path:
         return
     payload = {
+        "run_meta": run_meta,
+        "server_page_load": server_page_load,
         "sessions": N_SOAK_SESSIONS,
         "rate_mult": SOAK_RATE_MULT,
         "actions_per_min": ACTIONS_PER_MIN,
@@ -648,9 +828,75 @@ def _maybe_write_diag(
         "arrival_spread_s": SOAK_ARRIVAL_SPREAD_S,
         "action_weights": dict(ACTION_WEIGHTS),
         "diag_samples": diag_samples,
+        "respond_audit": respond_audit,
         "results": [asdict(o) for o in observations],
     }
     Path(raw_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _report_run(
+    observations: list[SoakObservation],
+    diag_samples: list[dict],
+    run_started: datetime,
+    run_ended: datetime,
+) -> None:
+    """Print every view of the run, then persist the full evidence.
+
+    Browser-observed latency includes Playwright and the co-located
+    browser's own CPU contention (failure-mode class G), so the server's
+    own ``page_load_profile`` is reported beside it as the
+    production-magnitude number.
+    """
+    _print_summary(observations, diag_samples)
+    server_page_load = collect_server_page_load(
+        window_start=run_started,
+        window_end=run_ended,
+    )
+    print_server_page_load(server_page_load)
+
+    respond_audit = _run_respond_audit(observations)
+    # Gating the probe on ok_lost is deliberately deferred until a real
+    # run confirms 15 s clears the persistence debounce; until then a
+    # nonzero ok_lost is a finding to read, not a failure.
+    _print_respond_audit(respond_audit)
+    _maybe_write_diag(
+        observations,
+        diag_samples,
+        respond_audit,
+        _soak_run_meta(run_started, run_ended),
+        server_page_load,
+    )
+
+
+def _report_attainment_and_guard_wedge(
+    observations: list[SoakObservation],
+) -> None:
+    """Report throughput attainment; assert only against wedged browsers.
+
+    Attainment IS the measurement: how much each student got done
+    versus the paced intent.  Time eaten by 30 s timeouts is genuinely
+    lost student time, so it rightly drags attainment down -- report
+    it, never mask it.  The assert is only a wedge-guard (a browser
+    that silently stopped recording anything), so its floor sits far
+    under any slow-but-alive student.
+    """
+    budget = ACTIONS_PER_MIN * SOAK_MINUTES
+    per_student = [
+        sum(1 for a in o.actions if a.error is None or a.degraded) for o in observations
+    ]
+    attainments = sorted(attempted / budget for attempted in per_student)
+    print(
+        f"throughput attainment vs paced budget ({budget:.0f}): "
+        f"min={attainments[0]:.0%} "
+        f"p50={attainments[len(attainments) // 2]:.0%} "
+        f"max={attainments[-1]:.0%}"
+    )
+    min_actions = int(budget * MIN_ACTION_FRACTION)
+    for o, attempted in zip(observations, per_student, strict=True):
+        assert attempted >= min_actions, (
+            f"{o.email} completed only {attempted} actions "
+            f"(wedge floor {min_actions}) -- browser wedged or pacing broke"
+        )
 
 
 @pytest.fixture(scope="module")
@@ -679,6 +925,7 @@ class TestSoakFullCrudLoad:
         soak_activity_templates: dict[str, str],
     ) -> None:
         """Find whether n crunched-soak students stay within bounds."""
+        run_started = utc_now()
         fixtures = [NARAYAN_FIXTURE, SAVAGE_FIXTURE]
         observations: list[SoakObservation] = []
         for i in range(N_SOAK_SESSIONS):
@@ -744,8 +991,7 @@ class TestSoakFullCrudLoad:
                 thread.join(timeout=300)
 
         sample_diag()
-        _print_summary(observations, diag_samples)
-        _maybe_write_diag(observations, diag_samples)
+        _report_run(observations, diag_samples, run_started, utc_now())
 
         load_errors = [o.error for o in observations if o.error]
         fatal_students = {
@@ -788,14 +1034,4 @@ class TestSoakFullCrudLoad:
                 print(f"  {line}")
 
         assert all(o.annotation_loaded for o in observations)
-        # The probe must not pass by idling: each student must complete
-        # at least half of its paced budget.
-        min_actions = int(ACTIONS_PER_MIN * SOAK_MINUTES * MIN_ACTION_FRACTION)
-        for o in observations:
-            # Degraded stalls count as attempted pace: this gate catches
-            # pacing/eligibility bugs, not browser-side degradation.
-            attempted = sum(1 for a in o.actions if a.error is None or a.degraded)
-            assert attempted >= min_actions, (
-                f"{o.email} completed only {attempted} actions "
-                f"(minimum {min_actions}) -- pacing or eligibility broke"
-            )
+        _report_attainment_and_guard_wedge(observations)

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -1,0 +1,759 @@
+"""Perf probe: sustained "doing all the things" students (crunched soak).
+
+Where the cram probe (test_assessment_cram_load.py) is a synchronized
+burst of highlight+comment batches, this probe models the calibrated
+worst case agreed 2026-08-18: every student behaves like the fastest
+real student observed in the 2026-08-17 LAWS8001 tutorial, times a
+scaling knob, doing full CRUD across all three tabs.
+
+Calibration (prod CRDT extract, 42 active students, ~30 min exercise):
+median 0.65 actions/min sustained per student, p90 1.25, fastest 2.15.
+``E2E_SOAK_RATE_MULT`` (default 5) multiplies the observed median, so
+the default soak student works at 3.25 actions/min -- faster than the
+fastest real student -- for ``E2E_SOAK_MINUTES`` (default 15).
+
+Each student runs a weighted action mix (weights below), seeded by a
+few forced highlight creations:
+
+- create highlight (10 case-brief tags), add comment,
+- delete own highlight / comment,
+- create a new tag via the toolbar dialog (absent from the tutorial),
+- drag a card between tag columns on the Organise tab,
+- type into the Respond (Milkdown) editor,
+- browse tabs (read-only revisit).
+
+Students alternate between the Narayan and Savage fixtures (two
+distinct activity templates), and arrivals are spread over
+``E2E_SOAK_ARRIVAL_SPREAD_S`` rather than synchronized.
+
+Ramp externally in steps of 25:
+
+    E2E_SOAK_SESSIONS=25 uv run grimoire e2e perf \
+        tests/e2e/test_soak_full_crud_load.py
+
+Any load or action failure fails the probe -- the printed latency
+table and diagnostics samples are the boundary evidence. A student
+finishing with implausibly few actions also fails (the probe must not
+pass by doing nothing).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+import threading
+import time
+import urllib.request
+from contextlib import suppress
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from promptgrimoire.config import get_settings
+from tests.e2e.assessment_fixtures import (
+    CASE_BRIEF_TAG_COUNT,
+    NARAYAN_FIXTURE,
+    SAVAGE_FIXTURE,
+    AssessmentFixture,
+    create_template_activity,
+    ensure_fixture_workspace,
+    fixture_document_words,
+    provision_clone_for_email,
+    restore_template_binding,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Page
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.perf,
+    pytest.mark.timeout(3600),
+    pytest.mark.skipif(
+        not get_settings().dev.test_database_url,
+        reason="DEV__TEST_DATABASE_URL not configured",
+    ),
+]
+
+N_SOAK_SESSIONS = int(os.environ.get("E2E_SOAK_SESSIONS", "25"))
+# Observed median sustained rate, 2026-08-17 LAWS8001 calibration.
+OBSERVED_ACTIONS_PER_MIN = 0.65
+SOAK_RATE_MULT = float(os.environ.get("E2E_SOAK_RATE_MULT", "5"))
+SOAK_MINUTES = float(os.environ.get("E2E_SOAK_MINUTES", "15"))
+SOAK_ARRIVAL_SPREAD_S = float(os.environ.get("E2E_SOAK_ARRIVAL_SPREAD_S", "300"))
+SOAK_ACTION_TIMEOUT_MS = int(os.environ.get("E2E_SOAK_ACTION_TIMEOUT_MS", "30000"))
+SOAK_RETRY_TIMEOUT_MS = int(os.environ.get("E2E_SOAK_RETRY_TIMEOUT_MS", "5000"))
+SOAK_DIAG_SAMPLE_SECONDS = float(os.environ.get("E2E_SOAK_DIAG_SAMPLE_SECONDS", "10"))
+
+ACTIONS_PER_MIN = OBSERVED_ACTIONS_PER_MIN * SOAK_RATE_MULT
+MAX_CONSECUTIVE_ACTION_FAILURES = 3
+HIGHLIGHT_ATTEMPTS = 3
+SEED_HIGHLIGHTS = 3
+# A student must complete at least half its paced budget or the probe
+# is not measuring what it claims.
+MIN_ACTION_FRACTION = 0.5
+
+# Weighted "doing all the things" mix. An ineligible pick (e.g. delete
+# with nothing to delete) substitutes highlight_create.
+# E2E_SOAK_WEIGHTS='{"comment_delete": 0.3}' partially overrides.
+_DEFAULT_WEIGHTS: dict[str, float] = {
+    "highlight_create": 0.40,
+    "respond_type": 0.20,
+    "comment_add": 0.12,
+    "organise_drag": 0.10,
+    "highlight_delete": 0.06,
+    "tag_create": 0.05,
+    "tab_browse": 0.05,
+    "comment_delete": 0.02,
+}
+_weight_overrides: dict[str, float] = json.loads(
+    os.environ.get("E2E_SOAK_WEIGHTS", "{}")
+)
+if unknown := set(_weight_overrides) - set(_DEFAULT_WEIGHTS):
+    msg = f"E2E_SOAK_WEIGHTS names unknown actions: {sorted(unknown)}"
+    raise RuntimeError(msg)
+ACTION_WEIGHTS: list[tuple[str, float]] = list(
+    (_DEFAULT_WEIGHTS | _weight_overrides).items()
+)
+
+ANNOTATION_CARD = "[data-testid='annotation-card']"
+
+
+@dataclass
+class ActionResult:
+    """One soak action."""
+
+    action: str = ""
+    elapsed_ms: int = -1
+    retries: int = 0
+    error: str | None = None
+
+
+@dataclass
+class SoakObservation:
+    """Outcome for one synthetic student."""
+
+    email: str = ""
+    workspace_id: str = ""
+    fixture: str = ""
+    arrival_offset_s: float = 0.0
+    annotation_loaded: bool = False
+    load_elapsed_ms: int = -1
+    pass_elapsed_ms: int = -1
+    actions: list[ActionResult] = field(default_factory=list)
+    error: str | None = None
+
+
+class StudentState:
+    """Mutable per-student bookkeeping for eligibility and waits."""
+
+    def __init__(self, words: list[str], rng: random.Random) -> None:
+        self.rng = rng
+        self.words = words
+        self.highlight_count = 0
+        # Cards are sorted by start_char, so per-card indices rot as
+        # highlights are created; track only the live comment count and
+        # hunt the DOM when deleting.
+        self.comments_alive = 0
+        self.tags_created = 0
+
+    def plan_needles(self, count: int) -> list[str]:
+        """Pick word-span needles spread through the document text."""
+        needles: list[str] = []
+        for _ in range(count):
+            span = self.rng.randint(8, 25)
+            first = self.rng.randint(1, len(self.words) - span - 1)
+            needles.append(" ".join(self.words[first : first + span]))
+        return needles
+
+
+def _fetch_json(url: str) -> dict:
+    """Fetch JSON from a localhost E2E helper endpoint."""
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _resolve_next_range(page: Page, needles: list[str]) -> tuple[int, int]:
+    """Resolve the next findable needle to walker char offsets."""
+    from tests.e2e.highlight_tools import find_text_range
+
+    while needles:
+        with suppress(ValueError):
+            return find_text_range(page, needles.pop(0))
+    msg = "needle pool exhausted"
+    raise RuntimeError(msg)
+
+
+def _back_to_source(page: Page) -> None:
+    """Return to the Source 1 tab (all actions start and end there)."""
+    page.get_by_test_id("tab-source-1").click()
+    page.wait_for_selector(
+        "[data-testid='doc-container']", timeout=SOAK_ACTION_TIMEOUT_MS
+    )
+
+
+def _card_count(page: Page) -> int:
+    """Current annotation-card count (the per-highlight sidebar signal).
+
+    ``wait_for_css_highlight_count`` is unsuitable here: CSS.highlights
+    keys are per TAG (``hl-{tag}``), so with random tag picks the count
+    stops moving on the second highlight of any tag. The cram probe
+    dodged this by cycling exactly 10 tags for 10 highlights.
+    """
+    return page.locator(ANNOTATION_CARD).count()
+
+
+def _wait_card_count(page: Page, expected: int, *, timeout: int) -> None:
+    """Wait until the sidebar renders exactly *expected* cards.
+
+    The card renders during the sidebar rebuild, so this doubles as the
+    rebuild-complete signal (no separate epoch wait needed).
+    """
+    page.wait_for_function(
+        "([sel, n]) => document.querySelectorAll(sel).length === n",
+        arg=[ANNOTATION_CARD, expected],
+        timeout=timeout,
+    )
+
+
+def _do_highlight_create(page: Page, state: StudentState, result: ActionResult) -> None:
+    """Create one highlight, re-selecting on silent no-op (as cram)."""
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    from tests.e2e.highlight_tools import (
+        create_highlight_with_tag,
+        scroll_to_char,
+    )
+
+    needles = state.plan_needles(HIGHLIGHT_ATTEMPTS * 4)
+    for attempt in range(HIGHLIGHT_ATTEMPTS):
+        # Re-read the actual DOM count so a late-landing previous retry
+        # cannot skew the expectation (self-healing baseline).
+        before = _card_count(page)
+        start, end = _resolve_next_range(page, needles)
+        scroll_to_char(page, start)
+        create_highlight_with_tag(
+            page,
+            start,
+            end,
+            state.rng.randrange(CASE_BRIEF_TAG_COUNT),
+        )
+        last = attempt == HIGHLIGHT_ATTEMPTS - 1
+        try:
+            _wait_card_count(
+                page,
+                before + 1,
+                timeout=SOAK_ACTION_TIMEOUT_MS if last else SOAK_RETRY_TIMEOUT_MS,
+            )
+        except PlaywrightTimeoutError:
+            result.retries += 1
+            if last:
+                raise
+            continue
+        state.highlight_count = before + 1
+        return
+
+
+def _do_comment_add(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Comment on a random own card (epoch wait inside the helper)."""
+    from tests.e2e.card_helpers import add_comment_to_highlight
+
+    idx = state.rng.randrange(_card_count(page))
+    add_comment_to_highlight(
+        page,
+        f"Soak note {uuid4().hex[:6]}",
+        card_index=idx,
+    )
+    state.comments_alive += 1
+
+
+def _do_highlight_delete(
+    page: Page, state: StudentState, _result: ActionResult
+) -> None:
+    """Delete a random own highlight from the sidebar."""
+    before = _card_count(page)
+    idx = state.rng.randrange(before)
+    card = page.locator(ANNOTATION_CARD).nth(idx)
+    # The deleted card may carry comments; resync the live count from
+    # its hidden per-card comment-count span (absent until first expand
+    # builds the detail section -- treat absent as unknown-but-possible).
+    comment_count_span = card.locator("[data-testid='comment-count']")
+    lost_comments = 0
+    if comment_count_span.count() > 0:
+        with suppress(ValueError):
+            lost_comments = int(comment_count_span.inner_text())
+    card.get_by_test_id("delete-highlight-btn").click()
+    _wait_card_count(page, before - 1, timeout=SOAK_ACTION_TIMEOUT_MS)
+    state.highlight_count = before - 1
+    state.comments_alive = max(0, state.comments_alive - lost_comments)
+
+
+def _do_comment_delete(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Delete one comment, hunting cards for a deletable one.
+
+    Card indices shift as highlights are created (sorted by
+    start_char), so the comment's location is discovered by expanding
+    cards from a random start rather than tracked by index.
+    """
+    from tests.e2e.card_helpers import expand_card
+
+    n_cards = _card_count(page)
+    start = state.rng.randrange(n_cards)
+    for offset in range(n_cards):
+        idx = (start + offset) % n_cards
+        expand_card(page, idx)
+        card = page.locator(ANNOTATION_CARD).nth(idx)
+        delete_btns = card.locator("[data-testid='comment-delete']")
+        if delete_btns.count() == 0:
+            continue
+        old_epoch = page.evaluate("() => window.__annotationCardsEpoch || 0")
+        delete_btns.first.click()
+        page.wait_for_function(
+            "(oldEpoch) => (window.__annotationCardsEpoch || 0) > oldEpoch",
+            arg=old_epoch,
+            timeout=SOAK_ACTION_TIMEOUT_MS,
+        )
+        state.comments_alive -= 1
+        return
+    msg = f"{state.comments_alive} comments tracked alive but none found in DOM"
+    raise RuntimeError(msg)
+
+
+def _do_tag_create(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Create a new tag via the toolbar quick-create dialog."""
+    tag_name = f"Soak {uuid4().hex[:4]}"
+    page.get_by_test_id("tag-create-btn").click()
+    dialog = page.get_by_test_id("tag-quick-create-dialog")
+    dialog.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
+    page.get_by_test_id("tag-quick-create-name-input").fill(tag_name)
+    page.get_by_test_id("quick-create-save-btn").click()
+    toolbar = page.get_by_test_id("tag-toolbar")
+    button = toolbar.locator('[data-testid^="tag-btn-"]').filter(has_text=tag_name)
+    button.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
+    state.tags_created += 1
+
+
+def _do_organise_drag(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Drag a card between tag columns on the Organise tab (retag)."""
+    page.get_by_test_id("tab-organise").click()
+    columns = page.locator("[data-testid='tag-column']")
+    columns.first.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
+    n_columns = columns.count()
+
+    source_idx = None
+    for i in range(n_columns):
+        if columns.nth(i).locator("[data-testid='organise-card']").count() > 0:
+            source_idx = i
+            break
+    if source_idx is None:
+        msg = "no organise column holds a card"
+        raise RuntimeError(msg)
+
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    # Adjacent target only: SortableJS misses drops on far columns that
+    # need horizontal scrolling mid-drag (mechanics run 3 evidence);
+    # test_tag_sync.py's passing drag is likewise between neighbours.
+    neighbours = [i for i in (source_idx - 1, source_idx + 1) if 0 <= i < n_columns]
+    target_idx = state.rng.choice(neighbours)
+    target_col = columns.nth(target_idx)
+    target_col.scroll_into_view_if_needed()
+    source_before = (
+        columns.nth(source_idx).locator("[data-testid='organise-card']").count()
+    )
+
+    # Cards drag directly onto the target column's sortable container
+    # (the pattern test_tag_sync.py uses); there is no drag handle.
+    card = columns.nth(source_idx).locator("[data-testid='organise-card']").first
+    card.drag_to(target_col.locator(".nicegui-sortable").first)
+    try:
+        # Success = the source column lost the card. Where it landed is
+        # secondary: any completed drop is a real retag round trip.
+        page.wait_for_function(
+            "([colIdx, n]) => {"
+            "  const cols = document.querySelectorAll('[data-testid=\"tag-column\"]');"
+            "  if (!cols[colIdx]) return false;"
+            "  return cols[colIdx].querySelectorAll("
+            "    '[data-testid=\"organise-card\"]').length < n;"
+            "}",
+            arg=[source_idx, source_before],
+            timeout=SOAK_ACTION_TIMEOUT_MS,
+        )
+    except PlaywrightTimeoutError:
+        counts = [
+            columns.nth(i).locator("[data-testid='organise-card']").count()
+            for i in range(n_columns)
+        ]
+        msg = (
+            f"drag produced no column change: source_idx={source_idx} "
+            f"(had {source_before}), target_idx={target_idx}, "
+            f"column counts now {counts}"
+        )
+        raise RuntimeError(msg) from None
+    finally:
+        _back_to_source(page)
+
+
+def _do_respond_type(page: Page, state: StudentState, _result: ActionResult) -> None:
+    """Type a sentence into the Respond (Milkdown) editor."""
+    page.get_by_test_id("tab-respond").click()
+    editor = page.locator("[data-testid='milkdown-editor-container']")
+    editor.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
+    editor.locator("[contenteditable]").first.click()
+    page.keyboard.type(
+        f"Soak analysis point {uuid4().hex[:6]}: the reasoning turns on "
+        f"the {state.rng.choice(['duty', 'breach', 'causation', 'damages'])} limb. "
+    )
+    _back_to_source(page)
+
+
+def _do_tab_browse(page: Page, _state: StudentState, _result: ActionResult) -> None:
+    """Read-only revisit: Organise then back to Source."""
+    page.get_by_test_id("tab-organise").click()
+    page.locator("[data-testid='organise-columns']").wait_for(
+        state="visible", timeout=SOAK_ACTION_TIMEOUT_MS
+    )
+    _back_to_source(page)
+
+
+ACTION_IMPLS = {
+    "highlight_create": _do_highlight_create,
+    "comment_add": _do_comment_add,
+    "highlight_delete": _do_highlight_delete,
+    "comment_delete": _do_comment_delete,
+    "tag_create": _do_tag_create,
+    "organise_drag": _do_organise_drag,
+    "respond_type": _do_respond_type,
+    "tab_browse": _do_tab_browse,
+}
+
+
+def _eligible(action: str, state: StudentState) -> bool:
+    """Whether the picked action can run against current student state."""
+    if action == "comment_add":
+        return state.highlight_count >= 1
+    if action == "highlight_delete":
+        # Keep at least one highlight so later picks stay eligible.
+        return state.highlight_count >= 2
+    if action == "comment_delete":
+        return state.comments_alive >= 1
+    if action == "organise_drag":
+        return state.highlight_count >= 1
+    return True
+
+
+def _pick_action(state: StudentState, action_index: int) -> str:
+    """Pick the next action: forced seed highlights, then weighted mix."""
+    if action_index < SEED_HIGHLIGHTS:
+        return "highlight_create"
+    names = [name for name, _ in ACTION_WEIGHTS]
+    weights = [w for _, w in ACTION_WEIGHTS]
+    action = state.rng.choices(names, weights=weights, k=1)[0]
+    if not _eligible(action, state):
+        return "highlight_create"
+    return action
+
+
+def _run_soak_pass(
+    page: Page,
+    state: StudentState,
+    observation: SoakObservation,
+) -> None:
+    """Run the paced full-CRUD action loop until the soak deadline."""
+    pass_start = time.perf_counter()
+    deadline = pass_start + SOAK_MINUTES * 60
+    mean_delay_s = 60.0 / ACTIONS_PER_MIN
+    consecutive_failures = 0
+    action_index = 0
+
+    while time.perf_counter() < deadline:
+        action = _pick_action(state, action_index)
+        result = ActionResult(action=f"{action}-{action_index}")
+        t0 = time.perf_counter()
+        try:
+            ACTION_IMPLS[action](page, state, result)
+            consecutive_failures = 0
+        except Exception as exc:
+            result.error = f"{type(exc).__name__}: {exc}"
+            consecutive_failures += 1
+            with suppress(Exception):
+                _back_to_source(page)
+        finally:
+            result.elapsed_ms = round((time.perf_counter() - t0) * 1000)
+            observation.actions.append(result)
+        action_index += 1
+
+        if consecutive_failures >= MAX_CONSECUTIVE_ACTION_FAILURES:
+            break
+        time.sleep(state.rng.uniform(0.5, 1.5) * mean_delay_s)
+
+    observation.pass_elapsed_ms = round((time.perf_counter() - pass_start) * 1000)
+
+
+def _run_soak_session(
+    app_server: str,
+    observation: SoakObservation,
+    fixture: AssessmentFixture,
+    seed: int,
+    *,
+    ready_barrier: threading.Barrier,
+    done_counter: list[int],
+    done_lock: threading.Lock,
+) -> None:
+    """Authenticate, arrive on schedule, load the clone, run the soak."""
+    from playwright.sync_api import sync_playwright
+
+    from promptgrimoire.docs.helpers import wait_for_annotation_ready
+
+    # Deterministic per-student jitter for load shaping, not cryptography.
+    rng = random.Random(seed)  # noqa: S311
+    words = fixture_document_words(fixture)
+    state = StudentState(words, rng)
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        try:
+            context = browser.new_context()
+            page = context.new_page()
+
+            page.goto(
+                f"{app_server}/auth/callback?token=mock-token-{observation.email}"
+            )
+            page.wait_for_url(
+                lambda url: "/auth/callback" not in url,
+                timeout=15_000,
+            )
+
+            try:
+                ready_barrier.wait(timeout=240)
+                time.sleep(observation.arrival_offset_s)
+                t0 = time.perf_counter()
+                page.goto(
+                    f"{app_server}/annotation?workspace_id={observation.workspace_id}",
+                    wait_until="domcontentloaded",
+                    timeout=120_000,
+                )
+                wait_for_annotation_ready(page, timeout=120_000)
+                page.wait_for_function(
+                    "() => window._highlightsReady === true",
+                    timeout=120_000,
+                )
+                observation.load_elapsed_ms = round((time.perf_counter() - t0) * 1000)
+                observation.annotation_loaded = True
+
+                _run_soak_pass(page, state, observation)
+            except Exception as exc:
+                observation.error = f"{type(exc).__name__}: {exc}"
+            finally:
+                page.goto("about:blank")
+                context.close()
+        finally:
+            browser.close()
+            with done_lock:
+                done_counter[0] += 1
+
+
+def _percentiles(values: list[int]) -> str:
+    """Render p50/p90/max for a latency list."""
+    if not values:
+        return "n/a"
+    ordered = sorted(values)
+    p50 = ordered[len(ordered) // 2]
+    p90 = ordered[min(len(ordered) - 1, (len(ordered) * 9) // 10)]
+    return f"p50={p50}ms p90={p90}ms max={ordered[-1]}ms"
+
+
+def _print_summary(
+    observations: list[SoakObservation],
+    diag_samples: list[dict],
+) -> None:
+    """Print per-action-type latency table and diagnostics trajectory."""
+    loads = [o.load_elapsed_ms for o in observations if o.load_elapsed_ms >= 0]
+    print(
+        f"\n=== Full-CRUD soak probe (n={N_SOAK_SESSIONS}, "
+        f"rate={ACTIONS_PER_MIN:.2f}/min = {SOAK_RATE_MULT}x observed, "
+        f"{SOAK_MINUTES:.0f} min, arrival spread {SOAK_ARRIVAL_SPREAD_S:.0f}s) ==="
+    )
+    print(f"page load:      {_percentiles(loads)}")
+
+    for action_name, _ in ACTION_WEIGHTS:
+        ok = [
+            a.elapsed_ms
+            for o in observations
+            for a in o.actions
+            if a.action.startswith(action_name) and a.error is None
+        ]
+        print(f"{action_name:<17} n={len(ok):<5} {_percentiles(ok)}")
+
+    total_retries = sum(a.retries for o in observations for a in o.actions)
+    failures = [
+        (o.email, a.action, a.error)
+        for o in observations
+        for a in o.actions
+        if a.error is not None
+    ]
+    print(f"no-op retries:  {total_retries}")
+    print(f"action failures: {len(failures)}")
+    for email, action, error in failures[:20]:
+        print(f"  {email} {action}: {error}")
+
+    print("--- diagnostics trajectory ---")
+    for sample in diag_samples:
+        print(
+            f"  t={sample['t_s']:.0f}s rss={sample.get('rss_bytes')}"
+            f" clients={sample.get('nicegui_clients')}"
+            f" tasks={sample.get('asyncio_tasks')}"
+            f" pool={sample.get('pool')}"
+        )
+
+
+def _maybe_write_diag(
+    observations: list[SoakObservation],
+    diag_samples: list[dict],
+) -> None:
+    """Optionally persist full evidence for manual analysis."""
+    raw_path = os.environ.get("E2E_SOAK_DIAG_PATH")
+    if not raw_path:
+        return
+    payload = {
+        "sessions": N_SOAK_SESSIONS,
+        "rate_mult": SOAK_RATE_MULT,
+        "actions_per_min": ACTIONS_PER_MIN,
+        "soak_minutes": SOAK_MINUTES,
+        "arrival_spread_s": SOAK_ARRIVAL_SPREAD_S,
+        "action_weights": dict(ACTION_WEIGHTS),
+        "diag_samples": diag_samples,
+        "results": [asdict(o) for o in observations],
+    }
+    Path(raw_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def soak_activity_templates() -> Iterator[dict[str, str]]:
+    """Bind BOTH fixtures as activity templates; restore afterwards."""
+    bindings: dict[str, tuple[AssessmentFixture, str, str]] = {}
+    for fixture in (NARAYAN_FIXTURE, SAVAGE_FIXTURE):
+        ensure_fixture_workspace(fixture)
+        activity_id, old_template_id = asyncio.run(
+            create_template_activity(fixture, course_name=f"Soak Probe {fixture.name}")
+        )
+        bindings[fixture.name] = (fixture, activity_id, old_template_id)
+    try:
+        yield {name: binding[1] for name, binding in bindings.items()}
+    finally:
+        for fixture, activity_id, old_template_id in bindings.values():
+            asyncio.run(restore_template_binding(fixture, activity_id, old_template_id))
+
+
+class TestSoakFullCrudLoad:
+    """Sustained full-CRUD load: calibrated worst-case students."""
+
+    def test_soak_full_crud(
+        self,
+        app_server: str,
+        soak_activity_templates: dict[str, str],
+    ) -> None:
+        """Find whether n crunched-soak students stay within bounds."""
+        fixtures = [NARAYAN_FIXTURE, SAVAGE_FIXTURE]
+        observations: list[SoakObservation] = []
+        for i in range(N_SOAK_SESSIONS):
+            fixture = fixtures[i % len(fixtures)]
+            email = f"soak-{uuid4().hex[:8]}@test.example.edu.au"
+            workspace_id = asyncio.run(
+                provision_clone_for_email(soak_activity_templates[fixture.name], email)
+            )
+            observations.append(
+                SoakObservation(
+                    email=email,
+                    workspace_id=workspace_id,
+                    fixture=fixture.name,
+                    arrival_offset_s=(
+                        (i / max(1, N_SOAK_SESSIONS - 1)) * SOAK_ARRIVAL_SPREAD_S
+                    ),
+                )
+            )
+
+        diag_samples: list[dict] = []
+        t_origin = time.perf_counter()
+
+        def sample_diag() -> None:
+            diag = _fetch_json(f"{app_server}/api/test/diagnostics")
+            diag["t_s"] = time.perf_counter() - t_origin
+            diag_samples.append(diag)
+
+        ready_barrier = threading.Barrier(N_SOAK_SESSIONS + 1, timeout=240)
+        done_counter = [0]
+        done_lock = threading.Lock()
+
+        threads = [
+            threading.Thread(
+                target=_run_soak_session,
+                args=(app_server, observation, fixtures[i % len(fixtures)], i),
+                kwargs={
+                    "ready_barrier": ready_barrier,
+                    "done_counter": done_counter,
+                    "done_lock": done_lock,
+                },
+                name=f"soak-session-{i}",
+            )
+            for i, observation in enumerate(observations)
+        ]
+
+        for thread in threads:
+            thread.start()
+
+        try:
+            sample_diag()
+            ready_barrier.wait(timeout=240)
+            watch_deadline = (
+                time.perf_counter() + SOAK_ARRIVAL_SPREAD_S + SOAK_MINUTES * 60 + 600
+            )
+            while time.perf_counter() < watch_deadline:
+                with done_lock:
+                    if done_counter[0] >= N_SOAK_SESSIONS:
+                        break
+                time.sleep(SOAK_DIAG_SAMPLE_SECONDS)
+                sample_diag()
+        finally:
+            for thread in threads:
+                thread.join(timeout=300)
+
+        sample_diag()
+        _print_summary(observations, diag_samples)
+        _maybe_write_diag(observations, diag_samples)
+
+        load_errors = [o.error for o in observations if o.error]
+        action_failures = [
+            f"{o.email} {a.action}: {a.error}"
+            for o in observations
+            for a in o.actions
+            if a.error is not None
+        ]
+        if load_errors or action_failures:
+            pytest.fail(
+                "\n".join(
+                    [
+                        f"Soak probe boundary hit at n={N_SOAK_SESSIONS}:",
+                        *load_errors,
+                        *action_failures,
+                    ]
+                )
+            )
+
+        assert all(o.annotation_loaded for o in observations)
+        # The probe must not pass by idling: each student must complete
+        # at least half of its paced budget.
+        min_actions = int(ACTIONS_PER_MIN * SOAK_MINUTES * MIN_ACTION_FRACTION)
+        for o in observations:
+            ok_actions = sum(1 for a in o.actions if a.error is None)
+            assert ok_actions >= min_actions, (
+                f"{o.email} completed only {ok_actions} actions "
+                f"(minimum {min_actions}) -- pacing or eligibility broke"
+            )

--- a/tests/e2e/test_soak_full_crud_load.py
+++ b/tests/e2e/test_soak_full_crud_load.py
@@ -126,12 +126,15 @@ ACTION_WEIGHTS: list[tuple[str, float]] = list(
 ANNOTATION_CARD = "[data-testid='annotation-card']"
 
 
-# Action types whose Playwright timeouts are browser-side degradation,
-# not server boundary evidence. Milkdown init is browser-CPU-heavy and
-# the co-located harness (failure-mode class G) starves it at high n:
-# the n=25 run had 74 respond timeouts against a flat-task, zero-error
-# server. These are counted and reported, never fatal.
-DEGRADED_NONFATAL_ACTIONS = frozenset({"respond_type"})
+# Action types whose failures are browser-side degradation, not server
+# boundary evidence (failure-mode class G, co-located harness):
+# - respond_type: Milkdown init is browser-CPU-heavy; n=25 had 74
+#   timeouts against a flat-task, zero-error server.
+# - organise_drag: SortableJS drops bounce ~1% when a rebuild lands
+#   mid-drag; a real student re-drags (retried, then degraded).
+# These are counted and reported, never fatal. If the server itself
+# stalls, the fatal action types (creates, comments, tags) catch it.
+DEGRADED_NONFATAL_ACTIONS = frozenset({"respond_type", "organise_drag"})
 
 
 @dataclass
@@ -349,8 +352,12 @@ def _do_tag_create(page: Page, state: StudentState, _result: ActionResult) -> No
     state.tags_created += 1
 
 
-def _do_organise_drag(page: Page, state: StudentState, _result: ActionResult) -> None:
-    """Drag a card between tag columns on the Organise tab (retag)."""
+def _do_organise_drag(page: Page, state: StudentState, result: ActionResult) -> None:
+    """Drag a card between tag columns on the Organise tab (retag).
+
+    Drops bounce (~1%) when a rebuild lands mid-drag; a real student
+    re-drags, so bounced drops are retried before giving up.
+    """
     page.get_by_test_id("tab-organise").click()
     columns = page.locator("[data-testid='tag-column']")
     columns.first.wait_for(state="visible", timeout=SOAK_ACTION_TIMEOUT_MS)
@@ -378,34 +385,45 @@ def _do_organise_drag(page: Page, state: StudentState, _result: ActionResult) ->
         columns.nth(source_idx).locator("[data-testid='organise-card']").count()
     )
 
-    # Cards drag directly onto the target column's sortable container
-    # (the pattern test_tag_sync.py uses); there is no drag handle.
-    card = columns.nth(source_idx).locator("[data-testid='organise-card']").first
-    card.drag_to(target_col.locator(".nicegui-sortable").first)
     try:
-        # Success = the source column lost the card. Where it landed is
-        # secondary: any completed drop is a real retag round trip.
-        page.wait_for_function(
-            "([colIdx, n]) => {"
-            "  const cols = document.querySelectorAll('[data-testid=\"tag-column\"]');"
-            "  if (!cols[colIdx]) return false;"
-            "  return cols[colIdx].querySelectorAll("
-            "    '[data-testid=\"organise-card\"]').length < n;"
-            "}",
-            arg=[source_idx, source_before],
-            timeout=SOAK_ACTION_TIMEOUT_MS,
-        )
-    except PlaywrightTimeoutError:
-        counts = [
-            columns.nth(i).locator("[data-testid='organise-card']").count()
-            for i in range(n_columns)
-        ]
-        msg = (
-            f"drag produced no column change: source_idx={source_idx} "
-            f"(had {source_before}), target_idx={target_idx}, "
-            f"column counts now {counts}"
-        )
-        raise RuntimeError(msg) from None
+        for attempt in range(HIGHLIGHT_ATTEMPTS):
+            # Cards drag directly onto the target column's sortable
+            # container (the pattern test_tag_sync.py uses); no handle.
+            card = (
+                columns.nth(source_idx).locator("[data-testid='organise-card']").first
+            )
+            card.drag_to(target_col.locator(".nicegui-sortable").first)
+            last = attempt == HIGHLIGHT_ATTEMPTS - 1
+            try:
+                # Success = the source column lost the card. Where it
+                # landed is secondary: any completed drop is a real
+                # retag round trip.
+                page.wait_for_function(
+                    "([colIdx, n]) => {"
+                    "  const cols = document.querySelectorAll("
+                    "    '[data-testid=\"tag-column\"]');"
+                    "  if (!cols[colIdx]) return false;"
+                    "  return cols[colIdx].querySelectorAll("
+                    "    '[data-testid=\"organise-card\"]').length < n;"
+                    "}",
+                    arg=[source_idx, source_before],
+                    timeout=SOAK_ACTION_TIMEOUT_MS if last else SOAK_RETRY_TIMEOUT_MS,
+                )
+                return
+            except PlaywrightTimeoutError:
+                result.retries += 1
+                if last:
+                    counts = [
+                        columns.nth(i).locator("[data-testid='organise-card']").count()
+                        for i in range(n_columns)
+                    ]
+                    msg = (
+                        f"drag produced no column change after "
+                        f"{HIGHLIGHT_ATTEMPTS} attempts: "
+                        f"source_idx={source_idx} (had {source_before}), "
+                        f"target_idx={target_idx}, column counts now {counts}"
+                    )
+                    raise RuntimeError(msg) from None
     finally:
         _back_to_source(page)
 
@@ -482,8 +500,6 @@ def _run_soak_pass(
     consecutive_failures = 0
     action_index = 0
 
-    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-
     while time.perf_counter() < deadline:
         action = _pick_action(state, action_index)
         result = ActionResult(action=f"{action}-{action_index}")
@@ -493,9 +509,7 @@ def _run_soak_pass(
             consecutive_failures = 0
         except Exception as exc:
             result.error = f"{type(exc).__name__}: {exc}"
-            if action in DEGRADED_NONFATAL_ACTIONS and isinstance(
-                exc, PlaywrightTimeoutError
-            ):
+            if action in DEGRADED_NONFATAL_ACTIONS:
                 result.degraded = True
             else:
                 consecutive_failures += 1

--- a/tests/e2e/test_thundering_herd.py
+++ b/tests/e2e/test_thundering_herd.py
@@ -1,0 +1,759 @@
+"""Perf probe: a thundering herd landing on the heavyweight PABAI workspace.
+
+Where the cram probe (test_assessment_cram_load.py) measures a synchronized
+burst of *annotation writes*, and the soak probe measures sustained full
+CRUD, this probe measures the shape that historically crashed the server:
+N students arriving at once on a heavyweight annotated document, then
+churning -- reloading it and re-opening the annotation experience.
+
+The fixture is the PABAI extract (``pabai_workspace_scrubbed.json``: 426 KB
+document HTML, ~190 highlights in workspace CRDT state), the same workspace
+behind the April 2026 page-load investigation
+(docs/investigations/2026-04-23-page-load-failure-modes.md, CLAUDE.md
+"Performance failure modes"). Classes A and D are fixed; B (long
+transaction holds amplifying pool queueing), C (duplicate registry passes)
+and E (per-item O(N) synchronous UI loops during initial render) are known
+and unfixed, and every one of them is paid *per page load*. Reloading is
+therefore the load, not a detail of it.
+
+Shape:
+
+1. Rehydrate PABAI once, bind it as an Activity template.
+2. Pre-clone one workspace per synthetic student via the real
+   ``clone_workspace_from_activity`` path, so each student loads their own
+   independent workspace carrying its own copy of the ~190 highlights
+   (``db/workspaces.py``: CRDT state is replayed into the clone with
+   remapped document and tag ids). Per-student clones, not one shared
+   workspace: the historical crash was independent loads contending for
+   shared server resources, and a shared workspace would instead measure
+   broadcast/presence fan-out.
+3. All students authenticate, then wait on a barrier and navigate at once
+   -- that simultaneous arrival is the herd.
+4. Each student then runs ``E2E_HERD_CYCLES`` churn cycles: reload, wait
+   for the annotation page to be ready and the sidebar to mount, click
+   "Go to highlight" on random cards, visit Organise and Respond, return
+   to Source.
+
+Reload churn is **free-running by default**: only the first arrival is
+barrier-synchronized, and cycles are separated by jittered think time so
+students de-phase. Set ``E2E_HERD_SYNC_RELOADS=true`` to re-form the herd
+before every cycle instead (a barrier per cycle, degrading to free-running
+if it breaks). Free-running is the default because a warm-cache reload
+wave no longer meets the class-A cold-cache precondition, and sustained
+overlapping loads at independent phase are what a real class produces once
+everyone is in.
+
+Admission is already disabled by the E2E harness
+(``cli/e2e/_server_script.py:21`` sets ``ADMISSION__ENABLED=false``), so
+this probe never sees the queue and deliberately carries no queue handling.
+
+Ramp externally:
+
+    E2E_HERD_SESSIONS=150 E2E_HERD_DIAG_PATH=perf-data/herd_n150.json \
+        uv run grimoire e2e perf tests/e2e/test_thundering_herd.py
+
+Failures are data. The probe records every load and action failure, prints
+them, and writes them to the diag JSON; it fails only on systemic collapse
+(more than ``max(3, N // 10)`` students affected), so a single wedged
+co-located browser cannot masquerade as a server boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+import threading
+import time
+import urllib.request
+from contextlib import suppress
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from promptgrimoire.config import get_current_branch, get_settings
+from tests.e2e.assessment_fixtures import (
+    AssessmentFixture,
+    create_template_activity,
+    ensure_fixture_workspace,
+    provision_clone_for_email,
+    restore_template_binding,
+)
+from tests.e2e.card_helpers import PABAI_FIXTURE_JSON, PABAI_WORKSPACE_ID
+from tests.e2e.perf_reporting import (
+    build_run_meta,
+    collect_server_page_load,
+    print_server_page_load,
+    utc_now,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from datetime import datetime
+
+    from playwright.sync_api import Page
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.perf,
+    # Overrides the global 30s cap: a 150-session herd spends minutes in
+    # clone provisioning alone, then several reload cycles per student.
+    pytest.mark.timeout(3600),
+    pytest.mark.skipif(
+        not get_settings().dev.test_database_url,
+        reason="DEV__TEST_DATABASE_URL not configured",
+    ),
+]
+
+# PABAI is not one of the assessment fixtures, but the provisioning
+# machinery is fixture-agnostic; its id and path already have a single
+# home in card_helpers, so reuse both rather than restating the UUID.
+PABAI_FIXTURE = AssessmentFixture(
+    name="pabai",
+    workspace_id=PABAI_WORKSPACE_ID,
+    json_path=PABAI_FIXTURE_JSON,
+)
+
+ANNOTATION_CARD = "[data-testid='annotation-card']"
+
+
+def _bool_env(name: str, *, default: bool = False) -> bool:
+    """Read a boolean runner flag from the environment."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+N_HERD_SESSIONS = int(os.environ.get("E2E_HERD_SESSIONS", "25"))
+N_HERD_CYCLES = int(os.environ.get("E2E_HERD_CYCLES", "3"))
+# Locate ("Go to highlight") clicks per cycle: a read-only card
+# interaction that still costs a full client -> server -> client round
+# trip, so its latency is a server-responsiveness signal.
+N_HERD_LOCATES = int(os.environ.get("E2E_HERD_LOCATES", "2"))
+HERD_THINK_MS = int(os.environ.get("E2E_HERD_THINK_MS", "2000"))
+HERD_ACTION_TIMEOUT_MS = int(os.environ.get("E2E_HERD_ACTION_TIMEOUT_MS", "30000"))
+HERD_LOAD_TIMEOUT_MS = int(os.environ.get("E2E_HERD_LOAD_TIMEOUT_MS", "120000"))
+HERD_BARRIER_TIMEOUT_S = float(os.environ.get("E2E_HERD_BARRIER_TIMEOUT_S", "240"))
+HERD_DIAG_SAMPLE_SECONDS = float(os.environ.get("E2E_HERD_DIAG_SAMPLE_SECONDS", "5"))
+HERD_SYNC_RELOADS = _bool_env("E2E_HERD_SYNC_RELOADS")
+
+# Worst case if every student burns every timeout: one first load plus a
+# reload per cycle, and each cycle's locate/organise/respond actions.
+# Bounded rather than generous -- the point is to record collapse, not to
+# hang until the pytest timeout.
+_DEFAULT_WATCH_S = (
+    (N_HERD_CYCLES + 1) * HERD_LOAD_TIMEOUT_MS / 1000
+    + N_HERD_CYCLES * (N_HERD_LOCATES + 2) * HERD_ACTION_TIMEOUT_MS / 1000
+    + 300
+)
+HERD_WATCH_SECONDS = float(
+    os.environ.get("E2E_HERD_WATCH_SECONDS", str(round(_DEFAULT_WATCH_S)))
+)
+
+# Failures that are recorded and printed but never fatal, because this
+# harness cannot attribute them to the server:
+#
+# - respond: opening the tab initialises Milkdown, which is browser-CPU
+#   heavy. The soak probe measured this directly -- n=25 produced 74
+#   respond timeouts against a flat-task, zero-error server
+#   (test_soak_full_crud_load.py DEGRADED_NONFATAL_ACTIONS, class G).
+# - locate: the only observable for the round trip is the 'hl-throb'
+#   registration, which the app deletes 800 ms later. A main thread
+#   blocked past that window loses the signal, so a locate timeout means
+#   either the round trip never completed or the window was missed. Both
+#   are lag evidence; neither is cleanly attributable.
+DEGRADED_NONFATAL_ACTIONS = frozenset({"respond", "locate"})
+
+# The locate round trip: the server answers the click by pushing JS that
+# scrolls to the highlight and registers 'hl-throb' for 800 ms
+# (``pages/annotation/document.py`` ``_on_locate_highlight`` ->
+# ``throbHighlight`` in annotation-highlight.js). CSS highlights are not
+# DOM nodes, so this readiness wait -- the same channel every probe uses
+# for ``window._highlightsReady`` -- is the only signal available.
+_THROB_PRESENT_JS = (
+    "() => !!(window.CSS && CSS.highlights && CSS.highlights.has('hl-throb'))"
+)
+_THROB_ABSENT_JS = (
+    "() => !(window.CSS && CSS.highlights && CSS.highlights.has('hl-throb'))"
+)
+# A throb from the previous locate lives 800 ms; clearing it first stops
+# the next locate reading a stale registration as its own answer.
+_THROB_CLEAR_TIMEOUT_MS = 5000
+
+
+@dataclass
+class ActionResult:
+    """One read-only interaction inside a churn cycle."""
+
+    action: str = ""
+    elapsed_ms: int = -1
+    error: str | None = None
+    degraded: bool = False
+
+
+@dataclass
+class CycleResult:
+    """One reload-and-reopen churn cycle for one student."""
+
+    cycle: int = 0
+    reload_ms: int = -1
+    sidebar_ms: int = -1
+    cards: int = -1
+    actions: list[ActionResult] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class HerdObservation:
+    """Outcome for one synthetic student."""
+
+    email: str = ""
+    workspace_id: str = ""
+    annotation_loaded: bool = False
+    load_elapsed_ms: int = -1
+    sidebar_ms: int = -1
+    cards: int = -1
+    cycles: list[CycleResult] = field(default_factory=list)
+    error: str | None = None
+
+
+def _fetch_json(url: str) -> dict:
+    """Fetch JSON from a localhost E2E helper endpoint."""
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _think(rng: random.Random) -> None:
+    """Sleep a jittered think-time so students de-phase between cycles."""
+    if HERD_THINK_MS <= 0:
+        return
+    time.sleep(rng.uniform(0.5, 1.5) * HERD_THINK_MS / 1000)
+
+
+def _wait_page_ready(page: Page) -> None:
+    """Wait for the deferred load and the highlight pass to complete."""
+    from promptgrimoire.docs.helpers import wait_for_annotation_ready
+
+    wait_for_annotation_ready(page, timeout=HERD_LOAD_TIMEOUT_MS)
+    page.wait_for_function(
+        "() => window._highlightsReady === true",
+        timeout=HERD_LOAD_TIMEOUT_MS,
+    )
+
+
+def _wait_sidebar_mounted(page: Page) -> int:
+    """Wait for the Vue sidebar's mount epoch, then count its cards.
+
+    The sidebar increments ``window.__annotationCardsEpoch`` on mount
+    (``immediate: true`` watch, annotationsidebar.js) and on every items
+    change, so ``>= 1`` is the mounted-with-items signal. With ~190
+    highlights per clone this is the O(N) card render, failure-mode
+    class E.
+    """
+    page.wait_for_function(
+        "() => (window.__annotationCardsEpoch || 0) >= 1",
+        timeout=HERD_LOAD_TIMEOUT_MS,
+    )
+    return page.locator(ANNOTATION_CARD).count()
+
+
+def _back_to_source(page: Page) -> None:
+    """Return to the Source 1 tab (every cycle starts and ends there)."""
+    page.get_by_test_id("tab-source-1").click()
+    page.wait_for_selector(
+        "[data-testid='doc-container']", timeout=HERD_ACTION_TIMEOUT_MS
+    )
+
+
+def _do_locate(page: Page, rng: random.Random, n_cards: int) -> None:
+    """Click "Go to highlight" on a random card, wait for the throb."""
+    page.wait_for_function(_THROB_ABSENT_JS, timeout=_THROB_CLEAR_TIMEOUT_MS)
+    card = page.locator(ANNOTATION_CARD).nth(rng.randrange(n_cards))
+    card.get_by_test_id("locate-btn").click()
+    page.wait_for_function(_THROB_PRESENT_JS, timeout=HERD_ACTION_TIMEOUT_MS)
+
+
+def _do_organise(page: Page, n_cards: int) -> None:
+    """Open the Organise tab, wait for its columns, return to Source."""
+    page.get_by_test_id("tab-organise").click()
+    page.locator("[data-testid='organise-columns']").wait_for(
+        state="visible", timeout=HERD_ACTION_TIMEOUT_MS
+    )
+    if n_cards > 0:
+        # Columns can appear before their cards do; waiting for a card
+        # is what makes this a measurement of the per-card render.
+        page.locator("[data-testid='organise-card']").first.wait_for(
+            state="visible", timeout=HERD_ACTION_TIMEOUT_MS
+        )
+    _back_to_source(page)
+
+
+def _do_respond(page: Page) -> None:
+    """Open the Respond tab, wait for the editor, return to Source."""
+    page.get_by_test_id("tab-respond").click()
+    page.locator("[data-testid='milkdown-editor-container']").wait_for(
+        state="visible", timeout=HERD_ACTION_TIMEOUT_MS
+    )
+    _back_to_source(page)
+
+
+def _record(
+    page: Page,
+    result: CycleResult,
+    action: str,
+    run: Callable[[], None],
+) -> None:
+    """Run one interaction, recording latency and any failure as data."""
+    entry = ActionResult(action=action)
+    t0 = time.perf_counter()
+    try:
+        run()
+    except Exception as exc:
+        entry.error = f"{type(exc).__name__}: {exc}"
+        entry.degraded = action.partition("-")[0] in DEGRADED_NONFATAL_ACTIONS
+        # Leave the page where the next action expects it; a failure to
+        # recover is itself recorded on the next action.
+        with suppress(Exception):
+            _back_to_source(page)
+    finally:
+        entry.elapsed_ms = round((time.perf_counter() - t0) * 1000)
+        result.actions.append(entry)
+
+
+def _run_cycle(
+    page: Page,
+    rng: random.Random,
+    observation: HerdObservation,
+    cycle_index: int,
+    cycle_barrier: threading.Barrier | None,
+) -> None:
+    """Reload, re-open the annotation experience, record the timings."""
+    result = CycleResult(cycle=cycle_index)
+    observation.cycles.append(result)
+
+    if cycle_barrier is None:
+        _think(rng)
+    else:
+        # A broken barrier (a student died, or one is slow past the
+        # timeout) degrades this cycle to free-running rather than
+        # failing every student in it.
+        with suppress(threading.BrokenBarrierError):
+            cycle_barrier.wait(timeout=HERD_BARRIER_TIMEOUT_S)
+
+    t0 = time.perf_counter()
+    try:
+        page.reload(wait_until="domcontentloaded", timeout=HERD_LOAD_TIMEOUT_MS)
+        _wait_page_ready(page)
+        result.reload_ms = round((time.perf_counter() - t0) * 1000)
+        result.cards = _wait_sidebar_mounted(page)
+        result.sidebar_ms = round((time.perf_counter() - t0) * 1000)
+    except Exception as exc:
+        result.error = f"{type(exc).__name__}: {exc}"
+        return
+
+    for i in range(N_HERD_LOCATES):
+        if result.cards <= 0:
+            break
+        _record(
+            page,
+            result,
+            f"locate-{i}",
+            lambda: _do_locate(page, rng, result.cards),
+        )
+    _record(page, result, "organise", lambda: _do_organise(page, result.cards))
+    _record(page, result, "respond", lambda: _do_respond(page))
+
+
+def _run_herd_session(
+    app_server: str,
+    observation: HerdObservation,
+    seed: int,
+    *,
+    start_barrier: threading.Barrier,
+    loaded_barrier: threading.Barrier,
+    cycle_barriers: list[threading.Barrier],
+    done_counter: list[int],
+    done_lock: threading.Lock,
+    release_event: threading.Event,
+) -> None:
+    """Authenticate, arrive with the herd, then churn."""
+    from playwright.sync_api import sync_playwright
+
+    # Deterministic per-student jitter for load shaping, not cryptography.
+    rng = random.Random(seed)  # noqa: S311
+    workspace_url = f"{app_server}/annotation?workspace_id={observation.workspace_id}"
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        try:
+            context = browser.new_context()
+            page = context.new_page()
+
+            page.goto(
+                f"{app_server}/auth/callback?token=mock-token-{observation.email}"
+            )
+            page.wait_for_url(
+                lambda url: "/auth/callback" not in url,
+                timeout=15_000,
+            )
+
+            try:
+                start_barrier.wait(timeout=HERD_BARRIER_TIMEOUT_S)
+                t0 = time.perf_counter()
+                page.goto(
+                    workspace_url,
+                    wait_until="domcontentloaded",
+                    timeout=HERD_LOAD_TIMEOUT_MS,
+                )
+                _wait_page_ready(page)
+                observation.load_elapsed_ms = round((time.perf_counter() - t0) * 1000)
+                observation.annotation_loaded = True
+                observation.cards = _wait_sidebar_mounted(page)
+                observation.sidebar_ms = round((time.perf_counter() - t0) * 1000)
+                # This barrier only marks "the herd has landed" for the
+                # diagnostics sample. One student failing aborts it for
+                # everyone, so a break here must not convert healthy
+                # students into failed ones, nor cost them their churn.
+                with suppress(threading.BrokenBarrierError):
+                    loaded_barrier.wait(timeout=HERD_BARRIER_TIMEOUT_S)
+
+                for cycle_index in range(N_HERD_CYCLES):
+                    _run_cycle(
+                        page,
+                        rng,
+                        observation,
+                        cycle_index,
+                        cycle_barriers[cycle_index] if cycle_barriers else None,
+                    )
+            except Exception as exc:
+                observation.error = f"{type(exc).__name__}: {exc}"
+                # Release everyone still waiting on this student rather
+                # than making them burn the full barrier timeout.
+                for barrier in (loaded_barrier, *cycle_barriers):
+                    with suppress(threading.BrokenBarrierError):
+                        barrier.abort()
+            finally:
+                with done_lock:
+                    done_counter[0] += 1
+                release_event.wait(timeout=120)
+                page.goto("about:blank")
+                context.close()
+        finally:
+            browser.close()
+
+
+def _percentiles(values: list[int]) -> str:
+    """Render p50/p90/max for a latency list."""
+    if not values:
+        return "n/a"
+    ordered = sorted(values)
+    p50 = ordered[len(ordered) // 2]
+    p90 = ordered[min(len(ordered) - 1, (len(ordered) * 9) // 10)]
+    return f"p50={p50}ms p90={p90}ms max={ordered[-1]}ms"
+
+
+def _all_actions(
+    observations: list[HerdObservation],
+) -> list[tuple[HerdObservation, CycleResult, ActionResult]]:
+    """Flatten every recorded action with its student and cycle."""
+    return [
+        (observation, cycle, action)
+        for observation in observations
+        for cycle in observation.cycles
+        for action in cycle.actions
+    ]
+
+
+def _print_cycle_table(observations: list[HerdObservation]) -> None:
+    """Print reload and sidebar latency per churn cycle."""
+    for cycle_index in range(N_HERD_CYCLES):
+        cycles = [c for o in observations for c in o.cycles if c.cycle == cycle_index]
+        reloads = [c.reload_ms for c in cycles if c.reload_ms >= 0]
+        sidebars = [c.sidebar_ms for c in cycles if c.sidebar_ms >= 0]
+        errors = sum(1 for c in cycles if c.error)
+        print(
+            f"cycle {cycle_index}: reload n={len(reloads)} {_percentiles(reloads)}"
+            f" | sidebar {_percentiles(sidebars)} | reload failures {errors}"
+        )
+
+
+def _print_summary(
+    observations: list[HerdObservation],
+    diag_samples: list[dict],
+) -> None:
+    """Print the latency tables and the diagnostics trajectory."""
+    loads = [o.load_elapsed_ms for o in observations if o.load_elapsed_ms >= 0]
+    sidebars = [o.sidebar_ms for o in observations if o.sidebar_ms >= 0]
+    cards = [o.cards for o in observations if o.cards >= 0]
+
+    mode = "synchronized" if HERD_SYNC_RELOADS else "free-running"
+    print(
+        f"\n=== Thundering-herd probe (n={N_HERD_SESSIONS}, "
+        f"{N_HERD_CYCLES} {mode} cycles, PABAI) ==="
+    )
+    print(f"first load:     {_percentiles(loads)}")
+    print(f"first sidebar:  {_percentiles(sidebars)}")
+    print(
+        f"cards rendered: min={min(cards) if cards else 'n/a'} "
+        f"max={max(cards) if cards else 'n/a'}"
+    )
+    _print_cycle_table(observations)
+
+    actions = _all_actions(observations)
+    for name in ("locate", "organise", "respond"):
+        ok = [
+            a.elapsed_ms
+            for _, _, a in actions
+            if a.action.startswith(name) and a.error is None
+        ]
+        print(f"{name:<10} n={len(ok):<5} {_percentiles(ok)}")
+
+    degraded = [(o.email, a.action) for o, _, a in actions if a.degraded]
+    failures = [
+        (o.email, a.action, a.error)
+        for o, _, a in actions
+        if a.error is not None and not a.degraded
+    ]
+    print(f"degraded (unattributable, nonfatal): {len(degraded)}")
+    print(f"action failures (fatal): {len(failures)}")
+    for email, action, error in failures[:20]:
+        print(f"  {email} {action}: {error}")
+
+    print("--- diagnostics trajectory ---")
+    for sample in diag_samples:
+        print(
+            f"  t={sample['t_s']:.0f}s rss={sample.get('rss_bytes')}"
+            f" clients={sample.get('nicegui_clients')}"
+            f" tasks={sample.get('asyncio_tasks')}"
+            f" pool={sample.get('pool')}"
+        )
+
+
+def _herd_run_meta(started: datetime, ended: datetime) -> dict:
+    """Describe this run's configuration for the diag JSON."""
+    return build_run_meta(
+        probe="thundering_herd",
+        env=os.environ,
+        started=started,
+        ended=ended,
+        knobs={
+            "sessions": N_HERD_SESSIONS,
+            "cycles": N_HERD_CYCLES,
+            "locates_per_cycle": N_HERD_LOCATES,
+            "sync_reloads": HERD_SYNC_RELOADS,
+            "think_ms": HERD_THINK_MS,
+            "action_timeout_ms": HERD_ACTION_TIMEOUT_MS,
+            "load_timeout_ms": HERD_LOAD_TIMEOUT_MS,
+            "barrier_timeout_s": HERD_BARRIER_TIMEOUT_S,
+            "watch_seconds": HERD_WATCH_SECONDS,
+            "diag_sample_seconds": HERD_DIAG_SAMPLE_SECONDS,
+            "fixture": PABAI_FIXTURE.name,
+        },
+        snapshot_enabled=get_settings().snapshot.enabled,
+        branch=get_current_branch(),
+    )
+
+
+def _maybe_write_diag(
+    observations: list[HerdObservation],
+    diag_samples: list[dict],
+    run_meta: dict,
+    server_page_load: dict,
+) -> None:
+    """Optionally persist full evidence for manual analysis."""
+    raw_path = os.environ.get("E2E_HERD_DIAG_PATH")
+    if not raw_path:
+        return
+    payload = {
+        "run_meta": run_meta,
+        "server_page_load": server_page_load,
+        "sessions": N_HERD_SESSIONS,
+        "cycles": N_HERD_CYCLES,
+        "locates_per_cycle": N_HERD_LOCATES,
+        "sync_reloads": HERD_SYNC_RELOADS,
+        "think_ms": HERD_THINK_MS,
+        "diag_samples": diag_samples,
+        "results": [asdict(o) for o in observations],
+    }
+    Path(raw_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _report_failures_and_gate(observations: list[HerdObservation]) -> None:
+    """Print every failure, then assert only against systemic collapse.
+
+    A student counts as failed if their first load never completed, any
+    reload cycle failed, or any non-degraded action errored. The gate
+    mirrors the cram probe: individual failures are data, and the run
+    fails only when the failures spread across the cohort.
+    """
+    load_errors = [f"{o.email}: {o.error}" for o in observations if o.error]
+    cycle_errors = [
+        f"{o.email} cycle-{c.cycle}: {c.error}"
+        for o in observations
+        for c in o.cycles
+        if c.error
+    ]
+    action_failures = [
+        f"{o.email} {a.action}: {a.error}"
+        for o, _, a in _all_actions(observations)
+        if a.error is not None and not a.degraded
+    ]
+    if load_errors or cycle_errors or action_failures:
+        print(f"\nherd failures at n={N_HERD_SESSIONS} (reported, not fatal):")
+        for line in (*load_errors, *cycle_errors, *action_failures):
+            print(f"  {line}")
+
+    failed_students = {
+        o.email
+        for o in observations
+        if o.error
+        or not o.annotation_loaded
+        or any(c.error for c in o.cycles)
+        or any(a.error and not a.degraded for c in o.cycles for a in c.actions)
+    }
+    max_failed = max(3, N_HERD_SESSIONS // 10)
+    assert len(failed_students) <= max_failed, (
+        f"Herd collapse: {len(failed_students)} of {N_HERD_SESSIONS} students"
+        f" failed (gate {max_failed}): {sorted(failed_students)}"
+    )
+
+
+@pytest.fixture(scope="module")
+def pabai_herd_template() -> Iterator[str]:
+    """Bind the PABAI fixture as an activity template for the run."""
+    ensure_fixture_workspace(PABAI_FIXTURE)
+    activity_id, old_template_id = asyncio.run(
+        create_template_activity(PABAI_FIXTURE, course_name="Thundering Herd Probe")
+    )
+    try:
+        yield activity_id
+    finally:
+        asyncio.run(
+            restore_template_binding(PABAI_FIXTURE, activity_id, old_template_id)
+        )
+
+
+class TestThunderingHerd:
+    """Simultaneous arrival plus reload churn on heavyweight clones."""
+
+    def test_thundering_herd_pabai(
+        self,
+        app_server: str,
+        pabai_herd_template: str,
+    ) -> None:
+        """Find whether n students arriving at once stay within bounds."""
+        run_started = utc_now()
+        observations: list[HerdObservation] = []
+        for _ in range(N_HERD_SESSIONS):
+            email = f"herd-{uuid4().hex[:8]}@test.example.edu.au"
+            workspace_id = asyncio.run(
+                provision_clone_for_email(pabai_herd_template, email)
+            )
+            observations.append(HerdObservation(email=email, workspace_id=workspace_id))
+
+        diag_samples: list[dict] = []
+        t_origin = time.perf_counter()
+
+        def sample_diag() -> None:
+            # A server that has fallen over cannot answer this, and that
+            # is precisely the case the probe exists to record: keep the
+            # failed sample as evidence rather than aborting the run and
+            # losing every other observation with it.
+            diag: dict
+            try:
+                diag = _fetch_json(f"{app_server}/api/test/diagnostics")
+            except Exception as exc:
+                diag = {"error": f"{type(exc).__name__}: {exc}"}
+            diag["t_s"] = time.perf_counter() - t_origin
+            diag_samples.append(diag)
+
+        start_barrier = threading.Barrier(
+            N_HERD_SESSIONS + 1, timeout=HERD_BARRIER_TIMEOUT_S
+        )
+        loaded_barrier = threading.Barrier(
+            N_HERD_SESSIONS + 1, timeout=HERD_BARRIER_TIMEOUT_S
+        )
+        # Students only: the harness thread takes no part in the churn.
+        cycle_barriers = (
+            [
+                threading.Barrier(N_HERD_SESSIONS, timeout=HERD_BARRIER_TIMEOUT_S)
+                for _ in range(N_HERD_CYCLES)
+            ]
+            if HERD_SYNC_RELOADS
+            else []
+        )
+        done_counter = [0]
+        done_lock = threading.Lock()
+        release_event = threading.Event()
+
+        threads = [
+            threading.Thread(
+                target=_run_herd_session,
+                args=(app_server, observation, i),
+                kwargs={
+                    "start_barrier": start_barrier,
+                    "loaded_barrier": loaded_barrier,
+                    "cycle_barriers": cycle_barriers,
+                    "done_counter": done_counter,
+                    "done_lock": done_lock,
+                    "release_event": release_event,
+                },
+                name=f"herd-session-{i}",
+            )
+            for i, observation in enumerate(observations)
+        ]
+
+        for thread in threads:
+            thread.start()
+
+        try:
+            sample_diag()
+            # A broken start barrier means the herd never formed (a
+            # browser failed to launch, say). Every student records that
+            # as its own load error, so let the run reach its report
+            # rather than dying here with no evidence written.
+            with suppress(threading.BrokenBarrierError):
+                start_barrier.wait(timeout=HERD_BARRIER_TIMEOUT_S)
+            with suppress(threading.BrokenBarrierError):
+                loaded_barrier.wait(timeout=HERD_BARRIER_TIMEOUT_S)
+            # The herd has landed (or broken): this sample is its peak.
+            sample_diag()
+
+            watch_deadline = time.perf_counter() + HERD_WATCH_SECONDS
+            while time.perf_counter() < watch_deadline:
+                with done_lock:
+                    if done_counter[0] >= N_HERD_SESSIONS:
+                        break
+                time.sleep(HERD_DIAG_SAMPLE_SECONDS)
+                sample_diag()
+        finally:
+            release_event.set()
+            for thread in threads:
+                thread.join(timeout=300)
+
+        sample_diag()
+        run_ended = utc_now()
+        _print_summary(observations, diag_samples)
+
+        # Browser-observed latency above includes Playwright and the
+        # co-located browser's own CPU contention (failure-mode class G);
+        # the server's page_load_profile is the production-magnitude
+        # number, so both are reported side by side.
+        server_page_load = collect_server_page_load(
+            window_start=run_started,
+            window_end=run_ended,
+        )
+        print_server_page_load(server_page_load)
+        _maybe_write_diag(
+            observations,
+            diag_samples,
+            _herd_run_meta(run_started, run_ended),
+            server_page_load,
+        )
+
+        _report_failures_and_gate(observations)

--- a/tests/unit/test_cli_e2e_runner.py
+++ b/tests/unit/test_cli_e2e_runner.py
@@ -39,14 +39,65 @@ def test_perf_queue_pool_removes_test_nullpool_override(
     from promptgrimoire.cli.e2e import _configure_perf_server
 
     monkeypatch.setenv("_PROMPTGRIMOIRE_USE_NULL_POOL", "1")
+    # Seeded through monkeypatch so its teardown removes what
+    # _configure_perf_server writes; a leaked "1" would flip later tests
+    # in this worker from NullPool to QueuePool.
+    monkeypatch.setenv("_PROMPTGRIMOIRE_POOL_FIDELITY", "0")
     monkeypatch.setenv(
         "E2E_PERF_DATABASE_URL", "postgresql+asyncpg://localhost:6432/test"
     )
     _configure_perf_server(queue_pool=True)
     assert "_PROMPTGRIMOIRE_USE_NULL_POOL" not in os.environ
+    assert os.environ["_PROMPTGRIMOIRE_POOL_FIDELITY"] == "1"
     assert os.environ["DATABASE__URL"] == os.environ["E2E_PERF_DATABASE_URL"]
     assert os.environ["E2E_RECONNECT_TIMEOUT"] == "15"
     assert os.environ["E2E_INSTRUMENT_OUTBOX"] == "1"
+
+
+def test_perf_queue_pool_scopes_fidelity_to_the_measured_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The harness keeps NullPool; only the managed server gets QueuePool.
+
+    ``_run_pytest`` calls ``_pre_test_db_cleanup()`` a second time, which
+    restores ``_PROMPTGRIMOIRE_USE_NULL_POOL=1`` and the direct database URL
+    for the pytest process.  The perf command must clear the fidelity flag
+    for that subprocess, or the harness's own fixtures would silently move
+    off NullPool.
+    """
+    from promptgrimoire.cli import e2e
+
+    # Seeded through monkeypatch so teardown removes whatever the command
+    # writes to the real process environment.
+    for leaked in (
+        "_PROMPTGRIMOIRE_POOL_FIDELITY",
+        "E2E_BASE_URL",
+        "E2E_RECONNECT_TIMEOUT",
+        "E2E_INSTRUMENT_OUTBOX",
+    ):
+        monkeypatch.setenv(leaked, "0")
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(e2e, "_configure_test_run_resources", lambda: None)
+    monkeypatch.setattr(e2e, "_wait_for_idle_perf_host", lambda: None)
+    monkeypatch.setattr(e2e, "_pre_test_db_cleanup", lambda: None)
+    monkeypatch.setattr(e2e, "_allocate_ports", lambda _count: [4321])
+    monkeypatch.setattr(e2e, "_start_e2e_server", lambda _port: "server")
+    monkeypatch.setattr(e2e, "_stop_e2e_server", lambda _process: None)
+
+    def fake_run_pytest(**kwargs: Any) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(e2e, "_run_pytest", fake_run_pytest)
+
+    result = CliRunner().invoke(e2e.e2e_app, ["perf", "--queue-pool"])
+
+    assert result.exit_code == 0, result.output
+    # Server side: started while the flag was on.
+    assert os.environ["_PROMPTGRIMOIRE_POOL_FIDELITY"] == "1"
+    # Harness side: explicitly turned back off for the pytest subprocess.
+    assert captured["extra_env"]["_PROMPTGRIMOIRE_POOL_FIDELITY"] == "0"
 
 
 def test_e2e_server_can_use_dedicated_cpus(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_engine_pool_fidelity.py
+++ b/tests/unit/test_engine_pool_fidelity.py
@@ -1,0 +1,176 @@
+"""Tests for the production-fidelity pool override in init_db().
+
+The E2E harness forces NullPool (``_PROMPTGRIMOIRE_USE_NULL_POOL=1``) so
+xdist workers do not share asyncpg connection state.  A perf run needs the
+opposite: QueuePool with the configured sizing, so the measured topology
+matches production behind PgBouncer.  ``_PROMPTGRIMOIRE_POOL_FIDELITY=1``
+is that opt-in.
+
+Verified here:
+- fidelity defeats the test-harness forcing (QueuePool, configured sizing);
+- fidelity does not defeat the standalone-worker override;
+- fidelity does not defeat explicit ``DATABASE__USE_NULL_POOL``;
+- only the exact value ``"1"`` counts;
+- the chosen mode is logged with a reason that names the deciding input.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import structlog
+from sqlalchemy.pool import NullPool
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+    import pytest
+
+
+def _dummy_creator() -> Any:
+    """Stand in for a DBAPI connection factory; never invoked."""
+    return None
+
+
+async def _init_db_capturing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, object], list[MutableMapping[str, Any]]]:
+    """Run init_db() with a fake engine factory and captured structlog events.
+
+    Returns the kwargs handed to ``create_async_engine`` together with the
+    structlog events emitted during the call.
+    """
+    from promptgrimoire.config import Settings
+    from promptgrimoire.db import engine as engine_mod
+
+    monkeypatch.setattr(engine_mod, "_state", engine_mod._DatabaseState())
+    monkeypatch.setattr(
+        "promptgrimoire.db.engine.get_settings",
+        lambda: Settings(_env_file=None),  # type: ignore[call-arg]
+    )
+    monkeypatch.setenv("DATABASE__URL", "postgresql+asyncpg://test@localhost/test")
+
+    captured_kwargs: dict[str, object] = {}
+    mock_engine = AsyncMock()
+    mock_engine.sync_engine.pool = NullPool(creator=_dummy_creator)
+
+    def fake_create_async_engine(_url: str, **kwargs: object) -> AsyncMock:
+        captured_kwargs.update(kwargs)
+        return mock_engine
+
+    monkeypatch.setattr(engine_mod, "create_async_engine", fake_create_async_engine)
+
+    with structlog.testing.capture_logs() as events:
+        await engine_mod.init_db()
+    return captured_kwargs, events
+
+
+def _pool_mode_event(
+    events: list[MutableMapping[str, Any]],
+) -> MutableMapping[str, Any]:
+    """Return the single db_pool_mode event, failing loudly if it is absent."""
+    matches = [e for e in events if e.get("event") == "db_pool_mode"]
+    assert len(matches) == 1, f"expected one db_pool_mode event, got {matches}"
+    return matches[0]
+
+
+def _clear_pool_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each case from no pool-selection input at all."""
+    for name in (
+        "_PROMPTGRIMOIRE_USE_NULL_POOL",
+        "_PROMPTGRIMOIRE_WORKER_NULLPOOL",
+        "_PROMPTGRIMOIRE_POOL_FIDELITY",
+        "DATABASE__USE_NULL_POOL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+class TestPoolFidelityOverride:
+    """_PROMPTGRIMOIRE_POOL_FIDELITY=1 crosses from forced NullPool to QueuePool."""
+
+    async def test_fidelity_beats_test_environment_forcing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fidelity set under the test harness selects configured QueuePool."""
+        _clear_pool_env(monkeypatch)
+        monkeypatch.setenv("_PROMPTGRIMOIRE_USE_NULL_POOL", "1")
+        monkeypatch.setenv("_PROMPTGRIMOIRE_POOL_FIDELITY", "1")
+        monkeypatch.setenv("DATABASE__POOL_SIZE", "17")
+        monkeypatch.setenv("DATABASE__MAX_OVERFLOW", "7")
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert "poolclass" not in kwargs
+        assert kwargs["pool_size"] == 17
+        assert kwargs["max_overflow"] == 7
+        event = _pool_mode_event(events)
+        assert event["mode"] == "QueuePool"
+        assert event["reason"] == "pool_fidelity"
+
+    async def test_without_fidelity_test_environment_still_forces_nullpool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unset fidelity leaves today's forced-NullPool behaviour intact."""
+        _clear_pool_env(monkeypatch)
+        monkeypatch.setenv("_PROMPTGRIMOIRE_USE_NULL_POOL", "1")
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert kwargs["poolclass"] is NullPool
+        assert "pool_size" not in kwargs
+        event = _pool_mode_event(events)
+        assert event["mode"] == "NullPool"
+        assert event["reason"] == "test"
+
+    async def test_fidelity_requires_exact_value_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-"1" value is not an opt-in; the harness forcing still wins."""
+        _clear_pool_env(monkeypatch)
+        monkeypatch.setenv("_PROMPTGRIMOIRE_USE_NULL_POOL", "1")
+        monkeypatch.setenv("_PROMPTGRIMOIRE_POOL_FIDELITY", "0")
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert kwargs["poolclass"] is NullPool
+        assert _pool_mode_event(events)["reason"] == "test"
+
+    async def test_worker_override_outranks_fidelity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The standalone export worker keeps NullPool even under fidelity."""
+        _clear_pool_env(monkeypatch)
+        monkeypatch.setenv("_PROMPTGRIMOIRE_WORKER_NULLPOOL", "1")
+        monkeypatch.setenv("_PROMPTGRIMOIRE_POOL_FIDELITY", "1")
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert kwargs["poolclass"] is NullPool
+        assert _pool_mode_event(events)["reason"] == "worker_override"
+
+    async def test_explicit_config_outranks_fidelity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DATABASE__USE_NULL_POOL is an operator decision, not harness forcing."""
+        _clear_pool_env(monkeypatch)
+        monkeypatch.setenv("DATABASE__USE_NULL_POOL", "true")
+        monkeypatch.setenv("_PROMPTGRIMOIRE_POOL_FIDELITY", "1")
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert kwargs["poolclass"] is NullPool
+        assert _pool_mode_event(events)["reason"] == "config"
+
+    async def test_plain_run_reports_default_queuepool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no pool env input at all the reason distinguishes from fidelity."""
+        _clear_pool_env(monkeypatch)
+
+        kwargs, events = await _init_db_capturing(monkeypatch)
+
+        assert "poolclass" not in kwargs
+        event = _pool_mode_event(events)
+        assert event["mode"] == "QueuePool"
+        assert event["reason"] == "default"

--- a/tests/unit/test_env_vars.py
+++ b/tests/unit/test_env_vars.py
@@ -274,6 +274,10 @@ _ALLOWED_TEST_OS_ENVIRON_GET = {
     _TESTS_DIR / "e2e" / "test_independent_workspace_load.py",
     # Cram probe E2E_CRAM_* knobs are runner flags, not app config
     _TESTS_DIR / "e2e" / "test_assessment_cram_load.py",
+    # Soak probe E2E_SOAK_* knobs are runner flags, not app config
+    _TESTS_DIR / "e2e" / "test_soak_full_crud_load.py",
+    # Herd probe E2E_HERD_* knobs are runner flags, not app config
+    _TESTS_DIR / "e2e" / "test_thundering_herd.py",
     # Snapshot E2E reads SNAPSHOT__ENABLED (runner flag gating the file)
     # and E2E_BASE_URL (set by the test runner) pre-launch, not app config
     _TESTS_DIR / "e2e" / "test_snapshot_delivery.py",

--- a/tests/unit/test_perf_server_log_parse.py
+++ b/tests/unit/test_perf_server_log_parse.py
@@ -1,0 +1,323 @@
+"""Unit tests for the perf probes' server-log aggregation.
+
+``summarise_page_load_profile`` turns raw structlog JSONL lines into the
+``server_page_load`` block the soak and cram probes write to their diag
+JSON.  It is the only place the probes' server-side latency numbers come
+from, so its window filtering, coverage reporting and percentile
+arithmetic are checked here against hand-computed expectations rather
+than against the parser's own output.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from tests.e2e.perf_reporting import find_server_jsonl, summarise_page_load_profile
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+WINDOW_START = datetime(2026, 8, 19, 5, 0, 0, tzinfo=UTC)
+WINDOW_END = datetime(2026, 8, 19, 5, 30, 0, tzinfo=UTC)
+
+SERVER_PID = 4169473
+OTHER_PID = 3792888
+
+
+def _line(**fields: object) -> str:
+    """Serialise one structlog-shaped JSON log line."""
+    return json.dumps(fields)
+
+
+def _profile(
+    timestamp: str,
+    total_ms: float,
+    *,
+    pid: int = SERVER_PID,
+    request_path: str | None = "/annotation",
+    db_resolve_ms: float = 1.0,
+) -> str:
+    """One ``page_load_profile`` line as the annotation page emits it."""
+    return _line(
+        event="page_load_profile",
+        timestamp=timestamp,
+        pid=pid,
+        request_path=request_path,
+        total_ms=total_ms,
+        db_resolve_ms=db_resolve_ms,
+        tab_panels_ms=5.0,
+        branch="perf/soak-full-crud",
+        commit="e6fd6b20",
+        workspace_id="bfc9d81d-2101-4037-8a3d-18a06ecf4432",
+    )
+
+
+def _summarise(lines: list[str]) -> dict:
+    """Run the aggregation over the default window."""
+    return summarise_page_load_profile(
+        lines,
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+    )
+
+
+class TestWindowFiltering:
+    """Only page loads inside the run window feed the aggregate."""
+
+    def test_events_outside_the_window_are_excluded_and_counted(self) -> None:
+        """Before/after events are reported separately, not aggregated."""
+        result = _summarise(
+            [
+                _profile("2026-08-19T04:59:59.000000Z", 9000.0),
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+                _profile("2026-08-19T05:29:59.000000Z", 200.0),
+                _profile("2026-08-19T05:30:01.000000Z", 8000.0),
+            ]
+        )
+
+        assert result["count"] == 2
+        assert result["total_ms"]["max"] == 200.0
+        assert result["coverage"]["profiles_before_window"] == 1
+        assert result["coverage"]["profiles_after_window"] == 1
+
+    def test_non_annotation_paths_are_excluded_and_counted(self) -> None:
+        """A profile from another route never enters the latency stats."""
+        result = _summarise(
+            [
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+                _profile(
+                    "2026-08-19T05:00:02.000000Z", 7000.0, request_path="/navigator"
+                ),
+            ]
+        )
+
+        assert result["count"] == 1
+        assert result["total_ms"]["max"] == 100.0
+        assert result["coverage"]["profiles_other_path"] == 1
+
+    def test_null_request_path_is_still_aggregated(self) -> None:
+        """An unbound request_path must not silently empty the aggregate.
+
+        The path filter exists to drop other routes.  If a future build
+        stops binding request_path, dropping those events would report a
+        confident zero instead of the loads that actually happened.
+        """
+        result = _summarise(
+            [_profile("2026-08-19T05:00:01.000000Z", 100.0, request_path=None)]
+        )
+
+        assert result["count"] == 1
+        assert result["coverage"]["profiles_other_path"] == 0
+
+
+class TestLocatingTheServerLog:
+    """Which file was read, and how confidently it was identified.
+
+    The two strategies are not equally trustworthy, so the run JSON
+    records which one applied: a glob fallback can land on a previous
+    run's or another branch's log and produce plausible numbers with no
+    other symptom.
+    """
+
+    def test_startup_line_names_the_measured_process_log(self, tmp_path: Path) -> None:
+        """setup_logging()'s own line is the authoritative locator."""
+        jsonl = tmp_path / "promptgrimoire-somebranch.jsonl"
+        jsonl.write_text("", encoding="utf-8")
+        stdout_log = tmp_path / "test-e2e-server.log"
+        stdout_log.write_text(
+            _line(
+                event=f"Structured logging configured. Log file: {jsonl}",
+                timestamp="2026-08-19T05:00:00.000000Z",
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert find_server_jsonl(stdout_log) == (jsonl, "startup_line")
+
+    def test_missing_stdout_log_falls_back_to_glob(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the startup line the newest logs/ file is a guess."""
+        sessions = tmp_path / "logs" / "sessions"
+        sessions.mkdir(parents=True)
+        guessed = sessions / "promptgrimoire-otherbranch.jsonl"
+        guessed.write_text("", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        found, strategy = find_server_jsonl(tmp_path / "absent.log")
+
+        # The fallback globs a relative "logs/", so it returns a
+        # cwd-relative path where the startup line returns an absolute one.
+        assert found is not None
+        assert found.resolve() == guessed.resolve()
+        assert strategy == "glob_fallback"
+
+    def test_no_log_anywhere_reports_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing log is a gap in the evidence, not a quiet None."""
+        monkeypatch.chdir(tmp_path)
+
+        assert find_server_jsonl(tmp_path / "absent.log") == (None, "not_found")
+
+
+class TestPercentiles:
+    """Latency statistics are nearest-rank over the in-window values."""
+
+    def test_stats_match_hand_computed_values(self) -> None:
+        """10 loads of 10..100 ms: p50=50, p95=100, max=100, mean=55."""
+        lines = [
+            _profile(f"2026-08-19T05:00:{second:02d}.000000Z", float(second * 10))
+            for second in range(1, 11)
+        ]
+
+        stats = _summarise(lines)["total_ms"]
+
+        assert stats == {"p50": 50.0, "p95": 100.0, "max": 100.0, "mean": 55.0}
+
+    def test_phase_columns_are_aggregated_separately(self) -> None:
+        """db_resolve_ms carries its own stats, not total_ms's."""
+        lines = [
+            _profile("2026-08-19T05:00:01.000000Z", 100.0, db_resolve_ms=20.0),
+            _profile("2026-08-19T05:00:02.000000Z", 300.0, db_resolve_ms=40.0),
+        ]
+
+        result = _summarise(lines)
+
+        assert result["total_ms"]["max"] == 300.0
+        assert result["db_resolve_ms"]["max"] == 40.0
+
+    def test_no_events_yields_null_stats_not_zero(self) -> None:
+        """Zero samples must not render as a 0 ms page load."""
+        result = _summarise([])
+
+        assert result["count"] == 0
+        assert result["total_ms"] is None
+
+
+class TestCoverage:
+    """The aggregate states what the scan could and could not see."""
+
+    def test_window_start_covered_when_log_predates_the_run(self) -> None:
+        """A log line older than the window proves nothing was rotated away."""
+        result = _summarise(
+            [
+                _line(event="db_pool_mode", timestamp="2026-08-19T04:58:00.123456Z"),
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+            ]
+        )
+
+        assert result["coverage"]["window_start_covered"] is True
+        assert result["coverage"]["earliest_log_ts"] == "2026-08-19T04:58:00.123456Z"
+
+    def test_earliest_log_ts_renders_as_iso_utc(self) -> None:
+        """Timestamps are re-rendered, so a whole second loses ".000000".
+
+        ``datetime.isoformat()`` omits a zero microsecond field.  Pinned
+        here because the coverage timestamps are read by eye against raw
+        log lines, where the two spellings sit side by side.
+        """
+        result = _summarise(
+            [_profile("2026-08-19T04:58:00.000000Z", 100.0)],
+        )
+
+        assert result["coverage"]["earliest_log_ts"] == "2026-08-19T04:58:00Z"
+
+    def test_window_start_uncovered_when_rotation_ate_the_head(self) -> None:
+        """Oldest retained line inside the window: count is a lower bound."""
+        result = _summarise([_profile("2026-08-19T05:10:00.000000Z", 100.0)])
+
+        assert result["coverage"]["window_start_covered"] is False
+
+    def test_malformed_lines_are_counted_not_fatal(self) -> None:
+        """A truncated line (rotation tear) must not abort the scan."""
+        result = _summarise(
+            [
+                '{"event": "page_load_profile", "timesta',
+                "",
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+            ]
+        )
+
+        assert result["count"] == 1
+        assert result["coverage"]["unparsed_lines"] == 1
+        assert result["coverage"]["lines_scanned"] == 3
+
+
+class TestProvenance:
+    """Run provenance is read back off the measured process's own lines."""
+
+    def test_server_pid_branch_and_commit_come_from_the_events(self) -> None:
+        """The dominant in-window pid identifies the measured server."""
+        result = _summarise(
+            [
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+                _profile("2026-08-19T05:00:02.000000Z", 100.0),
+                _profile("2026-08-19T05:00:03.000000Z", 100.0, pid=OTHER_PID),
+            ]
+        )
+
+        assert result["server_pid"] == SERVER_PID
+        assert result["pids"] == {str(SERVER_PID): 2, str(OTHER_PID): 1}
+        assert result["server_branch"] == "perf/soak-full-crud"
+        assert result["server_commit"] == "e6fd6b20"
+
+    def test_pool_mode_is_taken_from_the_server_pid_before_the_window(self) -> None:
+        """db_pool_mode is emitted at server start, ahead of the window."""
+        result = _summarise(
+            [
+                _line(
+                    event="db_pool_mode",
+                    timestamp="2026-08-19T04:58:00.000000Z",
+                    pid=OTHER_PID,
+                    mode="NullPool",
+                    reason="test",
+                ),
+                _line(
+                    event="db_pool_mode",
+                    timestamp="2026-08-19T04:59:00.000000Z",
+                    pid=SERVER_PID,
+                    mode="QueuePool",
+                    reason="pool_fidelity",
+                ),
+                _profile("2026-08-19T05:00:01.000000Z", 100.0),
+            ]
+        )
+
+        assert result["pool_mode"]["mode"] == "QueuePool"
+        assert result["pool_mode"]["reason"] == "pool_fidelity"
+
+    def test_snapshot_served_events_in_window_are_counted(self) -> None:
+        """Bundle deliveries observed server-side, not inferred from env.
+
+        The snapshot service logs to the same JSONL file from its own
+        pid, so a nonzero count is evidence the flag was live for this
+        run rather than merely set in the harness's environment.
+        """
+        result = _summarise(
+            [
+                _line(
+                    event="snapshot_served",
+                    timestamp="2026-08-19T04:00:00.000000Z",
+                    pid=99,
+                ),
+                _line(
+                    event="snapshot_served",
+                    timestamp="2026-08-19T05:00:01.000000Z",
+                    pid=99,
+                ),
+                _line(
+                    event="snapshot_served",
+                    timestamp="2026-08-19T05:00:02.000000Z",
+                    pid=99,
+                ),
+                _profile("2026-08-19T05:00:03.000000Z", 100.0),
+            ]
+        )
+
+        assert result["snapshot_served"] == 2

--- a/tests/unit/test_pool_settings_config.py
+++ b/tests/unit/test_pool_settings_config.py
@@ -226,9 +226,20 @@ class TestInitDbReadsPoolConfig:
             _state.session_factory = original_factory
 
     @pytest.mark.asyncio
-    async def test_init_db_logs_pool_config(self) -> None:
-        """init_db logs pool_size and max_overflow on startup."""
+    async def test_init_db_logs_pool_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """init_db logs pool sizing and the reason that chose QueuePool."""
         from promptgrimoire.db.engine import _state
+
+        # Pin the pool-mode precedence to "default": none of the
+        # env overrides may leak in from the lane environment.
+        for var in (
+            "_PROMPTGRIMOIRE_WORKER_NULLPOOL",
+            "_PROMPTGRIMOIRE_POOL_FIDELITY",
+            "_PROMPTGRIMOIRE_USE_NULL_POOL",
+        ):
+            monkeypatch.delenv(var, raising=False)
 
         original_engine = _state.engine
         original_factory = _state.session_factory
@@ -257,8 +268,10 @@ class TestInitDbReadsPoolConfig:
                 mock_logger.info.assert_any_call(
                     "db_pool_mode",
                     mode="QueuePool",
+                    reason="default",
                     pool_size=42,
                     max_overflow=7,
+                    pool_pre_ping=True,
                 )
         finally:
             _state.engine = None


### PR DESCRIPTION
## What this delivers

Performance evidence for the initial-snapshot question, and the
instrumentation that produced it. Seventeen commits: the perf probe
series (soak, cram, thundering herd), production-shaped pooling for
perf runs, run provenance and server-side page-load profiles in every
diagnostic JSON, a GC pause recorder, the #562 settle fix, and a
logging overhaul (INFO-default file handler, tunable rotation,
per-render chatter demoted to debug).

## The two findings

1. **Server-side page-load p50 is flat at ~21 ms from n=2 to n=200**
   under the paced soak with production-shaped pooling (PgBouncer,
   transaction mode, QueuePool 20+10). The earlier NullPool connection
   wall was harness topology, not the app.
2. **The initial snapshot's browser-side win did not replicate** under
   ABBA order control: snapshot-on was equal or slower at n=50/100, run
   position dominated at n=200, and the snapshot-on leg produced a
   4/200 init-load hang tail (#573).

Full tables, methodology, and ten caveats:
`docs/investigations/2026-08-19-soak-cram-perf-evidence.md`. Raw run
JSONs are per-event telemetry (no document content) and stay untracked
on the run machine; each is regenerable in kind via the committed
probes.

## Open items

- **Every number predates #570.** The branch is rebased onto post-#570
  main, but all runs were taken on pre-#570 code (evidence doc §9). The
  Milkdown-degradation class should collapse on a rebased rerun.
- **The split-rig mode (`E2E_PERF_SERVER_URL`) is committed but
  unexercised** — no split run has executed, and split runs do not yet
  capture the server-side page-load profile (the parser reads a local
  log path).
- Issues filed from this campaign: #572 (engineio disconnect 500s,
  mechanism pinned in comments), #573 (snapshot init-load hang), #574
  (GC pauses to 4.7 s under herd burst), #575 (class E organise
  render, measured at last). #562 takes a closing-evidence comment
  once this lands.

## Verification

On the final tree (pre-rebase): unit 4132/4132, JS 140/140, BATS pass,
Playwright 155 passed / 5 known skips / 1 pre-existing xfail,
integration 980 passed / 2 loadtest-precondition skips / 1 pre-existing
xfail — each lane's own exit code checked. Post-rebase: fast lanes and
the Playwright lane rerun green (results in the PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
