### PR TITLE
ci: reconcile Bunyip act and add isolated pre-PR runner

### DIFF
--- a/.agents/skills/bunyip-ci/SKILL.md
+++ b/.agents/skills/bunyip-ci/SKILL.md
@@ -9,6 +9,20 @@ Use the operator-installed wrapper as the only entry point. The wrapper owns
 the kernel `flock`; never acquire a second lock or infer availability from a
 note, timestamp, PID, port, process name, or lock-file existence.
 
+## Shared-host affordances
+
+- A durable interruptible staging service may remain healthy while the heavy
+  lock is free. Its container, listener, and health endpoint do not mean act or
+  another heavy workload is running.
+- The wrapper acquires the shared flock before stopping staging, then restores
+  staging during cleanup before releasing the flock. Loud preemption and
+  restoration messages are expected.
+- Perf uses the same flock for each atomic leg and releases it between legs.
+  CI waits for a running leg; it never kills one. Do not dispatch a second
+  workload or invent another lock.
+- Only successful `flock` acquisition establishes exclusive use. Durable
+  services and retained caches or artifacts are outside that ownership signal.
+
 For focused red/green work, pass the repository command as an argument vector:
 
 ```bash

--- a/.agents/skills/bunyip-ci/SKILL.md
+++ b/.agents/skills/bunyip-ci/SKILL.md
@@ -37,12 +37,18 @@ focused test is restored.
 
 1. Launch the wrapper once from the checkout being tested in a background
    terminal that emits a completion event. Keep that terminal attached to the
-   wrapper; do not detach the wrapper into an unobservable shell process.
+   wrapper; do not detach the wrapper into an unobservable shell process. Retain
+   every monitor handle until the wrapper exits. Yield the agent turn only when
+   the runtime guarantees that its completion event survives the yield.
 2. Treat `waiting for the bunyip heavy-work queue` as queued, not stalled. Do
    not submit a duplicate.
-3. Do not poll the terminal, processes, logs, note files, or lock while the run
-   is active. Await the terminal's completion notification and send no lane-by-
-   lane progress narration unless the user explicitly asks for it.
+3. Do not poll processes, logs, note files, or the lock while the run is active.
+   Await only the attached monitor, using its longest supported wait. If it
+   yields without an exit status, wait again on the same handle. Wrapper state
+   transitions such as queued, started, staging preemption, and restoration are
+   authoritative and may be reported once. Individual test output is non-final:
+   do not interpret, summarize, quote, or narrate it unless the user explicitly
+   asks for progress. An empty wait is not a state change and needs no update.
 4. Consider the lane finished only when the attached wrapper exits. A test
    summary is not completion: artifact handling, container cleanup, and
    interrupted staging restoration happen afterward.

--- a/.agents/skills/bunyip-ci/SKILL.md
+++ b/.agents/skills/bunyip-ci/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: bunyip-ci
+description: Run, wait for, diagnose, and report PromptGrimoire CI lanes submitted to the shared bunyip wrapper. Use for bunyip act, nightly, browser, NiceGUI, quality, image-build, or other heavy-lane work where an agent must track completion, inspect failures, verify cleanup, or hand back exact evidence.
+---
+
+# Bunyip CI
+
+Use the operator-installed wrapper as the only entry point. The wrapper owns
+the kernel `flock`; never acquire a second lock or infer availability from a
+note, timestamp, PID, port, process name, or lock-file existence.
+
+## Track completion
+
+1. Run the wrapper in the foreground from the checkout being tested. If the
+   execution tool returns a session identifier, keep polling that same session.
+2. Treat `waiting for the bunyip heavy-work queue` as queued, not stalled. Do
+   not submit a duplicate.
+3. Capture the printed lane, revision, artifact directory, start time, and
+   resource limits.
+4. Consider the lane finished only when the wrapper exits. A test summary is
+   not completion: artifact handling, container cleanup, and interrupted
+   staging restoration happen afterward.
+5. Record the wrapper exit status and its final `PASS` or `FAIL` line. On an
+   interrupted run, also verify the wrapper completed its cleanup/restoration
+   path before reporting done.
+
+## Diagnose failure
+
+Do not rerun first. Preserve the initial failure and classify it from evidence:
+
+1. Read the first failing step and the final job summary from the captured
+   output.
+2. Inspect the printed artifact directory and the lane's retained test log.
+   Report exact failing tests, counts, and artifact paths.
+3. If tests passed but artifact upload failed, report an artifact-service
+   failure rather than a test failure.
+4. If a container vanished or exited abruptly, inspect its exit/OOM state and
+   the host kernel OOM record before calling it a test failure.
+5. If many unrelated tests fail on one missing host capability or path, prove
+   that common cause with one focused reproduction. Do not label the failures
+   flaky or patch individual tests.
+6. After failure, confirm run-scoped containers, networks, and listeners are
+   gone and any preempted staging service is healthy. Preserve declared caches
+   and evidence artifacts.
+
+Rerun only after identifying a falsifiable cause or applying a relevant fix.
+Use the smallest focused lane that proves the fix, then rerun the originally
+failed lane when required for acceptance.
+
+## Report
+
+Return the lane and exact revision, wrapper exit status, elapsed time, test
+counts, first/root failure, artifact location, cache result, cleanup result,
+and staging restoration result. Distinguish observed facts from inference.

--- a/.agents/skills/bunyip-ci/SKILL.md
+++ b/.agents/skills/bunyip-ci/SKILL.md
@@ -19,20 +19,23 @@ The focused lane supplies the prepared image and PostgreSQL. Do not replace a
 focused run with an entire regular lane; run the regular lane once after the
 focused test is restored.
 
-## Track completion
+## Submit and await completion
 
-1. Run the wrapper in the foreground from the checkout being tested. If the
-   execution tool returns a session identifier, keep polling that same session.
+1. Launch the wrapper once from the checkout being tested in a background
+   terminal that emits a completion event. Keep that terminal attached to the
+   wrapper; do not detach the wrapper into an unobservable shell process.
 2. Treat `waiting for the bunyip heavy-work queue` as queued, not stalled. Do
    not submit a duplicate.
-3. Capture the printed lane, revision, artifact directory, start time, and
-   resource limits.
-4. Consider the lane finished only when the wrapper exits. A test summary is
-   not completion: artifact handling, container cleanup, and interrupted
-   staging restoration happen afterward.
-5. Record the wrapper exit status and its final `PASS` or `FAIL` line. On an
-   interrupted run, also verify the wrapper completed its cleanup/restoration
-   path before reporting done.
+3. Do not poll the terminal, processes, logs, note files, or lock while the run
+   is active. Await the terminal's completion notification and send no lane-by-
+   lane progress narration unless the user explicitly asks for it.
+4. Consider the lane finished only when the attached wrapper exits. A test
+   summary is not completion: artifact handling, container cleanup, and
+   interrupted staging restoration happen afterward.
+5. After notification, read the terminal result once and record the lane,
+   revision, artifact directory, start/end times, wrapper exit status, and its
+   final `PASS` or `FAIL` line. On an interrupted run, also verify the wrapper
+   completed its cleanup/restoration path before reporting done.
 
 ## Diagnose failure
 

--- a/.agents/skills/bunyip-ci/SKILL.md
+++ b/.agents/skills/bunyip-ci/SKILL.md
@@ -9,6 +9,16 @@ Use the operator-installed wrapper as the only entry point. The wrapper owns
 the kernel `flock`; never acquire a second lock or infer availability from a
 note, timestamp, PID, port, process name, or lock-file existence.
 
+For focused red/green work, pass the repository command as an argument vector:
+
+```bash
+run-tests.sh focused -- uv run grimoire test run path/to/test.py::test_name
+```
+
+The focused lane supplies the prepared image and PostgreSQL. Do not replace a
+focused run with an entire regular lane; run the regular lane once after the
+focused test is restored.
+
 ## Track completion
 
 1. Run the wrapper in the foreground from the checkout being tested. If the

--- a/.agents/skills/bunyip-ci/agents/openai.yaml
+++ b/.agents/skills/bunyip-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bunyip CI"
+  short_description: "Run and diagnose queued bunyip CI lanes"
+  default_prompt: "Use $bunyip-ci to run the requested CI lane on bunyip and report its verified result."

--- a/.claude/skills/bunyip-ci
+++ b/.claude/skills/bunyip-ci
@@ -1,0 +1,1 @@
+../../.agents/skills/bunyip-ci

--- a/.github/workflows/act-ci.yml
+++ b/.github/workflows/act-ci.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: promptgrimoire_test
@@ -106,7 +106,7 @@ jobs:
         #   --health-timeout 5s
         #   --health-retries 5
         ports:
-          - 5433:5432
+          - "127.0.0.1:5434:5432"
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -187,15 +187,19 @@ jobs:
 
       - name: Run unit and integration tests
         env:
-          DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5433/promptgrimoire_test
+          DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5434/promptgrimoire_test
           OSFONTDIR: /usr/share/fonts:/usr/share/texmf/fonts
         run: uv run grimoire test all
 
   e2e-playwright:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox]
     services:
       postgres:
-        image: postgres:17
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: promptgrimoire_test
@@ -206,7 +210,7 @@ jobs:
         #   --health-timeout 5s
         #   --health-retries 5
         ports:
-          - 5433:5432
+          - "127.0.0.1:5435:5432"
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -235,18 +239,18 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
       - name: Install Playwright browsers
-        run: uv run playwright install --with-deps chromium
+        run: uv run playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
         env:
-          DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5433/promptgrimoire_test
-        run: uv run grimoire e2e run
+          DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5435/promptgrimoire_test
+        run: uv run grimoire e2e run --browser ${{ matrix.browser }}
 
       - name: Upload Playwright lane artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-playwright-artifacts
+          name: e2e-playwright-${{ matrix.browser }}-artifacts
           path: |
             output/test_output/e2e/playwright/**
             test-e2e.log
@@ -257,7 +261,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: promptgrimoire_test
@@ -268,7 +272,7 @@ jobs:
         #   --health-timeout 5s
         #   --health-retries 5
         ports:
-          - 5433:5432
+          - "127.0.0.1:5433:5432"
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - "127.0.0.1:5432:5432"
     steps:
       - name: Quieten Postgres logs
         run: |
@@ -199,7 +199,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - "127.0.0.1:5432:5432"
     steps:
       - name: Quieten Postgres logs
         run: |
@@ -270,7 +270,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - "127.0.0.1:5432:5432"
     steps:
       - name: Quieten Postgres logs
         run: |

--- a/.github/workflows/nightly-e2e-slow.yml
+++ b/.github/workflows/nightly-e2e-slow.yml
@@ -26,15 +26,15 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - "127.0.0.1:5432:5432"
+          - "127.0.0.1:5436:5432"
     env:
-      DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/promptgrimoire_test
+      DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5436/promptgrimoire_test
       OSFONTDIR: /usr/share/fonts:/usr/share/texmf/fonts
     steps:
       - name: Quieten Postgres logs
         run: |
           export PGPASSWORD=postgres
-          psql -h localhost -U postgres -d promptgrimoire_test \
+          psql -h localhost -p 5436 -U postgres -d promptgrimoire_test \
             -c "ALTER SYSTEM SET log_checkpoints = off" \
             -c "ALTER SYSTEM SET log_min_messages = warning" \
             -c "SELECT pg_reload_conf()"

--- a/.github/workflows/nightly-e2e-slow.yml
+++ b/.github/workflows/nightly-e2e-slow.yml
@@ -113,60 +113,15 @@ jobs:
 
       - name: Write job summary
         if: always()
-        run: |
-          echo "## Nightly E2E Slow Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Lane | Status | Log |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|------|--------|-----|" >> "$GITHUB_STEP_SUMMARY"
-
-          # Scan each log file for pass/fail status
-          overall_ok=true
-          for log in test-unit.log test-integration.log test-smoke.log test-blns-extra.log; do
-            if [ ! -f "$log" ]; then
-              continue
-            fi
-            lane="${log#test-}"
-            lane="${lane%.log}"
-            if grep -q "^FAILED " "$log" || grep -q "^=.*failed" "$log"; then
-              echo "| $lane | :x: FAIL | \`$log\` |" >> "$GITHUB_STEP_SUMMARY"
-              overall_ok=false
-            else
-              echo "| $lane | :white_check_mark: PASS | \`$log\` |" >> "$GITHUB_STEP_SUMMARY"
-            fi
-          done
-
-          # JS and BATS don't produce log files — check exit code from step
-          if [ "${{ steps.run-tests.outcome }}" = "failure" ] && [ "$overall_ok" = "true" ]; then
-            echo "| js/bats/playwright | :x: FAIL | (no log file — check step output) |" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-
-          # Extract FAILURES sections from each failed log for copy-paste debugging
-          for log in test-unit.log test-integration.log test-smoke.log test-blns-extra.log; do
-            if [ ! -f "$log" ]; then
-              continue
-            fi
-            if grep -q "^FAILED \|^=.*failed" "$log"; then
-              lane="${log#test-}"
-              lane="${lane%.log}"
-              echo "### Failures: $lane" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo '```' >> "$GITHUB_STEP_SUMMARY"
-              # Print from "= FAILURES =" through "= short test summary ="
-              sed -n '/^=\+ FAILURES =\+$/,/^=\+ short test summary/p' "$log" >> "$GITHUB_STEP_SUMMARY"
-              echo '```' >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-            fi
-          done
+        run: scripts/nightly-summary.sh "${{ steps.run-tests.outcome }}"
 
       - name: Upload nightly slow artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nightly-e2e-slow-artifacts
           path: |
             output/test_output/e2e/**
             test-*.log
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/nightly-e2e-slow.yml
+++ b/.github/workflows/nightly-e2e-slow.yml
@@ -26,7 +26,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - "127.0.0.1:5432:5432"
     env:
       DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/promptgrimoire_test
       OSFONTDIR: /usr/share/fonts:/usr/share/texmf/fonts

--- a/.github/workflows/pre-pr-ci.yml
+++ b/.github/workflows/pre-pr-ci.yml
@@ -1,0 +1,284 @@
+name: Pre-PR Isolated CI
+run-name: pre-pr-isolated ${{ inputs.request_id }} @ ${{ inputs.sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Exact pushed commit SHA to test
+        required: true
+        type: string
+      request_id:
+        description: Unpredictable one-run runner label
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: pre-pr-isolated
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Check out the trusted workflow helpers
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate trusted default-branch dispatch and exact commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_SHA: ${{ inputs.sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          test "$GITHUB_REF" = "refs/heads/${{ github.event.repository.default_branch }}"
+          scripts/pre-pr-status.sh validate-request
+
+      - name: Mark the exact commit pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_SHA: ${{ inputs.sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: scripts/pre-pr-status.sh set pending
+
+  isolated-ci:
+    needs: prepare
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - pre-pr-isolated
+      - ${{ inputs.request_id }}
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: promptgrimoire_test
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "127.0.0.1:5432:5432"
+    env:
+      DEV__TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/promptgrimoire_test
+      OSFONTDIR: /usr/share/fonts:/usr/share/texmf/fonts
+    steps:
+      - name: Check out the exact requested commit
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.sha }}
+          persist-credentials: false
+
+      - name: Verify exact checkout
+        env:
+          REQUESTED_SHA: ${{ inputs.sha }}
+        run: |
+          actual=$(git rev-parse HEAD)
+          test "${actual,,}" = "${REQUESTED_SHA,,}"
+
+      - name: Record request metadata
+        env:
+          REQUESTED_SHA: ${{ inputs.sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          mkdir -p output/pre-pr-ci
+          jq -n \
+            --arg requested_sha "$REQUESTED_SHA" \
+            --arg actual_sha "$(git rev-parse HEAD)" \
+            --arg request_id "$REQUEST_ID" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            '{schema_version:1,requested_sha:$requested_sha,actual_sha:$actual_sha,request_id:$request_id,run_id:$run_id}' \
+            >output/pre-pr-ci/request.json
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache
+          key: apt-pre-pr-${{ runner.os }}-${{ hashFiles('.github/workflows/pre-pr-ci.yml', 'uv.lock') }}
+
+      - name: Install system dependencies
+        run: |
+          if [ -d ~/apt-cache ]; then
+            sudo cp -r ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+          fi
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            bats \
+            postgresql-client \
+            mecab libmecab-dev \
+            pandoc \
+            poppler-utils \
+            fontconfig \
+            fonts-noto --install-recommends \
+            fonts-texgyre \
+            fonts-sil-gentiumplus fonts-sil-charis fonts-sil-doulos \
+            fonts-sil-scheherazade fonts-sil-ezra fonts-sil-annapurna \
+            fonts-sil-abyssinica fonts-sil-padauk fonts-sil-mondulkiri \
+            fonts-sil-galatia fonts-sil-sophia-nubian fonts-sil-nuosusil \
+            fonts-sil-taiheritagepro
+          mkdir -p ~/apt-cache
+          cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
+
+      - name: Quieten Postgres logs
+        run: |
+          export PGPASSWORD=postgres
+          psql -h localhost -U postgres -d promptgrimoire_test \
+            -c "ALTER SYSTEM SET log_checkpoints = off" \
+            -c "ALTER SYSTEM SET log_min_messages = warning" \
+            -c "SELECT pg_reload_conf()"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.3.1
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --locked --all-groups
+
+      - name: Install JS test dependencies
+        run: npm ci
+
+      - name: Cache TinyTeX
+        uses: actions/cache@v4
+        with:
+          path: ~/.TinyTeX
+          key: tinytex-pre-pr-${{ runner.os }}-${{ hashFiles('scripts/setup_latex.py') }}
+
+      - name: Install TinyTeX and LaTeX packages
+        run: |
+          echo "$HOME/.TinyTeX/bin/x86_64-linux" >> "$GITHUB_PATH"
+          export PATH="$HOME/.TinyTeX/bin/x86_64-linux:$PATH"
+          uv run python scripts/setup_latex.py
+          luaotfload-tool --update --force
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-pre-pr-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install Playwright browsers
+        run: uv run playwright install --with-deps chromium firefox
+
+      - name: Run ruff lint
+        run: uv run ruff check .
+
+      - name: Run ruff format check
+        run: uv run ruff format --check .
+
+      - name: Run vulture
+        run: uv run vulture
+
+      - name: Run pip-audit
+        run: |
+          uv run pip-audit -f json -o /tmp/audit.json || true
+          python3 <<'AUDIT_GATE'
+          import json
+          import sys
+          import urllib.request
+          from datetime import datetime, timedelta, timezone
+
+          grace_days = 14
+          cutoff = datetime.now(timezone.utc) - timedelta(days=grace_days)
+          with open("/tmp/audit.json") as audit_file:
+              data = json.load(audit_file)
+
+          actionable = []
+          for dependency in data.get("dependencies", []):
+              for vulnerability in dependency.get("vulns", []):
+                  fixes = vulnerability.get("fix_versions", [])
+                  if not fixes:
+                      continue
+                  package = dependency["name"]
+                  fix_version = fixes[0]
+                  try:
+                      url = f"https://pypi.org/pypi/{package}/{fix_version}/json"
+                      response = urllib.request.urlopen(url, timeout=10)
+                      release = json.loads(response.read())
+                      uploaded = release["urls"][0]["upload_time_iso_8601"]
+                      if datetime.fromisoformat(uploaded) > cutoff:
+                          continue
+                  except Exception as error:
+                      print(f"PyPI release lookup failed for {package}: {error}")
+                  actionable.append(
+                      f"{package} {vulnerability['id']} (fix: {', '.join(fixes)})"
+                  )
+
+          if actionable:
+              print(f"Vulnerabilities with fixes older than {grace_days} days:")
+              for item in actionable:
+                  print(f"  {item}")
+              sys.exit(1)
+          print("pip-audit: no actionable vulnerabilities")
+          AUDIT_GATE
+
+      - name: Run ty type check
+        run: uv run ty check
+
+      - name: Run the canonical slow suite
+        run: uv run grimoire e2e slow
+
+      - name: Run the ordinary Firefox lane
+        run: uv run grimoire e2e run --browser firefox
+
+      - name: Upload isolated CI evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-pr-isolated-${{ inputs.request_id }}
+          path: |
+            output/pre-pr-ci/**
+            output/test_output/e2e/**
+            test-*.log
+          if-no-files-found: error
+          retention-days: 7
+
+  finalize:
+    needs: [prepare, isolated-ci]
+    if: ${{ always() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Check out the trusted workflow helpers
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Stamp the exact commit with the terminal result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_SHA: ${{ inputs.sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_RESULT: ${{ needs.isolated-ci.result }}
+        run: |
+          case "$JOB_RESULT" in
+            success) FINAL_STATE=success ;;
+            failure) FINAL_STATE=failure ;;
+            cancelled|skipped) FINAL_STATE=error ;;
+            *) FINAL_STATE=error ;;
+          esac
+          scripts/pre-pr-status.sh set "$FINAL_STATE"

--- a/Dockerfile.act
+++ b/Dockerfile.act
@@ -4,7 +4,7 @@
 # font cache so act runs don't pay the cold-start penalty.
 #
 # Build:  docker build -t grimoire-act-runner -f Dockerfile.act .
-# Use:    gh act pull_request -W .github/workflows/act-ci.yml -j test-all \
+# Use:    gh act workflow_dispatch -W .github/workflows/act-ci.yml -j test-all \
 #           -P ubuntu-latest=grimoire-act-runner
 #
 # Or add to .actrc:  -P ubuntu-latest=grimoire-act-runner
@@ -13,6 +13,7 @@ FROM catthehacker/ubuntu:act-latest
 
 # System packages (matches ci.yml Install system dependencies step)
 RUN apt-get update && apt-get install -y \
+    postgresql-client \
     mecab libmecab-dev \
     pandoc \
     poppler-utils \
@@ -25,6 +26,9 @@ RUN apt-get update && apt-get install -y \
     fonts-sil-galatia fonts-sil-sophia-nubian fonts-sil-nuosusil \
     fonts-sil-taiheritagepro \
     && rm -rf /var/lib/apt/lists/*
+
+# ci.yml quietens its service through psql before checkout; prove the image can.
+RUN psql --version
 
 # TinyTeX + LaTeX packages (mirrors scripts/setup_latex.py)
 # Install TinyTeX
@@ -63,3 +67,7 @@ RUN printf '%s\n' \
     '\end{document}' > /tmp/warmup.tex \
     && lualatex -interaction=nonstopmode -halt-on-error -output-directory=/tmp /tmp/warmup.tex \
     && rm -f /tmp/warmup.*
+
+# The same image serves branch staging as well as act jobs.
+COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /uvx /bin/
+RUN uv --version

--- a/deploy/tests/test_nightly_summary.bats
+++ b/deploy/tests/test_nightly_summary.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+SUMMARY_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/nightly-summary.sh"
+
+setup() {
+    TEST_ROOT="$BATS_TEST_TMPDIR/nightly-summary-$BATS_TEST_NUMBER"
+    SUMMARY="$TEST_ROOT/summary.md"
+    mkdir -p "$TEST_ROOT"
+}
+
+write_log() {
+    local name=$1 exit_code=$2 pytest_summary=$3
+    cat >"$TEST_ROOT/$name" <<EOF
+============================= test session starts ==============================
+$pytest_summary
+
+============================================================
+Finished: 2026-08-24T00:00:00
+Duration: 0:00:01
+Exit code: $exit_code
+============================================================
+EOF
+}
+
+write_other_passing_logs() {
+    local excluded=$1 log
+    for log in test-unit.log test-integration.log test-smoke.log test-blns-extra.log; do
+        [ "$log" = "$excluded" ] || write_log "$log" 0 "1 passed in 0.01s"
+    done
+}
+
+run_summary() {
+    local outcome=$1
+    run bash -c 'cd "$1" && GITHUB_STEP_SUMMARY="$2" "$3" "$4"' \
+        _ "$TEST_ROOT" "$SUMMARY" "$SUMMARY_SCRIPT" "$outcome"
+}
+
+@test "xfailed pytest outcome remains a passing nightly lane" {
+    write_other_passing_logs test-smoke.log
+    write_log test-smoke.log 0 \
+        "==== 43 passed, 5487 deselected, 1 xfailed, 1 warning in 113.36s ===="
+
+    run_summary success
+
+    [ "$status" -eq 0 ]
+    grep -F "| smoke | :white_check_mark: PASS | \`test-smoke.log\` |" "$SUMMARY"
+    run grep -F '| smoke | :x: FAIL |' "$SUMMARY"
+    [ "$status" -eq 1 ]
+    run grep -F '### Failures: smoke' "$SUMMARY"
+    [ "$status" -eq 1 ]
+}
+
+@test "nonzero recorded exit code produces a failure row and details" {
+    write_other_passing_logs test-unit.log
+    cat >"$TEST_ROOT/test-unit.log" <<'EOF'
+=============================== FAILURES =======================================
+____________________________ test_real_failure _______________________________
+E   AssertionError: deliberate fixture failure
+=========================== short test summary info ============================
+FAILED tests/unit/test_example.py::test_real_failure
+
+============================================================
+Finished: 2026-08-24T00:00:00
+Duration: 0:00:01
+Exit code: 1
+============================================================
+EOF
+
+    run_summary failure
+
+    [ "$status" -eq 0 ]
+    grep -F "| unit | :x: FAIL | \`test-unit.log\` |" "$SUMMARY"
+    grep -F '### Failures: unit' "$SUMMARY"
+    grep -F 'AssertionError: deliberate fixture failure' "$SUMMARY"
+}
+
+@test "missing required lane log is reported as invalid evidence" {
+    write_other_passing_logs test-smoke.log
+
+    run_summary success
+
+    [ "$status" -eq 1 ]
+    grep -F "| smoke | :x: INVALID | \`test-smoke.log\` missing |" "$SUMMARY"
+}

--- a/deploy/tests/test_pre_pr_status.bats
+++ b/deploy/tests/test_pre_pr_status.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/pre-pr-status.sh"
+
+setup() {
+    TEST_ROOT="$BATS_TEST_TMPDIR/pre-pr-status-$BATS_TEST_NUMBER"
+    BIN_DIR="$TEST_ROOT/bin"
+    TRACE="$TEST_ROOT/gh.trace"
+    mkdir -p "$BIN_DIR"
+
+    cat >"$BIN_DIR/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%q ' "$@" >>"$GH_TRACE"
+printf '\n' >>"$GH_TRACE"
+if [[ " $* " == *" --method GET "* ]]; then
+    printf '%s\n' "$GH_RESOLVED_SHA"
+fi
+EOF
+    chmod +x "$BIN_DIR/gh"
+    export GH_TRACE="$TRACE"
+    export GH_RESOLVED_SHA=0123456789abcdef0123456789abcdef01234567
+}
+
+run_script() {
+    local requested_sha=${REQUESTED_SHA:-0123456789abcdef0123456789abcdef01234567}
+    local request_id=${REQUEST_ID:-prepr-0123456789abcdef0123456789abcdef}
+    run env \
+        PATH="$BIN_DIR:$PATH" \
+        GH_TOKEN=test-token \
+        GITHUB_REPOSITORY=owner/repository \
+        GH_RESOLVED_SHA="$GH_RESOLVED_SHA" \
+        REQUESTED_SHA="$requested_sha" \
+        REQUEST_ID="$request_id" \
+        STATUS_TARGET_URL=https://github.example.invalid/actions/runs/123 \
+        "$SCRIPT" "$@"
+}
+
+@test "validate-request resolves the exact pushed commit" {
+    run_script validate-request
+
+    [ "$status" -eq 0 ]
+    grep -F -- '--method GET' "$TRACE"
+    grep -F -- '/repos/owner/repository/commits/0123456789abcdef0123456789abcdef01234567' "$TRACE"
+}
+
+@test "validate-request rejects a malformed request label before GitHub access" {
+    REQUEST_ID=guessable run_script validate-request
+
+    [ "$status" -eq 2 ]
+    [ ! -e "$TRACE" ]
+}
+
+@test "validate-request rejects a commit resolution mismatch" {
+    GH_RESOLVED_SHA=ffffffffffffffffffffffffffffffffffffffff \
+        run_script validate-request
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"resolved commit does not match requested SHA"* ]]
+}
+
+@test "set posts the exact SHA and dedicated commit-status context" {
+    run_script set success
+
+    [ "$status" -eq 0 ]
+    grep -F -- '--method POST' "$TRACE"
+    grep -F -- '/repos/owner/repository/statuses/0123456789abcdef0123456789abcdef01234567' "$TRACE"
+    grep -F -- 'state=success' "$TRACE"
+    grep -F -- 'context=ci/pre-pr-isolated' "$TRACE"
+    grep -F -- 'target_url=https://github.example.invalid/actions/runs/123' "$TRACE"
+}
+
+@test "set rejects an unsupported state before posting" {
+    run_script set neutral
+
+    [ "$status" -eq 2 ]
+    [ ! -e "$TRACE" ]
+}

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -32,6 +32,30 @@ PDF validation. `.github/workflows/act-ci.yml` is a local diagnostic copy of
 the three regular test jobs plus quality; it does not claim eight-lane
 coverage. Both local workflows use PostgreSQL 16, matching GitHub.
 
+## Exact-SHA pre-PR route
+
+`.github/workflows/pre-pr-ci.yml` is a separate manual route for running the
+complete pre-PR campaign on an isolated one-job self-hosted runner. It is
+`workflow_dispatch`-only and must remain on the repository's default branch.
+Ordinary pushes and pull requests, including forks, continue to use
+GitHub-hosted runners through `ci.yml`.
+
+The trusted submitter supplies a full pushed commit SHA and an unpredictable
+request identifier. A GitHub-hosted preparation job validates that GitHub
+resolves the exact SHA and creates the dedicated `ci/pre-pr-isolated` pending
+status. The isolated job requires both its static labels and the unique request
+identifier, checks out that exact SHA without persisting checkout credentials,
+and receives only `contents: read`. A GitHub-hosted finalizer writes success,
+failure, or error to the same exact SHA.
+
+The isolated job runs the quality gates, the canonical `e2e slow` suite, and
+the ordinary Firefox E2E lane. It always uploads request metadata and available
+test evidence. The self-hosted executor is an operational boundary: it must be
+one-job/disposable, have no repository secrets or persistent GitHub credential,
+and be destroyed before its host releases the shared heavy-work lease. Its
+machine-specific provisioning, submission command, network policy, and
+evidence locations belong only in the private operator runbook.
+
 ## Provision a clean box
 
 Allow at least 30 GB free for Docker images, action caches, browser downloads,

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -1,76 +1,160 @@
-# Local CI Runners with `act`
+# Clean-box CI with `act`
 
-PromptGrimoire relies on GitHub Actions for its CI pipeline. When debugging complex failures—especially E2E test failures that are difficult to reproduce natively on a host machine—it is useful to run the CI pipeline locally exactly as it executes on GitHub.
+This is the authoritative public runbook for executing PromptGrimoire CI on a
+clean Ubuntu 24.04 LTS box with Docker and `act` 0.2.89. It describes the
+repository-facing contract only. Keep hostnames, addresses, credentials,
+credential paths, network assessments, and machine-specific provisioning in a
+private operator runbook.
 
-To achieve this, we use [`act`](https://github.com/nektos/act), a tool that runs GitHub Actions workflows locally using Docker. We specifically use it via the GitHub CLI extension: `gh act`.
+Use one installation and one host-wide wrapper for all repositories on the
+box. Retire older per-repository wrappers after migrating their callers; two
+independent locks or act configurations do not provide mutual exclusion.
 
-## Prerequisites
+## What runs where
 
-1. **Docker:** Must be installed and running.
-2. **Docker Permissions:** Your user must be part of the `docker` group so that `act` can interact with the Docker daemon without `sudo`.
-   ```bash
-   sudo usermod -aG docker $USER
-   # You may need to log out and log back in, or run `newgrp docker`
-   ```
-3. **GitHub CLI & Act Extension:**
-   ```bash
-   gh extension install https://github.com/nektos/gh-act
-   ```
+`uv run grimoire e2e all` is eight serial lane invocations. GitHub's regular CI
+splits the common lanes for speed; the nightly workflow is the canonical
+single-job full-suite environment and runs `e2e slow`, a superset of `e2e all`.
 
-## The Problem with Default Workflows
+| `e2e all` lane | Regular `.github/workflows/ci.yml` | Canonical full CI and local act |
+|---|---|---|
+| JavaScript | `test-all` via `test all` | nightly `e2e-slow` |
+| BATS | `test-all` via `test all` | nightly `e2e-slow` |
+| unit | `test-all` via `test all` | nightly `e2e-slow` |
+| integration | not run | nightly `e2e-slow` |
+| Playwright | `e2e-playwright`, Chromium and Firefox | nightly `e2e-slow`, Chromium |
+| NiceGUI | `nicegui-ui` | nightly `e2e-slow` |
+| smoke | not run | nightly `e2e-slow` |
+| BLNS + extra | not run | nightly `e2e-slow` |
 
-You **cannot** simply run `gh act pull_request` against the default `.github/workflows/ci.yml`. If you do, you will encounter several issues:
+The nightly command additionally enables `noci` Playwright tests and compiled
+PDF validation. `.github/workflows/act-ci.yml` is a local diagnostic copy of
+the three regular test jobs plus quality; it does not claim eight-lane
+coverage. Both local workflows use PostgreSQL 16, matching GitHub.
 
-1. **Port Conflicts:** `act` runs its main container on the host network by default and maps service ports directly to the host. The `ci.yml` defines three parallel jobs (`test-all`, `e2e-playwright`, `nicegui-ui`), each of which spins up a PostgreSQL 17 service mapped to `ports: - 5432:5432`. Running this will cause the jobs to collide with each other, and it will clobber any local Postgres instance you already have running on port 5432.
-2. **Docker Network Isolation Issues:** If you try to fix the port conflicts by isolating the run in a custom bridge network (e.g., `gh act ... --network act-bridge`), `act` exhibits a bug where the main container is placed on `act-bridge`, but the service containers are placed on dynamically generated, isolated networks. The main container will fail to resolve the `postgres` host, resulting in `[Errno -3] Temporary failure in name resolution`.
-3. **Segfaults on Health Checks:** The current version of `act` has a known bug where evaluating service health checks (e.g., `--health-cmd "pg_isready -U postgres"`) can cause the Go runtime to panic and segfault.
+## Provision a clean box
 
-## The Solution: `act-ci.yml`
+Allow at least 30 GB free for Docker images, action caches, browser downloads,
+and artifacts. Install Docker Engine, the GitHub CLI if desired, `flock`, and
+the pinned `act` binary. Transfer the repository without `.env`, production
+secrets, dependency directories, output, or logs; the runner needs no GitHub
+credentials for a public checkout copied from another machine.
 
-To work around these limitations, we maintain a modified workflow file specifically for local debugging at `.github/workflows/act-ci.yml`.
-
-This file patches the standard `ci.yml` in three ways:
-1. **Port Remapping:** The Postgres services are mapped to `ports: - 5433:5432` to avoid conflicting with a local host database on `5432`.
-2. **URL Adjustment:** The `DEV__TEST_DATABASE_URL` environment variables are updated to connect to `localhost:5433`.
-3. **Health Checks Disabled:** The `options: >- --health-cmd ...` block is commented out for the Postgres services to prevent `act` from segfaulting.
-
-*(Note: If the primary `ci.yml` changes significantly, `act-ci.yml` will need to be re-synced and patched with these three modifications).*
-
-## Custom Runner Image
-
-`act` does not support `actions/cache`, so every run cold-starts TinyTeX and system packages. The LaTeX font cache build alone takes ~5GB RAM and 10+ minutes. To avoid this, build a custom Docker image with everything pre-installed:
+Build the repository image and positively verify its PostgreSQL client:
 
 ```bash
 docker build -t grimoire-act-runner -f Dockerfile.act .
+docker run --rm grimoire-act-runner psql --version
 ```
 
-This only needs rebuilding when `scripts/setup_latex.py` or system dependencies change. Use `-P` to map it:
+The Dockerfile also proves `psql` during the build. This is required because
+the canonical workflows quieten PostgreSQL before checkout.
+
+Configure Docker-published ports to bind to loopback by default. Changing the
+Docker daemon configuration requires a coordinated daemon restart: announce
+the interruption, confirm no act, deployment, or performance job is live,
+restart Docker, then verify both the listener and an attempted connection from
+a separate host. The acceptance condition is: the service succeeds through
+`localhost:<published-port>` on the runner and cannot be reached through any
+non-loopback interface. Do not publish the observed address or network details.
+
+Under act 0.2.89 the service container is on its per-job bridge while job steps
+run on the host network. Docker publishes the service port to the host, so job
+steps correctly use `localhost:<published-port>`. The health-check crash is a
+dry-run-only act bug; do not disable real-run health checks because of it.
+
+## Required wrapper contract
+
+All act and performance entry points must take the same host-wide `flock`.
+Performance legs own the box exclusively. An interactive act request abstains
+while a leg is live. A GitHub-triggered priority request may stop a leg only
+through the private perf controller's checkpoint/stop hook, run CI under the
+lock, and invoke its resume hook afterward; never kill an uncheckpointed leg.
+Perf provisioning and hook implementation remain private and separate.
+
+For every invocation the wrapper must:
+
+1. take the shared lock before inspecting or changing services;
+2. refuse overlap with a live performance leg unless using the coordinated
+   stop/resume path;
+3. use unique run-scoped container, network, artifact, and temporary resource
+   names, and reserve non-conflicting ports;
+4. pass readable, explicitly empty env, secret, input, and var files when the
+   workflow requires none—never inherit ambient values;
+5. bind act's cache and artifact servers to loopback and preserve normal
+   `setup-uv` and `actions/cache@v4` locations;
+6. set CPU, memory, and shared-memory limits appropriate to the host;
+7. use a fixed, documented concurrency budget, serialize jobs whose published
+   ports collide, and record the revision, exact command, versions, timestamps,
+   exit status, and artifact directory; and
+8. remove run-scoped containers and networks on exit while retaining declared
+   caches and evidence artifacts according to the operator's retention policy.
+
+`actions/cache@v4` works with act 0.2.89 and has restored the setup-uv cache in
+a real run. Do not set `cache-local-path` or redirect caches to `/tmp`.
+`actions/upload-artifact@v4` is the supported artifact action for this setup;
+do not upgrade it independently to v6 or v7.
+
+## Run and record evidence
+
+Create four zero-byte files outside the checkout for env, secrets, inputs, and
+vars. A wrapper can do that without assigning a durable credential path:
 
 ```bash
-gh act pull_request -W .github/workflows/act-ci.yml -j test-all \
-  -P ubuntu-latest=grimoire-act-runner
+run_state=$(mktemp -d)
+trap 'rm -rf -- "$run_state"' EXIT
+touch "$run_state"/{env,secrets,inputs,vars}
+
+act workflow_dispatch \
+  --env-file "$run_state/env" \
+  --secret-file "$run_state/secrets" \
+  --input-file "$run_state/inputs" \
+  --var-file "$run_state/vars" \
+  --cache-server-addr 127.0.0.1 --cache-server-port 0 \
+  --artifact-server-addr 127.0.0.1 --artifact-server-port 34567 \
+  --artifact-server-path "$run_state/artifacts" \
+  --rm --concurrent-jobs 1 \
+  -W .github/workflows/act-ci.yml --list
 ```
 
-Or add to `~/.config/act/actrc` (or project `.actrc`):
-```
--P ubuntu-latest=grimoire-act-runner
-```
+For a real run, put artifacts in a unique retained run directory rather than
+the temporary example above. Keep act's default cache-server path so action
+caches survive runs.
 
-## How to Run
-
-To run a specific job locally, use the following command, specifying the patched workflow file and the exact job you want to debug.
-
-**Do not run all jobs at once**, as they will all try to bind to `5433`. Run them sequentially by targeting them with the `-j` flag:
+List jobs using the workflow's actual event:
 
 ```bash
-# Debug the NiceGUI UI lane
-gh act pull_request -W .github/workflows/act-ci.yml -j nicegui-ui
-
-# Debug the Playwright lane
-gh act pull_request -W .github/workflows/act-ci.yml -j e2e-playwright
-
-# Debug the standard unit and integration tests
-gh act pull_request -W .github/workflows/act-ci.yml -j test-all
+act workflow_dispatch -W .github/workflows/act-ci.yml --list
 ```
 
-**Warning on Dry Runs:** Do not use the `--dryrun` flag. Due to the way `act` handles service container stubs, it will still segfault when tearing down the environment even if the health checks are removed. Run the jobs natively.
+Run the five regular PR executions under one wrapper-owned lock: `quality`,
+`test-all`, `e2e-playwright` with Chromium, `e2e-playwright` with Firefox,
+and `nicegui-ui`. Independent jobs may share the campaign's fixed capacity;
+jobs using the same published port must remain serial unless the wrapper gives
+each one a unique port. For the authoritative eight-lane proof,
+run the `e2e-slow` job from `.github/workflows/nightly-e2e-slow.yml`; its
+`e2e slow` command covers all eight lanes plus the documented nightly extras.
+Never use `pull_request` with `act-ci.yml`: that workflow declares only
+`workflow_dispatch`.
+
+During a database-backed job, verify PostgreSQL is healthy, `psql` can execute
+`SELECT 1` through localhost, migrations complete before seed/application
+startup, and the schema-backed health check succeeds. From a separate host,
+verify the published service port is unreachable. After each job, save logs and
+artifacts, record cache restore/save results, and confirm no run-scoped
+containers, networks, or listeners remain before releasing the lock.
+
+Do not use `--dryrun` as evidence: act 0.2.89 may crash while tearing down
+service health-check stubs. Do not use `--reuse` for the final clean-box proof.
+
+## Supported boundary
+
+Supported pins are Ubuntu 24.04 LTS, act 0.2.89, PostgreSQL 16,
+`actions/cache@v4`, and `actions/upload-artifact@v4`. Routine independent
+upgrades are unsupported; update the workflows, image, contract test, and a
+recorded clean-box run together.
+
+Before publishing changes, search this file and evidence intended for the
+repository for machine names, addresses, usernames, tokens, secret or
+credential paths, and private network/security commentary. Keep those only in
+the private operator runbook.

--- a/scripts/nightly-summary.sh
+++ b/scripts/nightly-summary.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+run_outcome=${1:?usage: nightly-summary.sh RUN_OUTCOME}
+: "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+exec >>"$GITHUB_STEP_SUMMARY"
+
+echo "## Nightly E2E Slow Results"
+echo ""
+echo "| Lane | Status | Log |"
+echo "|------|--------|-----|"
+
+overall_ok=true
+summary_valid=true
+
+log_exit_code() {
+    awk '/^Exit code: [0-9]+$/ { code=$3 } END { if (code != "") print code }' "$1"
+}
+
+# The harness footer is the lane's positive completion signal. Pytest summary
+# words such as "xfailed" are descriptive counts, not process status.
+for log in test-unit.log test-integration.log test-smoke.log test-blns-extra.log; do
+    if [ ! -f "$log" ]; then
+        lane=${log#test-}
+        lane=${lane%.log}
+        echo "| $lane | :x: INVALID | \`$log\` missing |"
+        overall_ok=false
+        summary_valid=false
+        continue
+    fi
+    lane=${log#test-}
+    lane=${lane%.log}
+    exit_code=$(log_exit_code "$log")
+    if [ "$exit_code" = 0 ]; then
+        echo "| $lane | :white_check_mark: PASS | \`$log\` |"
+    elif [[ "$exit_code" =~ ^[0-9]+$ ]]; then
+        echo "| $lane | :x: FAIL | \`$log\` |"
+        overall_ok=false
+    else
+        echo "| $lane | :x: INVALID | \`$log\` has no exit footer |"
+        overall_ok=false
+        summary_valid=false
+    fi
+done
+
+# JS and BATS don't produce log files — check exit code from step.
+if [ "$run_outcome" = failure ] && [ "$overall_ok" = true ]; then
+    echo "| js/bats/playwright | :x: FAIL | (no log file — check step output) |"
+fi
+
+echo ""
+
+# Extract FAILURES sections from each failed log for copy-paste debugging.
+for log in test-unit.log test-integration.log test-smoke.log test-blns-extra.log; do
+    if [ ! -f "$log" ]; then
+        continue
+    fi
+    exit_code=$(log_exit_code "$log")
+    if [[ "$exit_code" =~ ^[0-9]+$ ]] && [ "$exit_code" -ne 0 ]; then
+        lane=${log#test-}
+        lane=${lane%.log}
+        echo "### Failures: $lane"
+        echo ""
+        echo '```'
+        # Print from "= FAILURES =" through "= short test summary =".
+        sed -n '/^=\+ FAILURES =\+$/,/^=\+ short test summary/p' "$log"
+        echo '```'
+        echo ""
+    fi
+done
+
+[ "$summary_valid" = true ]

--- a/scripts/pre-pr-status.sh
+++ b/scripts/pre-pr-status.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+STATUS_CONTEXT=ci/pre-pr-isolated
+
+die() {
+    echo "pre-pr-status: $*" >&2
+    exit 1
+}
+
+usage() {
+    echo "usage: $0 validate-request | set {pending|success|failure|error}" >&2
+    exit 2
+}
+
+require_request() {
+    : "${GH_TOKEN:?GH_TOKEN is required}"
+    : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+    : "${REQUESTED_SHA:?REQUESTED_SHA is required}"
+    : "${REQUEST_ID:?REQUEST_ID is required}"
+
+    [[ "$REQUESTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]] \
+        || { echo "pre-pr-status: requested SHA must be 40 hexadecimal characters" >&2; exit 2; }
+    [[ "$REQUEST_ID" =~ ^prepr-[0-9a-f]{32}$ ]] \
+        || { echo "pre-pr-status: request ID must be prepr- followed by 32 lowercase hexadecimal characters" >&2; exit 2; }
+    [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+        || { echo "pre-pr-status: invalid repository slug" >&2; exit 2; }
+}
+
+validate_commit() {
+    local resolved
+    resolved=$(gh api \
+        --method GET \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        "/repos/$GITHUB_REPOSITORY/commits/$REQUESTED_SHA" \
+        --jq .sha)
+    [ "${resolved,,}" = "${REQUESTED_SHA,,}" ] \
+        || die "resolved commit does not match requested SHA"
+}
+
+set_status() {
+    local state=$1 description
+    case "$state" in
+        pending) description="Isolated pre-PR CI queued" ;;
+        success) description="Isolated pre-PR CI passed" ;;
+        failure) description="Isolated pre-PR CI failed" ;;
+        error) description="Isolated pre-PR CI did not complete" ;;
+        *) usage ;;
+    esac
+    : "${STATUS_TARGET_URL:?STATUS_TARGET_URL is required}"
+    [[ "$STATUS_TARGET_URL" == https://* ]] \
+        || { echo "pre-pr-status: status target must use HTTPS" >&2; exit 2; }
+
+    require_request
+    validate_commit
+    gh api \
+        --method POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        "/repos/$GITHUB_REPOSITORY/statuses/$REQUESTED_SHA" \
+        -f "state=$state" \
+        -f "target_url=$STATUS_TARGET_URL" \
+        -f "description=$description" \
+        -f "context=$STATUS_CONTEXT" >/dev/null
+}
+
+case ${1:-} in
+    validate-request)
+        [ "$#" -eq 1 ] || usage
+        require_request
+        validate_commit
+        ;;
+    set)
+        [ "$#" -eq 2 ] || usage
+        case "$2" in
+            pending|success|failure|error) ;;
+            *) usage ;;
+        esac
+        set_status "$2"
+        ;;
+    *) usage ;;
+esac

--- a/src/promptgrimoire/db/export_jobs.py
+++ b/src/promptgrimoire/db/export_jobs.py
@@ -251,7 +251,7 @@ async def cleanup_expired_jobs(cutoff: datetime) -> int:
         for job in jobs:
             if job.pdf_path:
                 parent = Path(job.pdf_path).parent
-                if parent.is_relative_to(tmpdir):
+                if parent != tmpdir and parent.is_relative_to(tmpdir):
                     disk_dirs.append((str(job.id), parent))
                 else:
                     logger.warning(

--- a/tests/integration/test_export_jobs.py
+++ b/tests/integration/test_export_jobs.py
@@ -390,6 +390,32 @@ class TestCleanupExpiredJobs:
         assert not export_dir.exists()
 
     @pytest.mark.asyncio
+    async def test_never_deletes_system_temp_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed root-level PDF path must not make cleanup remove /tmp."""
+        import tempfile
+        from pathlib import Path
+
+        from promptgrimoire.db import export_jobs
+
+        deleted: list[Path] = []
+        monkeypatch.setattr(export_jobs.shutil, "rmtree", deleted.append)
+
+        user_id, workspace_id = await _create_user_and_workspace()
+        job = await export_jobs.create_export_job(
+            user_id, workspace_id, {"format": "pdf"}
+        )
+        tmpdir = Path(tempfile.gettempdir())
+        await export_jobs.complete_job(
+            job.id, f"tok-{uuid4().hex[:8]}", str(tmpdir / "root-level.pdf")
+        )
+
+        await export_jobs.cleanup_expired_jobs(datetime.now(UTC) + timedelta(hours=1))
+
+        assert tmpdir not in deleted
+
+    @pytest.mark.asyncio
     async def test_deletes_failed_jobs(self) -> None:
         """Failed jobs older than cutoff are deleted."""
         from promptgrimoire.db.export_jobs import (

--- a/tests/integration/test_instructor_course_admin_ui.py
+++ b/tests/integration/test_instructor_course_admin_ui.py
@@ -497,6 +497,4 @@ class TestEnrollStudent:
         from nicegui import ui
 
         table = nicegui_user.find(ui.table).elements.pop()
-        assert any(row["email"] == student_email for row in table.rows), (
-            f"Expected {student_email} in table rows"
-        )
+        await wait_for(lambda: any(row["email"] == student_email for row in table.rows))

--- a/tests/unit/test_act_ci_contract.py
+++ b/tests/unit/test_act_ci_contract.py
@@ -51,9 +51,11 @@ def test_act_runner_matches_ci_contract() -> None:
     ]
     act_service_ports = [
         port
-        for job in workflows[1]["jobs"].values()
+        for workflow in workflows[1:]
+        for job in workflow["jobs"].values()
         for service in job.get("services", {}).values()
         for port in service.get("ports", [])
     ]
     assert all(str(port).startswith("127.0.0.1:") for port in service_ports)
     assert len(act_service_ports) == len(set(act_service_ports))
+    assert all(str(port).split(":")[1] != "5432" for port in act_service_ports)

--- a/tests/unit/test_act_ci_contract.py
+++ b/tests/unit/test_act_ci_contract.py
@@ -1,0 +1,59 @@
+"""Repository contracts for running GitHub workflows through act."""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_act_runner_matches_ci_contract() -> None:
+    """Keep act's image, event, database, and cache behaviour CI-compatible."""
+    dockerfile = Path("Dockerfile.act").read_text()
+    act_workflow_text = Path(".github/workflows/act-ci.yml").read_text()
+    runbook = Path("docs/ci-runners.md").read_text()
+    workflows = [
+        yaml.safe_load(Path(path).read_text())
+        for path in (
+            ".github/workflows/ci.yml",
+            ".github/workflows/act-ci.yml",
+            ".github/workflows/nightly-e2e-slow.yml",
+        )
+    ]
+
+    assert "postgresql-client" in dockerfile
+    assert "psql --version" in dockerfile
+    assert "COPY --from=ghcr.io/astral-sh/uv:" in dockerfile
+    assert "workflow_dispatch" in workflows[1][True]
+    assert "pull_request" not in workflows[1][True]
+    assert "browser: [chromium, firefox]" in act_workflow_text
+    assert "postgres:17" not in "\n".join(
+        Path(path).read_text()
+        for path in (
+            ".github/workflows/ci.yml",
+            ".github/workflows/act-ci.yml",
+            ".github/workflows/nightly-e2e-slow.yml",
+        )
+    )
+    assert "cache-local-path" not in act_workflow_text
+    assert all(
+        flag in runbook
+        for flag in ("--env-file", "--secret-file", "--input-file", "--var-file")
+    )
+    assert "actions/upload-artifact@v4" in act_workflow_text
+    assert "actions/upload-artifact@v6" not in act_workflow_text
+    assert "actions/upload-artifact@v7" not in act_workflow_text
+
+    service_ports = [
+        port
+        for workflow in workflows
+        for job in workflow["jobs"].values()
+        for service in job.get("services", {}).values()
+        for port in service.get("ports", [])
+    ]
+    act_service_ports = [
+        port
+        for job in workflows[1]["jobs"].values()
+        for service in job.get("services", {}).values()
+        for port in service.get("ports", [])
+    ]
+    assert all(str(port).startswith("127.0.0.1:") for port in service_ports)
+    assert len(act_service_ports) == len(set(act_service_ports))

--- a/tests/unit/test_act_ci_contract.py
+++ b/tests/unit/test_act_ci_contract.py
@@ -59,3 +59,22 @@ def test_act_runner_matches_ci_contract() -> None:
     assert all(str(port).startswith("127.0.0.1:") for port in service_ports)
     assert len(act_service_ports) == len(set(act_service_ports))
     assert all(str(port).split(":")[1] != "5432" for port in act_service_ports)
+
+
+def test_nightly_summary_and_artifacts_are_durable_on_success() -> None:
+    """A green nightly publishes exact logs and uses the tested summary renderer."""
+    workflow = yaml.safe_load(
+        Path(".github/workflows/nightly-e2e-slow.yml").read_text()
+    )
+    steps = workflow["jobs"]["e2e-slow"]["steps"]
+    summary = next(step for step in steps if step.get("name") == "Write job summary")
+    upload = next(
+        step for step in steps if step.get("name") == "Upload nightly slow artifacts"
+    )
+
+    assert summary["if"] == "always()"
+    assert summary["run"] == (
+        'scripts/nightly-summary.sh "${{ steps.run-tests.outcome }}"'
+    )
+    assert upload["if"] == "always()"
+    assert upload["with"]["if-no-files-found"] == "error"

--- a/tests/unit/test_pre_pr_ci_contract.py
+++ b/tests/unit/test_pre_pr_ci_contract.py
@@ -1,0 +1,121 @@
+"""Repository contract for the isolated pre-PR workflow."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(".github/workflows/pre-pr-ci.yml")
+
+
+def _workflow() -> dict[str | bool, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_pre_pr_workflow_has_only_a_trusted_manual_entrypoint() -> None:
+    """The private runner must never be selected by ordinary push or PR events."""
+    workflow = _workflow()
+    triggers = workflow[True]
+    dispatch = triggers["workflow_dispatch"]
+
+    assert set(triggers) == {"workflow_dispatch"}
+    assert dispatch["inputs"]["sha"] == {
+        "description": "Exact pushed commit SHA to test",
+        "required": True,
+        "type": "string",
+    }
+    assert dispatch["inputs"]["request_id"] == {
+        "description": "Unpredictable one-run runner label",
+        "required": True,
+        "type": "string",
+    }
+    assert workflow["permissions"] == {}
+    assert workflow["concurrency"] == {
+        "group": "pre-pr-isolated",
+        "cancel-in-progress": False,
+    }
+
+
+def test_pre_pr_runner_is_one_job_uniquely_addressed_and_credential_minimal() -> None:
+    """Only the approved request can match the disposable repository runner."""
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    prepare = jobs["prepare"]
+    isolated = jobs["isolated-ci"]
+    finalize = jobs["finalize"]
+
+    assert prepare["runs-on"] == "ubuntu-latest"
+    assert prepare["permissions"] == {"contents": "read", "statuses": "write"}
+    assert isolated["needs"] == "prepare"
+    assert isolated["runs-on"] == [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "pre-pr-isolated",
+        "${{ inputs.request_id }}",
+    ]
+    assert isolated["permissions"] == {"contents": "read"}
+    assert "secrets" not in isolated
+    assert finalize["runs-on"] == "ubuntu-latest"
+    assert finalize["permissions"] == {"contents": "read", "statuses": "write"}
+    assert finalize["needs"] == ["prepare", "isolated-ci"]
+    assert finalize["if"] == ("${{ always() && needs.prepare.result == 'success' }}")
+
+
+def test_pre_pr_workflow_validates_and_runs_the_exact_sha() -> None:
+    """Hosted jobs stamp the same SHA whose tree the isolated job executes."""
+    workflow_text = WORKFLOW_PATH.read_text()
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    prepare_steps = jobs["prepare"]["steps"]
+    isolated_steps = jobs["isolated-ci"]["steps"]
+    finalize_steps = jobs["finalize"]["steps"]
+
+    assert any(
+        "scripts/pre-pr-status.sh validate-request" in step.get("run", "")
+        and "github.event.repository.default_branch" in step.get("run", "")
+        for step in prepare_steps
+    )
+    assert any(
+        step.get("run") == "scripts/pre-pr-status.sh set pending"
+        for step in prepare_steps
+    )
+    checkout = next(
+        step for step in isolated_steps if step.get("uses") == "actions/checkout@v6.0.2"
+    )
+    assert checkout["with"] == {
+        "ref": "${{ inputs.sha }}",
+        "persist-credentials": False,
+    }
+    assert any(
+        step.get("name") == "Verify exact checkout"
+        and "git rev-parse HEAD" in step.get("run", "")
+        for step in isolated_steps
+    )
+    finalize_run = next(
+        step["run"]
+        for step in finalize_steps
+        if step.get("name") == "Stamp the exact commit with the terminal result"
+    )
+    assert 'scripts/pre-pr-status.sh set "$FINAL_STATE"' in finalize_run
+    assert all(
+        mapping in finalize_run
+        for mapping in (
+            "success) FINAL_STATE=success",
+            "failure) FINAL_STATE=failure",
+            "cancelled|skipped) FINAL_STATE=error",
+        )
+    )
+    assert "uv run ruff check ." in workflow_text
+    assert "uv run ruff format --check ." in workflow_text
+    assert "uv run ty check" in workflow_text
+    assert "uv run grimoire e2e slow" in workflow_text
+    assert "uv run grimoire e2e run --browser firefox" in workflow_text
+
+
+def test_ordinary_pr_ci_remains_github_hosted() -> None:
+    """Adding the isolated manual route must not move pull requests onto it."""
+    workflow = yaml.safe_load(Path(".github/workflows/ci.yml").read_text())
+
+    assert "pull_request" in workflow[True]
+    assert all(job["runs-on"] == "ubuntu-latest" for job in workflow["jobs"].values())

--- a/uv.lock
+++ b/uv.lock
@@ -1395,11 +1395,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- reconcile the local `act` path with hosted CI: PostgreSQL 16, a positively
  verified `psql` client, real `workflow_dispatch`, ordinary caches,
  artifact-v4 support, loopback service publication, bounded resources, and
  deterministic cleanup
- make nightly evidence durable and accurate by classifying the harness's
  exact exit footer and always retaining required logs
- add a manual exact-SHA pre-PR route whose hosted preparation/finalization
  jobs stamp the requested commit and whose isolated job uses a uniquely
  labelled, one-job repository runner with `contents: read`
- document the public/private boundary and provide the shared Bunyip CI skill

The machine-specific JIT guest launcher, libvirt policy, host configuration,
and credentials remain private and are not part of this repository.

## Verification

- `uv run grimoire test bats`: 104/104 passed
- `uv run grimoire test run tests/unit/test_act_ci_contract.py tests/unit/test_pre_pr_ci_contract.py`: 6/6 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run ty check`: passed
- clean rebased branch, 11 commits ahead and 0 behind `main`
- private Bunyip behavioral suite: 50/50 passed; installed KVM/libvirt boundary
  positively verified

## Trust and rollout boundary

- ordinary pull-request and fork CI remains on GitHub-hosted runners
- the new isolated workflow is `workflow_dispatch`-only and must live on the
  default branch
- the guest receives no repository secrets, host mount, Tailnet client, or
  persistent GitHub credential
- this PR bootstraps the workflow itself, so its live exact-SHA JIT UAT cannot
  run until the workflow has landed on `main`

Post-merge acceptance still requires one exact-SHA campaign proving hosted
terminal status, one-job pickup, canonical lock ownership, staging
stop/restore, retained evidence, blocked private connectivity, guest
destruction, and transient JIT-material cleanup. Do not close issue 571 until
that evidence is recorded.

Refs #571
